### PR TITLE
feat(APIG-CPC-331): Get request for previous visits of a pet

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
@@ -63,6 +63,14 @@ public class VisitsServiceClient {
                 .bodyToFlux(VisitDetails.class);
     }
 
+    public Flux<VisitDetails> getPreviousVisitsForPet(final int petId) {
+        return webClientBuilder.build()
+                .get()
+                .uri(hostname + "/visits/previous/{petId}", petId)
+                .retrieve()
+                .bodyToFlux(VisitDetails.class);
+    }
+
     public Flux<VisitDetails> getVisitForPractitioner(final int practitionerId){
         return webClientBuilder.build()
                 .get()

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/VisitDetails.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/VisitDetails.java
@@ -1,5 +1,7 @@
 package com.petclinic.bffapigateway.dtos;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +12,8 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class VisitDetails {
 
     private Integer id = null;

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -126,6 +126,11 @@ public class BFFApiGatewayController {
     public Mono<VisitDetails> getVisitById(final @PathVariable int visitId){
         return visitsServiceClient.getVisitById(visitId);
     }
+    
+    @GetMapping(value = "visits/previous/{petId}")
+    public Flux<VisitDetails> getPreviousVisitsForPet(@PathVariable final int petId) {
+        return visitsServiceClient.getPreviousVisitsForPet(petId);
+    }
 
     @GetMapping(value = "visits/vets/{practitionerId}")
     public Flux<VisitDetails> getVisitForPractitioner(@PathVariable int practitionerId){

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.petclinic.bffapigateway.domainclientlayer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.petclinic.bffapigateway.dtos.VisitDetails;
 import com.petclinic.bffapigateway.dtos.Visits;
 import okhttp3.mockwebserver.MockResponse;
@@ -27,6 +29,8 @@ class VisitsServiceClientIntegrationTest {
 
     private MockWebServer server;
 
+    private ObjectMapper objectMapper;
+
     @BeforeEach
     void setUp() {
         server = new MockWebServer();
@@ -36,6 +40,7 @@ class VisitsServiceClientIntegrationTest {
                 "7000"
         );
         visitsServiceClient.setHostname(server.url("/").toString());
+        objectMapper = new ObjectMapper();
     }
 
     @AfterEach
@@ -63,6 +68,33 @@ class VisitsServiceClientIntegrationTest {
         Flux<VisitDetails> visits = visitsServiceClient.getVisitsForPet(1);
 
         assertVisitDescriptionEq(visits.blockFirst(), PET_ID,"test visit");
+    }
+
+    @Test
+    void shouldGetPreviousVisitsForPet() throws JsonProcessingException {
+        final VisitDetails visit = VisitDetails.builder()
+                .id(1)
+                .petId(21)
+                .practitionerId(2)
+                .date("2021-12-7")
+                .description("Cat is sick")
+                .status(false)
+                .build();
+
+        final String body = objectMapper.writeValueAsString(objectMapper.convertValue(visit, VisitDetails.class));
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setBody(body));
+
+        final VisitDetails previousVisits = visitsServiceClient.getPreviousVisitsForPet(21).blockFirst();
+
+        assertEquals(visit.getId(), previousVisits.getId());
+        assertEquals(visit.getPetId(), previousVisits.getPetId());
+        assertEquals(visit.getPractitionerId(), previousVisits.getPractitionerId());
+        assertEquals(visit.getDate(), previousVisits.getDate());
+        assertEquals(visit.getDescription(), previousVisits.getDescription());
+        assertEquals(visit.getStatus(), previousVisits.getStatus());
+
     }
 
     private void assertVisitDescriptionEq(VisitDetails visits, int petId, String description) {


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-331
## Context:
This ticket will implement the request to get previous visits of a pet and also the corresponding mapping in the API gateway controller.
## Changes
Added the method in the VisitsServiceClient.
Added the mapping in the BFFApiGatewayController.
Added Controller Testing.
Added Integration Testing.
## Before and After UI (Required for UI-impacting PRs)
No changes have been done to the UI.