### PR TITLE
feat(VISE-CPC-358): Fetching Dates of visits for Practitioner

### DIFF
--- a/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsService.java
+++ b/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsService.java
@@ -24,4 +24,6 @@ public interface VisitsService {
     public List<Visit> getVisitsForPets(List<Integer> petIds);
 
     List<Visit> getVisitsForPet(int petId, boolean scheduled);
+
+    List<String> getVisitDatesForPractitioner(int practitionerId);
 }

--- a/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsServiceImpl.java
+++ b/visits-service/src/main/java/com/petclinic/visits/businesslayer/VisitsServiceImpl.java
@@ -91,4 +91,12 @@ public class VisitsServiceImpl implements VisitsService {
         }
         return visits;
     }
+
+    @Override
+    public List<String> getVisitDatesForPractitioner(int practitionerId) {
+        if(practitionerId < 0)
+            throw new InvalidInputException("PractitionerId can't be negative.");
+        List<Visit> visits = visitRepository.findVisitsByPractitionerId(practitionerId);
+        return visits.stream().map(v -> v.getDate().toString()).collect(Collectors.toList());
+    }
 }

--- a/visits-service/src/main/java/com/petclinic/visits/datalayer/VisitRepository.java
+++ b/visits-service/src/main/java/com/petclinic/visits/datalayer/VisitRepository.java
@@ -29,6 +29,8 @@ public interface VisitRepository extends JpaRepository<Visit, Integer> {
 
     List<Visit> findByPetIdIn(Collection<Integer> petIds);
 
+    List<Visit> findVisitsByPractitionerId(int practitionerId);
+
     void findVisitById(int visitId);
 
 }

--- a/visits-service/src/main/java/com/petclinic/visits/presentationlayer/VisitResource.java
+++ b/visits-service/src/main/java/com/petclinic/visits/presentationlayer/VisitResource.java
@@ -89,6 +89,11 @@ public class VisitResource {
         return visitsService.getVisitsForPet(petId, true);
     }
 
