### PR TITLE
Bug/vets cpc 637 upgraded jacoco to the latest version

### DIFF
--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 }
 
 jacoco {
-	toolVersion = "0.8.6"
+	toolVersion = "0.8.8"
 }
 
 jacocoTestReport {

--- a/vets-service/build.gradle
+++ b/vets-service/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
 }
 jacoco {
-    toolVersion = "0.8.6"
+    toolVersion = "0.8.8"
 }
 
 jacocoTestReport {


### PR DESCRIPTION
JIRA: link to jira ticket
https://champlainsaintlambert.atlassian.net/browse/CPC-637
What is the ticket about and why are we doing this change?
Upgrading Jacoco to the latest version 0.8.8 to prevent the java.lang.instrument.IllegalClassFormatException when running tests via gradlew.
What are the various changes and what other modules do those changes affect.
Affects the VETS-service tests

NOTE TESTS might not pass due to other errors in the project.
