### PR TITLE
bug(BILL-CPC-442): Fix History Page Template Routing

### DIFF
--- a/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.component.js
+++ b/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.component.js
@@ -2,6 +2,6 @@
 
 angular.module('billHistory')
     .component('billHistory', {
-        templateUrl: 'scripts/bill/bill-history.template.html',
+        templateUrl: 'scripts/bill-history/bill-history.template.html',
         controller: 'BillHistoryController'
     });


### PR DESCRIPTION
### Context
Fixing the bug from bill component script to now correctly go to the appropriate template URL

### Jira
https://champlainsaintlambert.atlassian.net/browse/CPC-442?atlOrigin=eyJpIjoiOTBkNThhM2U2OWRhNDM4NGFiMzVmZmEzZGZmMzVhNTgiLCJwIjoiaiJ9

### Changes

- The bill-history.component.js file has had it's template URL changed to the bill-history scripts folder

### UI Changes

Before:
![Screenshot 2021-10-18 105210](https://user-images.githubusercontent.com/70395022/137759590-f7ef70f0-fb8b-4aa8-af76-67459b40e93e.jpg)

After:
![Screenshot 2021-10-18 104519](https://user-images.githubusercontent.com/70395022/137759604-5e7f0280-9317-4011-a5bc-92d7399fa3bc.jpg)