### PR TITLE
feat/ACMS-CPC-539_Add_Photo_To_Owner

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/PhotoDetails.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/PhotoDetails.java
@@ -18,6 +18,5 @@ public class PhotoDetails {
 
     private String type;
 
-    private byte[] photo;
-
+    private String photo;
 }

--- a/api-gateway/src/main/resources/static/css/ownerdetail.css
+++ b/api-gateway/src/main/resources/static/css/ownerdetail.css
@@ -1,0 +1,39 @@
+.parent {
+    position: relative;
+    height: 150px;
+    width: 150px;
+    top: 0;
+    left: 0;
+    z-index: 50;
+}
+
+
+.image1 {
+    position: relative;
+    top: 0;
+    left: 0;
+    border: 1px solid #000000;
+}
+
+.image2 {
+    position: absolute;
+    top: 0;
+    left: 0;
+    border: 1px solid #000000;
+}
+
+.fileInput {
+    cursor: pointer;
+    position:absolute;
+    opacity: 0;
+    top: 0;
+    right: 0;
+    height:150px;
+    width:150px;
+    z-index: 60;
+}
+
+.parent:hover {
+    background-color: black;
+    opacity: 0.8;
+}

--- a/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.controller.js
@@ -7,4 +7,48 @@ angular.module('ownerDetails')
         $http.get('api/gateway/owners/' + $stateParams.ownerId).then(function (resp) {
             self.owner = resp.data;
         });
+
+        $http.get('api/gateway/owners/photo/' + $stateParams.ownerId).then(function (resp) {
+            self.ownerPhoto = resp.data;
+        });
+
+        const fileInput = document.querySelector('input[id="photoOwner"]');
+        let ownerPhoto = "";
+        fileInput.addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            const reader = new FileReader();
+            reader.onloadend = () => {
+                ownerPhoto = reader.result
+                    .replace('data:', '')
+                    .replace(/^.+,/, '');
+                self.PreviewImage = ownerPhoto;
+                var image = {
+                    name: uuidv4(),
+                    type: "jpeg",
+                    photo: ownerPhoto
+                };
+
+                var test = $http.post('api/gateway/owners/photo/' + $stateParams.ownerId, image);
+                console.log(test);
+
+            };
+            reader.readAsDataURL(file);
+        });
+
+
+        // $http.post('api/gateway/owners/photo/' + $stateParams.ownerId, data);
+
+        // self.getPetPhoto = function (petId){
+        //     $http.get('api/gateway/owners/' + $stateParams.ownerId + '/pet/photo/' + petId).then(function (resp) {
+        //         return resp.data.photo;
+        //     });
+        // };
+
+        function uuidv4() {
+            return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+                (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+            );
+        };
+
     }]);
+

--- a/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.js
+++ b/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.js
@@ -9,11 +9,4 @@ angular.module('ownerDetails', ['ui.router'])
                 params: {ownerId: null},
                 template: '<owner-details></owner-details>'
             })
-        $stateProvider
-            .state('photoDetails', {
-                parent: 'app',
-                url: '/owners/photo/:ownerId',
-                params: {ownerId: null},
-                template: '<photo-details></photo-details>'
-            })
     }]);

--- a/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.js
+++ b/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.js
@@ -9,5 +9,11 @@ angular.module('ownerDetails', ['ui.router'])
                 params: {ownerId: null},
                 template: '<owner-details></owner-details>'
             })
-
+        $stateProvider
+            .state('photoDetails', {
+                parent: 'app',
+                url: '/owners/photo/:ownerId',
+                params: {ownerId: null},
+                template: '<photo-details></photo-details>'
+            })
     }]);

--- a/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.template.html
@@ -1,9 +1,19 @@
+<link href="/css/ownerdetail.css" rel="stylesheet" type="text/css"/>
+
 <div class="bColor"><h2 class="titleOwner form">Owner Information</h2></div>
 
 <table class="table table-striped">
     <tr>
+        <td rowspan="5">
+            <div class="parent">
+                <img alt="Profile picture preview" src="data:image/png;base64, {{$ctrl.ownerPhoto.photo}}" width="150" height="150" class="image1">
+                <img alt="" src="data:image/png;base64, {{$ctrl.PreviewImage}}" ng-show="$ctrl.PreviewImage != null" width="150" height="150" class="image2"/>
+                <input type="file" accept="image/jpeg" class="fileInput" id="photoOwner"/>
+            </div>
+        </td>
         <th class="col-sm-3">Name</th>
         <td id="tableName"><b>{{$ctrl.owner.firstName}} {{$ctrl.owner.lastName}}</b></td>
+
     </tr>
     <tr>
         <th>Address</th>
@@ -16,10 +26,6 @@
     <tr>
         <th>Telephone</th>
         <td>{{$ctrl.owner.telephone}}</td>