+    @GetMapping("visits/vets/dates/{practitionerId}")
+    public List<String> getVisitDatesForPractitioner(@PathVariable("practitionerId") int practitionerId){
+        log.debug("Calling VisitsService:getVisitDatesForPractitioner:practitionerId={}", practitionerId);
+        return visitsService.getVisitDatesForPractitioner(practitionerId);
+    }
 
     @Value
     static class Visits {

--- a/visits-service/src/test/java/com/petclinic/visits/businesslayer/VisitsServiceImplTests.java
+++ b/visits-service/src/test/java/com/petclinic/visits/businesslayer/VisitsServiceImplTests.java
@@ -332,6 +332,55 @@ public class VisitsServiceImplTests {
         assertEquals("PetId can't be negative.", ex.getMessage());
     }
 
+    @Test
+    public void shouldReturnListOfVisitDatesWhenFetchingWithValidPractitionerId() throws ParseException {
+        List<Visit> visitsList = asList(
+                visit()
+                        .id(1)
+                        .petId(1)
+                        .date(new SimpleDateFormat("yyyy-MM-dd").parse("2020-03-04"))
+                        .practitionerId(200200)
+                        .build(),
+                visit()
+                        .id(3)
+                        .petId(1)
+                        .date(new SimpleDateFormat("yyyy-MM-dd").parse("2021-03-04"))
+                        .practitionerId(200200)
+                        .build(),
+                visit()
+                        .id(2)
+                        .petId(1)
+                        .date(new SimpleDateFormat("yyyy-MM-dd").parse("2022-03-04"))
+                        .practitionerId(200200)
+                        .build());
+
+        when(repo.findVisitsByPractitionerId(anyInt())).thenReturn(visitsList);
+
+        List<String> returnedStringDates = visitsService.getVisitDatesForPractitioner(200200);
+
+        assertEquals(3, returnedStringDates.size());
+        assertEquals(new SimpleDateFormat("yyyy-MM-dd").parse("2021-03-04").toString(), returnedStringDates.get(1));
+    }
+
+    @Test
+    public void shouldThrowInvalidInputExceptionWhenFetchingDatesWithNegativePractitionerId(){
+        InvalidInputException ex = assertThrows(InvalidInputException.class, ()->{
+           visitsService.getVisitDatesForPractitioner(-1);
+        });
+
+        assertEquals("PractitionerId can't be negative.", ex.getMessage());
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenFetchingDatesForPractitionerWithNoVisits(){
+        List<Visit> repoResponse = new ArrayList<Visit>();
+        when(repo.findVisitsByPractitionerId(anyInt())).thenReturn(repoResponse);
+
+        List<String> returnedStringDates = visitsService.getVisitDatesForPractitioner(234);
+
+        assertEquals(0, returnedStringDates.size());
+    }
+
 
 
 }

--- a/visits-service/src/test/java/com/petclinic/visits/datalayer/PersistenceTests.java
+++ b/visits-service/src/test/java/com/petclinic/visits/datalayer/PersistenceTests.java
@@ -45,6 +45,7 @@ public class PersistenceTests {
         visit = Visit.visit()
                 .id(1)
                 .petId(1)
+                .practitionerId(200200)
                 .date(new SimpleDateFormat("yyyy-MM-dd").parse("2021-10-02"))
                 .status(true)
                 .build();
@@ -119,6 +120,18 @@ public class PersistenceTests {
         
         Visit foundVisit = repo.findById(savedVisit.getId()).get();
         assertEquals("Updated Description", foundVisit.getDescription());
+    }
+
+    @Test
+    public void findByPractitionerId(){
+        List<Visit> returnedVisits = repo.findVisitsByPractitionerId(200200);
+        assertEquals(1, returnedVisits.size());
+    }
+
+    @Test
+    public void findByNonExistentPractitionerId(){
+        List<Visit> returnedVisits = repo.findVisitsByPractitionerId(234234);
+        assertEquals(0, returnedVisits.size());
     }
 }
 

--- a/visits-service/src/test/java/com/petclinic/visits/presentationlayer/VisitResourceTest.java
+++ b/visits-service/src/test/java/com/petclinic/visits/presentationlayer/VisitResourceTest.java
@@ -21,6 +21,7 @@ import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -326,6 +328,29 @@ public class VisitResourceTest {
 				.andExpect(status().isUnprocessableEntity())
 				.andExpect(result -> assertTrue(result.getResolvedException() instanceof InvalidInputException))
 				.andExpect(result -> assertEquals("PetId can't be negative.", result.getResolvedException().getMessage()));
+	}
+
+	@Test
+	void whenFetchingStringDatesWithNegativePractitionerIdThenShouldHandleInvalidInputException() throws Exception {
+		when(visitsService.getVisitDatesForPractitioner(-1)).thenThrow(new InvalidInputException("PractitionerId can't be negative."));
+
+		mvc.perform(get("/visits/vets/dates/{practitionerId}",-1))
+				.andExpect(status().isUnprocessableEntity())
+				.andExpect(result -> assertTrue(result.getResolvedException() instanceof InvalidInputException))
+				.andExpect(result -> assertEquals("PractitionerId can't be negative.", result.getResolvedException().getMessage()));
+	}
+
+	@Test
+	void whenFetchingStringDatesWithValidPractitionerIdThenShouldReturnListOfDates() throws Exception {
+		List<String> returnedStringDates = Arrays.asList("2020-03-02", "2021-04-09","2022-12-12");
+
+		given(visitsService.getVisitDatesForPractitioner(200200)).willReturn(returnedStringDates);
+
+		MvcResult result = mvc.perform(get("/visits/vets/dates/{practitionerId}",200200))
+				.andExpect(status().isOk())
+				.andReturn();
+
+		assertEquals("[\"2020-03-02\",\"2021-04-09\",\"2022-12-12\"]", result.getResponse().getContentAsString());
 	}
 
 	// UTILS PACKAGE UNIT TESTING


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-358?atlOrigin=eyJpIjoiMWMxMTJiNGE0NjhjNGUyM2FjZGY4OTA0NjY1ZDZlZDMiLCJwIjoiaiJ9
## Context:
This PR aims to add a way to get the dates of the visits associated with the given practitionerId/vetId as a list of strings. This was a request from the vets service team (@amine-12 )
## Changes
- Added GetMapping in presentation layer with a method that responds to requests from API with a list of strings.
- Added method in service layer that exrtacts dates out of the associated visits and returns a list of string dates.
- Added method in data layer to fetch visits based on practitionerId.
- Added tests for each layer.

## Dev notes
- The methods do not cross-reference with the vets database to check if a practitioner/vet with the returned practitionerId actually exists.
- ^^^ We should make sure to use the same format that the vets are using for their public business key.
