### PR TITLE
bug/ACMS-CPC-686_OwnerPersistenceupdate_owner_test not saving Id correctly

### DIFF
--- a/customers-service/src/test/java/com/petclinic/customers/presentationlayer/OwnerPersistenceTest.java
+++ b/customers-service/src/test/java/com/petclinic/customers/presentationlayer/OwnerPersistenceTest.java
@@ -118,7 +118,7 @@ class OwnerPersistenceTest {
         //Arrange
         int OwnerId = 1;
         Owner newOwner = new Owner (OwnerId, "Brian", "Smith", "940 Rue des Oiseaux", "Montreal", "1111111111",1);
-        Owner savedOwner = repository.save(newOwner);;
+        Owner savedOwner = repository.save(newOwner);
 
         //Act
         Owner foundSaved = repository.findById(savedOwner.getId()).orElse(null);
@@ -134,7 +134,7 @@ class OwnerPersistenceTest {
     public void update_owner_test()
     {
         // Arrange
-        int ownerId = 11;
+        int ownerId = 14;
         Owner newOwner = new Owner (ownerId,
                 "Brian",
                 "Smith",
@@ -142,9 +142,10 @@ class OwnerPersistenceTest {
                 "Montreal",
                 "1111111111",
                 1);
-        Owner savedOwner = repository.save(newOwner);;
+        Owner savedOwner = repository.save(newOwner);
         Owner foundSaved = repository.findById(savedOwner.getId()).orElse(null);
         assert foundSaved != null;
+        newOwner.setId(foundSaved.getId());
         assertThat(foundSaved, samePropertyValuesAs(newOwner));
 
         // Act


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-686?atlOrigin=eyJpIjoiZWQ4Y2Q1OWViMzRiNGFlMjhmNmJkYmQxMzExNWI5YTMiLCJwIjoiaiJ9

## Context:
update test had a chance to fail depending in what order tests ran since it would save with the wrong id

## Changes
I resigned the generated id on save to the local object to which we are comparing the saved one

