### PR TITLE
Moved delete owner button to owners list

### DIFF
--- a/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.js
+++ b/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.js
@@ -9,7 +9,6 @@ angular.module('ownerDetails', ['ui.router'])
                 params: {ownerId: null},
                 template: '<owner-details></owner-details>'
             })
-
     }]);
 
 

--- a/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.template.html
@@ -32,10 +32,6 @@
         <td>
             <a class="newBtn btn-default btn" style="background-color: royalblue; color: white" ui-sref="ownerEdit({ownerId: $ctrl.owner.id, method: 'edit'})">Edit Owner</a>
         </td>
-        <td>
-
-            <a class="newBtn btn-default btn btn-danger" style="background-color: #dc3545;" ui-sref="ownerEdit({ownerId: $ctrl.owner.id, method: 'delete'})">Delete Owner</a>
-        </td>
     </tr>
 </table>
 
@@ -68,7 +64,8 @@
                 <dd>{{pet.birthDate | date:'yyyy MMM dd'}}</dd>
                 <dt>Type</dt>
                 <dd>{{pet.type.name}}</dd>
-                <a class="newBtn btn-default btn btn-danger" style="background-color: #dc3545;" ui-sref="deletePet({ownerId: $ctrl.owner.id, petId: pet.id, method: 'delete'})">Delete Pet</a>
+               <a class="newBtn btn-default btn btn-danger" style="background-color: #dc3545;" ui-sref="deletePet({ownerId: $ctrl.owner.id, petId: pet.id, method: 'delete'})">Delete Pet</a>
+
             </dl>
         </td>
         <td valign="top">

--- a/api-gateway/src/main/resources/static/scripts/owner-form/owner-form.js
+++ b/api-gateway/src/main/resources/static/scripts/owner-form/owner-form.js
@@ -13,4 +13,9 @@ angular.module('ownerForm', ['ui.router'])
                 url: '/owners/:ownerId/:method',
                 template: '<owner-form></owner-form>'
             })
+            // .state('ownerEdit', {
+            //     parent: 'app',
+            //     url: '/owners/:ownerId/deleteOwner',
+            //     template: '<owner-form></owner-form>'
+            // })
     }]);

--- a/api-gateway/src/main/resources/static/scripts/owner-list/owner-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/owner-list/owner-list.template.html
@@ -14,6 +14,7 @@
         <th>City</th>
         <th>Telephone</th>
         <th class="hidden-xs">Pets</th>
+        <th>Delete</th>
     </tr>
     </thead>
 
@@ -27,5 +28,6 @@
         <td>{{owner.city}}</td>
         <td>{{owner.telephone}}</td>
         <td class="hidden-xs"><span ng-repeat="pet in owner.pets track by pet.id">{{pet.name + ' '}}</span></td>
+        <td class="newBtn btn-default btn btn-danger" style="background-color: #cd2f4b;" ui-sref="ownerEdit({ownerId: $ctrl.owner.id, method: 'delete'})">Delete Owner</td>
     </tr>
 </table>


### PR DESCRIPTION
Moved delete owner button from owner details to owners list, giving each owner its own button to prompt a removal for said owner

JIRA: [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-682?atlOrigin=eyJpIjoiYWY1MThlMTJmN2ZjNGYwYmE3NjRlNDU3MzMwODI4N2QiLCJwIjoiaiJ9)  

## Context:
Changing the location of the owner delete button since it makes more sense to put it in the owner list rather than owner details,  made a mistake of naming the branch, forgot to change it back. 
## Changes
- Removed delete owner from owner details
- Added delete owner to owners list for each owner in the list\

## Before and After UI (Required for UI-impacting PRs)
Removal of "Delete Owner" from owner details
![ownerDetailsChanges](https://user-images.githubusercontent.com/83139031/197314821-a785e93d-ab4c-4fb9-8b3f-ba51801edd33.PNG)

Addition of "Delete Owner" to owner list
![ownerListChanges](https://user-images.githubusercontent.com/83139031/197314846-e02d37fd-40b7-4c17-8553-d1b845947d19.PNG)

Images aren't in the standard UI due to there being an issue on main and it could not be pulled without reverting a bunch of changes or switching branches, however the changes do not effect anything since they have only been moved from one page to another. 

## Dev notes (Optional)
- Extra window still opens when "Delete Owner" is clicked because of how the function is developed and used. 


