### PR TITLE
bug(BILL-CPC-449): Configure logic for a not found visit type

### DIFF
--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -50,9 +50,14 @@ public class BillServiceImpl implements BillService{
             throw new InvalidInputException("That bill id does not exist");
         }
 
+        HashMap<String, Double> list = setUpVisitList();
+
+        if(list.get(model.getVisitType()) == null){
+            throw new InvalidInputException("That visit type does not exist");
+        }
+
         try{
             Bill entity = billMapper.ModelToEntity(model);
-            HashMap<String, Double> list = setUpVisitList();
             entity.setAmount(list.get(entity.getVisitType()));
             Bill newEntity = billRepository.save(entity);
 

--- a/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
@@ -130,7 +130,7 @@ public class BillServiceImplTest {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2021, Calendar.SEPTEMBER, 21);
         Date date = calendar.getTime();
-        Bill entity = new Bill(billId,customerId, date, "Checkup", 50.0);
+        Bill entity = new Bill(billId,customerId, date, "Consultations",39.99);
         when(billRepository.findById(1)).thenReturn(Optional.of(entity));
 
 
@@ -146,7 +146,7 @@ public class BillServiceImplTest {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2021, Calendar.SEPTEMBER, 21);
         Date date = calendar.getTime();
-        Bill entity = new Bill(billId,customerId, date, "Checkup", 50.0);
+        Bill entity = new Bill(billId,customerId, date, "Consultations", 39.99);
 
 
         billService.DeleteBill(1);

--- a/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Date;
+
 @SpringBootTest
 @ExtendWith(SpringExtension.class)
 public class BillServiceImplTest {
@@ -65,7 +67,7 @@ public class BillServiceImplTest {
         calendar.set(2021, Calendar.SEPTEMBER, 21);
 
         Date date = calendar.getTime();
-        Bill entity = new Bill(billId,customerId, "Checkup", date, 50.00);
+        Bill entity = new Bill(billId,customerId, "Examinations", date, 59.99);
         when(billRepository.findById(1)).thenReturn(Optional.of(entity));
 
         BillDTO returnedBill = billService.GetBill(1);
@@ -127,7 +129,7 @@ public class BillServiceImplTest {
         Date date = calendar.getTime();
 
         HashMap<String, Double> list = setUpVisitList();
-        BillDTO receivedDTO = new BillDTO(billId,customerId, date, "Checkup");
+        BillDTO receivedDTO = new BillDTO(billId,customerId, date, "Consultations");
         when(billRepository.save(any(Bill.class))).thenThrow(DuplicateKeyException.class);
 
 
@@ -158,7 +160,7 @@ public class BillServiceImplTest {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2021, Calendar.SEPTEMBER, 21);
         Date date = calendar.getTime();
-        Bill entity = new Bill(billId,customerId, date, "Consultations",39.99);
+        Bill entity = new Bill(billId,customerId, "Consultations", date, 59.99);
         when(billRepository.findById(1)).thenReturn(Optional.of(entity));
 
 
@@ -174,7 +176,8 @@ public class BillServiceImplTest {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2021, Calendar.SEPTEMBER, 21);
         Date date = calendar.getTime();
-        Bill entity = new Bill(billId,customerId, date, "Consultations", 39.99);
+        Bill entity = new Bill(billId,customerId, "Consultations", date, 59.99);
+
 
         billService.DeleteBill(1);
 

--- a/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
@@ -91,6 +91,19 @@ public class BillServiceImplTest {
 
     }
 
+
+    @Test
+    public void test_CreateBillInvalidVisitTypeReceived(){
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2021, Calendar.SEPTEMBER, 21);
+        Date date = calendar.getTime();
+
+        HashMap<String, Double> list = setUpVisitList();
+        BillDTO receivedDTO = new BillDTO(billId,customerId, date, "Checkup");
+        assertNull(list.get(receivedDTO.getVisitType()));
+
+    }
+
     @Test
     public void test_CreateBillInvalidInputException(){
         Calendar calendar = Calendar.getInstance();

--- a/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
@@ -100,7 +100,12 @@ public class BillServiceImplTest {
 
         HashMap<String, Double> list = setUpVisitList();
         BillDTO receivedDTO = new BillDTO(billId,customerId, date, "Checkup");
-        assertNull(list.get(receivedDTO.getVisitType()));
+        when(billRepository.save(any(Bill.class))).thenThrow(DuplicateKeyException.class);
+
+
+        assertThrows(InvalidInputException.class, () -> {
+            billService.CreateBill(receivedDTO);
+        });
 
     }
 


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/15?modal=detail&selectedIssue=CPC-449&assignee=6005c6881ffcc00076745e8b
## Context:
Configure logic for a not found visit type. The code for the visit type to price was done in sprint 2 but I realized we were missing logic for when a visit type is not found in our list of possible visit type
## Changes
Changed the tests and added to the CreateBill method of Billing service which now throws and exception if the get to the hashmap returns null
