### PR TITLE
Fixed issue with data not displaying because of incorrect syntax

### DIFF
--- a/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/owner-details/owner-details.template.html
@@ -34,7 +34,6 @@
         </td>
         <td>
 
-            <a class="newBtn btn-default btn btn-danger" style="background-color: #dc3545;" ui-sref="ownerEdit({ownerId: $ctrl.owner.id, method: 'delete'})">Delete Owner</a>
         </td>
     </tr>
 </table>

--- a/api-gateway/src/main/resources/static/scripts/owner-list/owner-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/owner-list/owner-list.template.html
@@ -14,6 +14,7 @@
         <th>City</th>
         <th>Telephone</th>
         <th class="hidden-xs">Pets</th>
+        <th>Delete</th>
     </tr>
     </thead>
 
@@ -27,5 +28,7 @@
         <td>{{owner.city}}</td>
         <td>{{owner.telephone}}</td>
         <td class="hidden-xs"><span ng-repeat="pet in owner.pets track by pet.id">{{pet.name + ' '}}</span></td>
+        <td><a class="newBtn btn-default btn btn-danger" style="background-color: #dc3545;" ui-sref="ownerEdit({ownerId: $ctrl.owner.id, method: 'delete'})">Delete Owner</a></td>
+
     </tr>
 </table>


### PR DESCRIPTION
Fixed a small issue where the owner list wouldn't display because of how the anchor tag wasn't wrapped in a td tag, functionality still needs implementation since originally it required for a specific owner to be selected to pass an id to delete said owner.

JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-682?atlOrigin=eyJpIjoiNWZkZjY4ODkxYjc2NDgxMTk2ZWU4ZmQ5MjA2OTkwNzAiLCJwIjoiaiJ9

## Context:
The delete owner button wasn't in a practical place, so it was moved.

## Changes
Moved "Delete Owner" button to owner list for consistency and simplify use of it.

## Before and After UI (Required for UI-impacting PRs)
Owners list with the delete button added
![image](https://user-images.githubusercontent.com/83139031/197359088-45626e7f-cfa1-4f1c-ab52-b6759e79b779.png)

OwnerDetails page still has the delete button since it is dangerous to remove functionality in one area while not adding it back entirely in another area.
![image](https://user-images.githubusercontent.com/83139031/197365705-cf9acf3c-3011-4e75-9734-c9084acc16b2.png)

## Dev notes (Optional)
Functionality still isn't put in, getting worked on now and done hopefully soon.

