### PR TITLE
feat(VISE-CPC-159): Fetch previous and scheduled visits separately

### DIFF
--- a/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsService.java
+++ b/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsService.java
@@ -23,4 +23,5 @@ public interface VisitsService {
 
     public List<Visit> getVisitsForPets(List<Integer> petIds);
 
+    List<Visit> getVisitsForPet(int petId, boolean scheduled);
 }

--- a/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsServiceImpl.java
+++ b/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsServiceImpl.java
@@ -80,12 +80,15 @@ public class VisitsServiceImpl implements VisitsService {
     @Override
     public List<Visit> getVisitsForPet(int petId, boolean scheduled) {
         Date now = new Date(System.currentTimeMillis());
+        log.debug("Fetching the visits for pet with petId: {}", petId);
         List<Visit> visits = getVisitsForPet(petId);
 
         if(scheduled){
+            log.debug("Filtering out visits before {}", now);
             visits = visits.stream().filter(v -> v.getDate().after(now)).collect(Collectors.toList());
         }
         else{
+            log.debug("Filtering out visits after {}", now);
             visits = visits.stream().filter(v -> v.getDate().before(now)).collect(Collectors.toList());
         }
         return visits;

--- a/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsServiceImpl.java
+++ b/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsServiceImpl.java
@@ -69,4 +69,9 @@ public class VisitsServiceImpl implements VisitsService {
     public List<Visit> getVisitsForPets(List<Integer> petIds){
         return visitRepository.findByPetIdIn(petIds);
     }
+
+    @Override
+    public List<Visit> getVisitsForPet(int petId, boolean scheduled) {
+        return null;
+    }
 }

--- a/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsServiceImpl.java
+++ b/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsServiceImpl.java
@@ -6,7 +6,10 @@ import com.petclinic.visits.utils.exceptions.InvalidInputException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
+
+import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /*
  * This class implements the necessary methods to make our service work. It is currently responsible for the logic
@@ -47,6 +50,10 @@ public class VisitsServiceImpl implements VisitsService {
 
     @Override
     public List<Visit> getVisitsForPet(int petId) {
+
+        if(petId < 0)
+            throw new InvalidInputException("PetId can't be negative.");
+
         log.info("Calling visit repo to get visits for pet with petId: {}", petId);
         return visitRepository.findByPetId(petId);
     }
@@ -72,6 +79,15 @@ public class VisitsServiceImpl implements VisitsService {
 
     @Override
     public List<Visit> getVisitsForPet(int petId, boolean scheduled) {
-        return null;
+        Date now = new Date(System.currentTimeMillis());
+        List<Visit> visits = getVisitsForPet(petId);
+
+        if(scheduled){
+            visits = visits.stream().filter(v -> v.getDate().after(now)).collect(Collectors.toList());
+        }
+        else{
+            visits = visits.stream().filter(v -> v.getDate().before(now)).collect(Collectors.toList());
+        }
+        return visits;
     }
 }

--- a/visits-service/src/main/java/com/petclinic/visits/datalayer/VisitRepository.java
+++ b/visits-service/src/main/java/com/petclinic/visits/datalayer/VisitRepository.java
@@ -33,9 +33,4 @@ public interface VisitRepository extends JpaRepository<Visit, Integer> {
 
     void findVisitById(int visitId);
 
-//    @Query("select v from Visit v where v.date < :dateTime")
-//    List<Visit> findAllWithDateBefore(@Param("dateTime") Date dateTime);
-//
-//    @Query("select v from Visit v where v.date >= :dateTime")
-//    List<Visit> findAllWithDateAfter(@Param("dateTime") Date dateTime);
 }

--- a/visits-service/src/main/java/com/petclinic/visits/datalayer/VisitRepository.java
+++ b/visits-service/src/main/java/com/petclinic/visits/datalayer/VisitRepository.java
@@ -1,8 +1,11 @@
 package com.petclinic.visits.datalayer;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,4 +32,7 @@ public interface VisitRepository extends JpaRepository<Visit, Integer> {
     //Optional<Visit> findById(int visitId);
 
     void findVisitById(int visitId);
+
+    @Query("select v from Visit v where v.date <= :dateTime")
+    List<Visit> findAllWithDateBefore(@Param("dateTime") Date dateTime);
 }

--- a/visits-service/src/main/java/com/petclinic/visits/datalayer/VisitRepository.java
+++ b/visits-service/src/main/java/com/petclinic/visits/datalayer/VisitRepository.java
@@ -33,6 +33,9 @@ public interface VisitRepository extends JpaRepository<Visit, Integer> {
 
     void findVisitById(int visitId);
 
-    @Query("select v from Visit v where v.date <= :dateTime")
-    List<Visit> findAllWithDateBefore(@Param("dateTime") Date dateTime);
+//    @Query("select v from Visit v where v.date < :dateTime")
+//    List<Visit> findAllWithDateBefore(@Param("dateTime") Date dateTime);
+//
+//    @Query("select v from Visit v where v.date >= :dateTime")
+//    List<Visit> findAllWithDateAfter(@Param("dateTime") Date dateTime);
 }

--- a/visits-service/src/main/java/com/petclinic/visits/presentationlayer/VisitResource.java
+++ b/visits-service/src/main/java/com/petclinic/visits/presentationlayer/VisitResource.java
@@ -35,56 +35,6 @@ public class VisitResource {
         this.visitsService = service;
     }
 
-
-    /*
-
-    private final VisitRepository visitRepository;
-
-
-    //Testing purposes to View all visits
-    @GetMapping(value = "/pets/visits/All")
-    public List<Visit> showVisitList() {
-        return (List<Visit>) visitRepository.findAll();
-    }
-
-    @PostMapping("/pets/visits")
-    @ResponseStatus(HttpStatus.OK)
-    public Visit createVisit(@Valid @RequestBody Visit visit){
-
-        visit.setId(visit.getId());
-        visit.setPetId(visit.getPetId());
-        visit.setDate(visit.getDate());
-        visit.setDescription(visit.getDescription());
-
-        log.info("Saving visit {}", visit);
-        return visitRepository.save(visit);
-    }
-*/
-
-/*  FOR REFERENCE
-
-    @PutMapping("/pets/visits/{petId}")
-    @ResponseStatus(HttpStatus.OK)
-    public Visit updateVisit(@PathVariable("petId") int petId, @Valid @RequestBody Visit visit){
-
-        visit.setId(petId);
-        visit.setPetId(visit.getPetId());
-        visit.setDate(visit.getDate());
-        visit.setDescription(visit.getDescription());
-
-        log.info("Updating visit {}", visit);
-        return visitRepository.save(visit);
-    }
-
-    @DeleteMapping (value = "/pets/visits/{petId}")
-    @ResponseStatus(HttpStatus.OK)
-    public Visit deleteVisit(@PathVariable("petId") int petId, @Valid @RequestBody Visit visit){
-        log.info("Deleting visit {}", visit);
-        visitRepository.deleteAll(visitRepository.findByPetId(petId));
-        return visit;
-    }
-*/
-
     @PostMapping("owners/*/pets/{petId}/visits")
     @ResponseStatus(HttpStatus.CREATED)
     public Visit create(

--- a/visits-service/src/main/java/com/petclinic/visits/presentationlayer/VisitResource.java
+++ b/visits-service/src/main/java/com/petclinic/visits/presentationlayer/VisitResource.java
@@ -78,13 +78,13 @@ public class VisitResource {
 
     @GetMapping("visits/previous/{petId}")
     public List<Visit> getPreviousVisitsForPet(@PathVariable("petId") int petId){
-        log.debug("Calling VisitsService:getVisitsForPet:previous");
+        log.debug("Calling VisitsService:getVisitsForPet:previous:petId={}", petId);
         return visitsService.getVisitsForPet(petId, false);
     }
 
     @GetMapping("visits/scheduled/{petId}")
     public List<Visit> getScheduledVisitsForPet(@PathVariable("petId") int petId){
-        log.debug("Calling VisitsService:getVisitsForPet:scheduled");
+        log.debug("Calling VisitsService:getVisitsForPet:scheduled:petId={}", petId);
         return visitsService.getVisitsForPet(petId, true);
     }
 

--- a/visits-service/src/main/java/com/petclinic/visits/presentationlayer/VisitResource.java
+++ b/visits-service/src/main/java/com/petclinic/visits/presentationlayer/VisitResource.java
@@ -126,6 +126,18 @@ public class VisitResource {
         return visitsService.updateVisit(visit);
     }
 
+    @GetMapping("visits/previous/{petId}")
+    public List<Visit> getPreviousVisitsForPet(@PathVariable("petId") int petId){
+        log.debug("Calling VisitsService:getVisitsForPet:previous");
+        return visitsService.getVisitsForPet(petId, false);
+    }
+
+    @GetMapping("visits/scheduled/{petId}")
+    public List<Visit> getScheduledVisitsForPet(@PathVariable("petId") int petId){
+        log.debug("Calling VisitsService:getVisitsForPet:scheduled");
+        return visitsService.getVisitsForPet(petId, true);
+    }
+
 
     @Value
     static class Visits {

--- a/visits-service/src/main/resources/data-h2.sql
+++ b/visits-service/src/main/resources/data-h2.sql
@@ -3,3 +3,16 @@ INSERT INTO visits VALUES (2, 8, '2013-01-02', 'rabies shot', 784233, 1);
 INSERT INTO visits VALUES (3, 8, '2013-01-03', 'neutered', 327874, 1);
 INSERT INTO visits VALUES (4, 7, '2013-01-04', 'spayed', 238372, 0);
 
+INSERT INTO visits VALUES (5, 1, '2020-03-04', 'rabies shot', 234568, 0);
+INSERT INTO visits VALUES (6, 1, '2022-03-04', 'rabies shot', 784233, 1);
+INSERT INTO visits VALUES (7, 2, '2023-06-04', 'neutered', 327874, 1);
+INSERT INTO visits VALUES (8, 2, '2008-09-04', 'spayed', 238372, 1);
+INSERT INTO visits VALUES (9, 3, '2010-03-04', 'rabies shot', 234568, 0);
+INSERT INTO visits VALUES (10, 3, '2031-03-04', 'rabies shot', 784233, 1);
+INSERT INTO visits VALUES (11, 4, '2009-06-04', 'neutered', 327874, 1);
+INSERT INTO visits VALUES (12, 4, '2022-09-04', 'spayed', 238372, 1);
+INSERT INTO visits VALUES (13, 5, '2023-03-04', 'rabies shot', 234568, 0);
+INSERT INTO visits VALUES (14, 5, '2011-03-04', 'rabies shot', 784233, 1);
+INSERT INTO visits VALUES (15, 6, '2029-06-04', 'neutered', 327874, 1);
+INSERT INTO visits VALUES (16, 6, '2008-09-04', 'spayed', 238372, 1);
+

--- a/visits-service/src/main/resources/data-mysql.sql
+++ b/visits-service/src/main/resources/data-mysql.sql
@@ -2,3 +2,16 @@ INSERT IGNORE INTO visits VALUES (1, 7, '2010-03-04', 'rabies shot', 234568, 0);
 INSERT IGNORE INTO visits VALUES (2, 8, '2011-03-04', 'rabies shot', 784233, 1);
 INSERT IGNORE INTO visits VALUES (3, 8, '2009-06-04', 'neutered', 327874, 1);
 INSERT IGNORE INTO visits VALUES (4, 7, '2008-09-04', 'spayed', 238372, 1);
+
+INSERT IGNORE INTO visits VALUES (5, 1, '2020-03-04', 'rabies shot', 234568, 0);
+INSERT IGNORE INTO visits VALUES (6, 1, '2022-03-04', 'rabies shot', 784233, 1);
+INSERT IGNORE INTO visits VALUES (7, 2, '2023-06-04', 'neutered', 327874, 1);
+INSERT IGNORE INTO visits VALUES (8, 2, '2008-09-04', 'spayed', 238372, 1);
+INSERT IGNORE INTO visits VALUES (9, 3, '2010-03-04', 'rabies shot', 234568, 0);
+INSERT IGNORE INTO visits VALUES (10, 3, '2031-03-04', 'rabies shot', 784233, 1);
+INSERT IGNORE INTO visits VALUES (11, 4, '2009-06-04', 'neutered', 327874, 1);
+INSERT IGNORE INTO visits VALUES (12, 4, '2022-09-04', 'spayed', 238372, 1);
+INSERT IGNORE INTO visits VALUES (13, 5, '2023-03-04', 'rabies shot', 234568, 0);
+INSERT IGNORE INTO visits VALUES (14, 5, '2011-03-04', 'rabies shot', 784233, 1);
+INSERT IGNORE INTO visits VALUES (15, 6, '2029-06-04', 'neutered', 327874, 1);
+INSERT IGNORE INTO visits VALUES (16, 6, '2008-09-04', 'spayed', 238372, 1);

--- a/visits-service/src/test/java/com/petclinic/visits/businesslayer/VisitsServiceImplTests.java
+++ b/visits-service/src/test/java/com/petclinic/visits/businesslayer/VisitsServiceImplTests.java
@@ -33,6 +33,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import javax.swing.text.html.Option;
 import java.sql.Time;
 import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 
@@ -203,5 +205,75 @@ public class VisitsServiceImplTests {
         visitsService.deleteVisit(3);
         verify(repo, never()).delete(vise);
     }
+
+    // TESTS FOR FETCHING VISITS BASED ON DATE
+    @Test
+    public void shouldReturnVisitsAfterNow() throws ParseException {
+        Date afterNow = new Date(System.currentTimeMillis() + 100000);
+        Date beforeNow = new Date(System.currentTimeMillis() - 100000);
+
+        List<Visit> visitsList = asList(
+                visit()
+                        .id(1)
+                        .petId(1)
+                        .date(afterNow)
+                        .build(),
+                visit()
+                        .id(3)
+                        .petId(1)
+                        .date(afterNow)
+                        .build(),
+                visit()
+                        .id(2)
+                        .petId(1)
+                        .date(beforeNow)
+                        .build());
+
+        when(repo.findByPetId(1)).thenReturn(visitsList);
+
+        List<Visit> returnedVisits = visitsService.getVisitsForPet(1, true);
+
+        assertEquals(2, returnedVisits.size());
+
+    }
+
+    @Test
+    public void shouldReturnVisitsBeforeNow() throws ParseException {
+        Date afterNow = new Date(System.currentTimeMillis() + 100000);
+        Date beforeNow = new Date(System.currentTimeMillis() - 100000);
+
+        List<Visit> visitsList = asList(
+                visit()
+                        .id(1)
+                        .petId(1)
+                        .date(afterNow)
+                        .build(),
+                visit()
+                        .id(3)
+                        .petId(1)
+                        .date(afterNow)
+                        .build(),
+                visit()
+                        .id(2)
+                        .petId(1)
+                        .date(beforeNow)
+                        .build());
+
+        when(repo.findByPetId(1)).thenReturn(visitsList);
+
+        List<Visit> returnedVisits = visitsService.getVisitsForPet(1, false);
+
+        assertEquals(1, returnedVisits.size());
+
+    }
+
+    @Test
+    public void shouldThrowInvalidInputExceptionWhenFetchingWithNegativePetId(){
+        assertThrows(InvalidInputException.class, () ->{
+            visitsService.getVisitsForPet(-1, true);
+        });
+    }
+
+
 
 }

--- a/visits-service/src/test/java/com/petclinic/visits/businesslayer/VisitsServiceImplTests.java
+++ b/visits-service/src/test/java/com/petclinic/visits/businesslayer/VisitsServiceImplTests.java
@@ -268,6 +268,62 @@ public class VisitsServiceImplTests {
     }
 
     @Test
+    public void shouldReturnEmptyListWhenNoScheduledVisits(){
+        Date beforeNow = new Date(System.currentTimeMillis() - 100000);
+
+        List<Visit> visitsList = asList(
+                visit()
+                        .id(1)
+                        .petId(1)
+                        .date(beforeNow)
+                        .build(),
+                visit()
+                        .id(3)
+                        .petId(1)
+                        .date(beforeNow)
+                        .build(),
+                visit()
+                        .id(2)
+                        .petId(1)
+                        .date(beforeNow)
+                        .build());
+
+        when(repo.findByPetId(1)).thenReturn(visitsList);
+
+        List<Visit> returnedVisits = visitsService.getVisitsForPet(1, true);
+
+        assertEquals(0, returnedVisits.size());
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenNoPreviousVisits(){
+        Date afterNow = new Date(System.currentTimeMillis() + 100000);
+
+        List<Visit> visitsList = asList(
+                visit()
+                        .id(1)
+                        .petId(1)
+                        .date(afterNow)
+                        .build(),
+                visit()
+                        .id(3)
+                        .petId(1)
+                        .date(afterNow)
+                        .build(),
+                visit()
+                        .id(2)
+                        .petId(1)
+                        .date(afterNow)
+                        .build());
+
+        when(repo.findByPetId(1)).thenReturn(visitsList);
+
+        List<Visit> returnedVisits = visitsService.getVisitsForPet(1, false);
+
+        assertEquals(0, returnedVisits.size());
+    }
+
+    @Test
     public void shouldThrowInvalidInputExceptionWhenFetchingWithNegativePetId(){
         InvalidInputException ex = assertThrows(InvalidInputException.class, () ->{
             visitsService.getVisitsForPet(-1, true);

--- a/visits-service/src/test/java/com/petclinic/visits/businesslayer/VisitsServiceImplTests.java
+++ b/visits-service/src/test/java/com/petclinic/visits/businesslayer/VisitsServiceImplTests.java
@@ -269,9 +269,11 @@ public class VisitsServiceImplTests {
 
     @Test
     public void shouldThrowInvalidInputExceptionWhenFetchingWithNegativePetId(){
-        assertThrows(InvalidInputException.class, () ->{
+        InvalidInputException ex = assertThrows(InvalidInputException.class, () ->{
             visitsService.getVisitsForPet(-1, true);
         });
+
+        assertEquals("PetId can't be negative.", ex.getMessage());
     }
 
 

--- a/visits-service/src/test/java/com/petclinic/visits/datalayer/PersistenceTests.java
+++ b/visits-service/src/test/java/com/petclinic/visits/datalayer/PersistenceTests.java
@@ -54,7 +54,13 @@ public class PersistenceTests {
     @Test
     public void getVisitsForPet() {
         List<Visit> repoResponse = repo.findByPetId(1);
-        assertThat(repoResponse, hasSize(2));
+        assertThat(repoResponse, hasSize(1));
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenPetDoesNotExist(){
+        List<Visit> repoResponse = repo.findByPetId(2);
+        assertThat(repoResponse, hasSize(0));
     }
     
     @Test
@@ -115,28 +121,8 @@ public class PersistenceTests {
         assertEquals("Updated Description", foundVisit.getDescription());
     }
 
-    // TESTS FOR FETCHING VISITS BASED ON DATE
-    @Test
-    public void whenFetchingVisitBeforeNowThenShouldReturn2Visits() throws ParseException {
-        Visit v2 = new Visit.VisitBuilder().petId(1).date(new SimpleDateFormat("yyyy-MM-dd").parse("2021-10-04"))
-                    .build();
-        Visit v3 = new Visit.VisitBuilder().petId(1).date(new SimpleDateFormat("yyyy-MM-dd").parse("2021-10-01"))
-                    .build();
-        Visit v4 = new Visit.VisitBuilder().petId(1).date(new SimpleDateFormat("yyyy-MM-dd").parse("2021-10-03"))
-                    .build();
 
-        repo.save(v2);
-        repo.save(v3);
-        repo.save(v4);
 
-        List<Visit> result = repo.findAllWithDateBefore(
-                new SimpleDateFormat("yyyy-MM-dd").parse("2021-10-03"));
-
-        assertEquals(3, result.size());
-        assertTrue(result.stream()
-        .map(Visit::getId)
-        .allMatch(id -> Arrays.asList(1, 3, 4).contains(id)));
-    }
 
 }
 

--- a/visits-service/src/test/java/com/petclinic/visits/datalayer/PersistenceTests.java
+++ b/visits-service/src/test/java/com/petclinic/visits/datalayer/PersistenceTests.java
@@ -120,9 +120,5 @@ public class PersistenceTests {
         Visit foundVisit = repo.findById(savedVisit.getId()).get();
         assertEquals("Updated Description", foundVisit.getDescription());
     }
-
-
-
-
 }
 

--- a/visits-service/src/test/java/com/petclinic/visits/presentationlayer/VisitResourceTest.java
+++ b/visits-service/src/test/java/com/petclinic/visits/presentationlayer/VisitResourceTest.java
@@ -29,6 +29,8 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
@@ -278,6 +280,42 @@ public class VisitResourceTest {
 				.andExpect(status().isNotFound())
 				.andExpect(result -> assertTrue(result.getResolvedException() instanceof NotFoundException))
 				.andExpect(result -> assertEquals("Pet does not exist.", result.getResolvedException().getMessage()));
+	}
+
+	@Test
+	void shouldReturnPreviousVisits() throws Exception {
+		Date beforeNow = new Date(System.currentTimeMillis() - 100000);
+		List<Visit> previousVisits = asList(
+				visit()
+						.id(1)
+						.petId(1)
+						.date(beforeNow)
+						.build());
+
+		when(visitsService.getVisitsForPet(1, false)).thenReturn(previousVisits);
+
+		mvc.perform(get("/visits/previous/{petId}", 1))
+				.andExpect(status().isOk());
+
+		verify(visitsService, times(1)).getVisitsForPet(1, false);
+	}
+
+	@Test
+	void shouldReturnScheduledVisits() throws Exception {
+		Date afterNow = new Date(System.currentTimeMillis() + 100000);
+		List<Visit> scheduledVisits = asList(
+				visit()
+						.id(1)
+						.petId(1)
+						.date(afterNow)
+						.build());
+
+		when(visitsService.getVisitsForPet(1, true)).thenReturn(scheduledVisits);
+
+		mvc.perform(get("/visits/scheduled/{petId}", 1))
+				.andExpect(status().isOk());
+		verify(visitsService, times(1)).getVisitsForPet(1, true);
+
 	}
 
 	// UTILS PACKAGE TESTING

--- a/visits-service/src/test/java/com/petclinic/visits/presentationlayer/VisitResourceTest.java
+++ b/visits-service/src/test/java/com/petclinic/visits/presentationlayer/VisitResourceTest.java
@@ -318,7 +318,17 @@ public class VisitResourceTest {
 
 	}
 
-	// UTILS PACKAGE TESTING
+	@Test
+	void whenFetchingWithNegativePetIdShouldHandleInvalidInputException() throws Exception {
+		when(visitsService.getVisitsForPet(-1)).thenThrow(new InvalidInputException("PetId can't be negative."));
+
+		mvc.perform(get("/visits/{petId}", -1))
+				.andExpect(status().isUnprocessableEntity())
+				.andExpect(result -> assertTrue(result.getResolvedException() instanceof InvalidInputException))
+				.andExpect(result -> assertEquals("PetId can't be negative.", result.getResolvedException().getMessage()));
+	}
+
+	// UTILS PACKAGE UNIT TESTING
 	@Test
 	void test_EmptyInvalidInputException(){
 		InvalidInputException ex = assertThrows(InvalidInputException.class, ()->{


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-159?atlOrigin=eyJpIjoiZGVkYjViMWExNTk1NGM5MmFhZjMxMzZjZWEzZWY1MTUiLCJwIjoiaiJ9

- Our service now has a GET mapping for fetching previous visits only and a GET mapping for fetching scheduled visits only (for a specific pet).
- Added a method in the business layer to filter out unwanted visits based on a boolean and the date and time when the request is made.
- Added tests for those methods.
- Fetching visits with a negative petId will now throw an InvalidInputException which is handled gracefully.