-    </tr>
-    <tr>
-        <th>Photo</th>
-        <td>{{$ctrl.owner.photo}}</td>
     </tr>
 
     <tr>
@@ -39,6 +45,8 @@
     <tr ng-repeat="pet in $ctrl.owner.pets track by pet.id">
         <td valign="top">
             <dl class="dl-horizontal">
+                <dt>Photo</dt>
+<!--                <dd><img alt="Profile picture preview" src="data:image/png;base64, {{$ctrl.getPetPhoto(pet.id)}}" width="100" height="100"></dd>-->
                 <dt>Name</dt>
                 <dd>{{pet.name}}</dd>
                 <dt>Birth Date</dt>
@@ -71,6 +79,7 @@
         </td>
     </tr>
 </table>
+
 
 
 

--- a/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.template.html
@@ -45,8 +45,6 @@
     <tr ng-repeat="pet in $ctrl.owner.pets track by pet.id">
         <td valign="top">
             <dl class="dl-horizontal">
-                <dt>Photo</dt>
-<!--                <dd><img alt="Profile picture preview" src="data:image/png;base64, {{$ctrl.getPetPhoto(pet.id)}}" width="100" height="100"></dd>-->
                 <dt>Name</dt>
                 <dd>{{pet.name}}</dd>
                 <dt>Birth Date</dt>

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/CustomerServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/CustomerServiceClientIntegrationTest.java
@@ -31,7 +31,7 @@ public class CustomerServiceClientIntegrationTest {
             .id(2)
             .name("photo")
             .type("jpeg")
-            .photo(testBytes)
+            .photo("testBytes")
             .build();
 
     private final OwnerDetails TEST_OWNER = OwnerDetails.builder()

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -463,7 +463,7 @@ class ApiGatewayControllerTest {
         photo.setId(2);
         photo.setName("photo");
         photo.setType("jpeg");
-        photo.setPhoto(testBytes);
+        photo.setPhoto("testBytes");
 
         when(customersServiceClient.setOwnerPhoto(photo, owner.getId()))
                 .thenReturn(Mono.just("Image uploaded successfully: " + photo.getName()));
@@ -498,7 +498,7 @@ class ApiGatewayControllerTest {
         photo.setId(2);
         photo.setName("photo");
         photo.setType("jpeg");
-        photo.setPhoto(testBytes);
+        photo.setPhoto("testBytes");
 
         when(customersServiceClient.getOwnerPhoto(owner.getId()))
                 .thenReturn(Mono.just(photo));
@@ -539,7 +539,7 @@ class ApiGatewayControllerTest {
             photo.setId(2);
             photo.setName("photo");
             photo.setType("jpeg");
-            photo.setPhoto(testBytes);
+            photo.setPhoto("testBytes");
 
             when(customersServiceClient.setPetPhoto(owner.getId(), photo, pet.getId()))
                     .thenReturn(Mono.just("Image uploaded successfully: " + photo.getName()));
@@ -575,7 +575,7 @@ class ApiGatewayControllerTest {
         photo.setId(2);
         photo.setName("photo");
         photo.setType("jpeg");
-        photo.setPhoto(testBytes);
+        photo.setPhoto("testBytes");
 
         when(customersServiceClient.getPetPhoto(owner.getId(), pet.getId()))
                 .thenReturn(Mono.just(photo));

--- a/customers-service/src/main/java/com/petclinic/customers/datalayer/Photo.java
+++ b/customers-service/src/main/java/com/petclinic/customers/datalayer/Photo.java
@@ -28,7 +28,7 @@ public class Photo {
     private String type;
 
     @Column(name = "image", unique = false, nullable = false, length = 100000)
-    private byte[] photo;
+    private String photo;
 
     @Override
     public String toString()
@@ -37,6 +37,6 @@ public class Photo {
                 this.id + ", Name: " +
                 this.name + ", Type: " +
                 this.type + ", Image: " +
-                Arrays.toString(this.photo);
+                this.photo;
     }
 }

--- a/customers-service/src/main/resources/db/mysql/schema.sql
+++ b/customers-service/src/main/resources/db/mysql/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS photos (
     id INT(4) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(80),
     type VARCHAR(80),
-    image LONGBLOB,
+    image LONGTEXT,
     INDEX(name)
     ) engine=InnoDB;
 

--- a/customers-service/src/main/resources/schema-mysql.sql
+++ b/customers-service/src/main/resources/schema-mysql.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS photos (
     id INT(4) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(80),
     type VARCHAR(80),
-    image LONGBLOB,
+    image LONGTEXT,
     INDEX(name)
     ) engine=InnoDB;
 

--- a/customers-service/src/test/java/com/petclinic/customers/businesslayer/PhotoServiceTest.java
+++ b/customers-service/src/test/java/com/petclinic/customers/businesslayer/PhotoServiceTest.java
@@ -160,13 +160,11 @@ class PhotoServiceTest {
 
 
     private Photo buildPhoto(){
-        final String test = "Test photo";
-        final byte[] testBytes = test.getBytes();
         return Photo.builder()
                 .id(2)
                 .name("test photo")
                 .type("jpeg")
-                .photo(testBytes)
+                .photo("testPhoto")
                 .build();
     }
 

--- a/customers-service/src/test/java/com/petclinic/customers/datalayer/PhotoPersistenceTest.java
+++ b/customers-service/src/test/java/com/petclinic/customers/datalayer/PhotoPersistenceTest.java
@@ -28,13 +28,11 @@ class PhotoPersistenceTest {
     }
 
     private Photo buildPhoto(){
-        final String test = "Test photo";
-        final byte[] testBytes = test.getBytes();
         return Photo.builder()
                 .id(1)
                 .name("test photo")
                 .type("jpeg")
-                .photo(testBytes)
+                .photo("testBytes")
                 .build();
     }
 

--- a/customers-service/src/test/java/com/petclinic/customers/datalayer/PhotoTest.java
+++ b/customers-service/src/test/java/com/petclinic/customers/datalayer/PhotoTest.java
@@ -12,9 +12,9 @@ class PhotoTest {
     public void test_setPhoto()
     {
         //Arrange
-        Photo photo = new Photo(1,"photoName","jpeg","testPhoto".getBytes());
+        Photo photo = new Photo(1,"photoName","jpeg","testPhoto");
 
-        String expected = "ID: 1, Name: photoName, Type: jpeg, Image: " + Arrays.toString("testPhoto".getBytes());
+        String expected = "ID: 1, Name: photoName, Type: jpeg, Image: testPhoto";
 
         //Act
         String result = photo.toString();

--- a/customers-service/src/test/java/com/petclinic/customers/presentationlayer/OwnerApiTest.java
+++ b/customers-service/src/test/java/com/petclinic/customers/presentationlayer/OwnerApiTest.java
@@ -65,14 +65,11 @@ class OwnerAPITest {
 
     private Photo setupPhoto() {
 
-        final String test = "Test photo";
-        final byte[] testBytes = test.getBytes();
-
         Photo photo = new Photo();
         photo.setId(1);
         photo.setName("photo");
         photo.setType("jpeg");
-        photo.setPhoto(testBytes);
+        photo.setPhoto("testBytes");
 
         return photo;
     }

--- a/customers-service/src/test/java/com/petclinic/customers/presentationlayer/PetAPITest.java
+++ b/customers-service/src/test/java/com/petclinic/customers/presentationlayer/PetAPITest.java
@@ -67,14 +67,11 @@ class PetAPITest {
 
     private Photo setupPhoto() {
 
-        final String test = "Test photo";
-        final byte[] testBytes = test.getBytes();
-
         Photo photo = new Photo();
         photo.setId(1);
         photo.setName("photo");
         photo.setType("jpeg");
-        photo.setPhoto(testBytes);
+        photo.setPhoto("testBytes");
 
         return photo;
     }


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-539?atlOrigin=eyJpIjoiMWViMmZiNDA5M2Q2NGU5Njk3ZjYzNzJjODE4MTYwNDYiLCJwIjoiaiJ9

## Context:
Front end image handling for Owner profile picture

## Changes
Profile picture displayed on Owner detail page
Clicking it will allow user to change the image

## Before and After UI (Required for UI-impacting PRs)
Before
![Screen Shot 2022-10-10 at 7 34 01 PM](https://user-images.githubusercontent.com/47580767/194967455-eaa06a73-1911-47bf-a89e-dbc5eb96e164.png)

#After
Default
![Screen Shot 2022-10-10 at 7 24 08 PM](https://user-images.githubusercontent.com/47580767/194966597-a18ff247-7703-4cd1-be62-a5381d812502.png)
When hovered
![Screen Shot 2022-10-10 at 7 25 23 PM](https://user-images.githubusercontent.com/47580767/194966716-a318fd0d-4f41-4e38-ab77-f30e6904d651.png)
Click to chose file
![Screen Shot 2022-10-10 at 7 25 56 PM](https://user-images.githubusercontent.com/47580767/194966801-915e0427-2d66-4ff3-9972-80ffd68b0f94.png)
New image right away
![Screen Shot 2022-10-10 at 7 26 45 PM](https://user-images.githubusercontent.com/47580767/194966861-53b00a5d-922e-4d8d-b773-cdc34b4dad83.png)

## Dev notes
Photo entity was modified to hold base64 of image as string rather than byte[]


