### PR TITLE
conf(VIST-CPC-769): edit files to disable non reactive version of visits service

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -2,7 +2,7 @@ server.port: 7000
 server.error.include-message: always
 
 app:
-  visits-service:
+  visits-service-new:
     host: localhost
     port: 7001
   vet-service:
@@ -31,8 +31,8 @@ spring.profiles: docker
 server.port: 8080
 
 app:
-  visits-service:
-    host: visits
+  visits-service-new:
+    host: visits-service-new
     port: 8080
   vet-service:
     host: vet-service

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
@@ -6,10 +6,7 @@ import com.petclinic.bffapigateway.dtos.VisitDetails;
 import com.petclinic.bffapigateway.dtos.Visits;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.junit.jupiter.api.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -18,9 +15,7 @@ import java.util.Collections;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class VisitsServiceClientIntegrationTest {
 
@@ -28,25 +23,23 @@ class VisitsServiceClientIntegrationTest {
 
     private VisitsServiceClient visitsServiceClient;
 
-    private MockWebServer server;
+    private static MockWebServer server;
 
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws IOException {
         server = new MockWebServer();
+        server.start();
         visitsServiceClient = new VisitsServiceClient(
-                WebClient.builder(),
-                "http://visits-service",
-                "7000"
+                "localhost",
+                String.valueOf(server.getPort())
         );
-        visitsServiceClient.setHostname(server.url("/").toString());
-        objectMapper = new ObjectMapper();
     }
 
-    @AfterEach
-    void shutdown() throws IOException {
-        this.server.shutdown();
+    @AfterAll
+    static void tearDown() throws IOException {
+        server.shutdown();
     }
 
     @Test
@@ -92,7 +85,7 @@ class VisitsServiceClientIntegrationTest {
 
         final Mono<Void> empty = visitsServiceClient.deleteVisitByVisitId(visit.getVisitId());
 
-        assertEquals(empty.block(), null);
+        assertNull(empty.block());
     }
 
     @Test
@@ -245,7 +238,7 @@ class VisitsServiceClientIntegrationTest {
         assertEquals(visit.getDescription(), previousVisits.getDescription());
         assertEquals(visit.getStatus(), previousVisits.getStatus());
     }
- 
+
     @Test
     void shouldGetScheduledVisitsForPet() throws JsonProcessingException {
         final VisitDetails visit = VisitDetails.builder()
@@ -270,7 +263,6 @@ class VisitsServiceClientIntegrationTest {
         assertEquals(visit.getDate(), scheduledVisits.getDate());
         assertEquals(visit.getDescription(), scheduledVisits.getDescription());
         assertEquals(visit.getStatus(), scheduledVisits.getStatus());
-      
     }
 
     private void assertVisitDescriptionEq(VisitDetails visits, int petId, String description) {
@@ -288,7 +280,7 @@ class VisitsServiceClientIntegrationTest {
     private void prepareResponse(Consumer<MockResponse> consumer) {
         MockResponse response = new MockResponse();
         consumer.accept(response);
-        this.server.enqueue(response);
+        server.enqueue(response);
     }
     
     @Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,15 +14,15 @@ services:
         depends_on:
             - mongo2
 
-    visits:
-        build: visits-service
-        hostname: visits
-        #mem_limit: 350m
-        environment:
-            - SPRING_PROFILES_ACTIVE=docker
-        depends_on:
-            mysql1:
-                condition: service_healthy
+#    visits:
+#        build: visits-service
+#        hostname: visits
+#        #mem_limit: 350m
+#        environment:
+#            - SPRING_PROFILES_ACTIVE=docker
+#        depends_on:
+#            mysql1:
+#                condition: service_healthy
 
     inventory-service:
       build: inventory-service
@@ -68,7 +68,8 @@ services:
         depends_on:
             - customers
             - vet-service
-            - visits
+            - visits-service-new
+#            - visits
 #            - inventory-service
 
     auth-service:
@@ -105,33 +106,33 @@ services:
         env_file:
             - mailer.env
 
-    mysql1:
-        image: mysql:5.7
-        #mem_limit: 350m
-        ports:
-            - "3307:3306"
-        environment:
-            - MYSQL_ROOT_PASSWORD=rootpwd
-            - MYSQL_DATABASE=visits-db
-            - MYSQL_USER=user
-            - MYSQL_PASSWORD=pwd
-        volumes:
-            - ./data/mysql1:/var/lib/mysql1
-            - ./data/init.d:/docker-entrypoint-initdb.d
-        healthcheck:
-            test:
-                [
-                    "CMD",
-                    "mysqladmin",
-                    "ping",
-                    "-uuser",
-                    "-ppwd",
-                    "-h",
-                    "localhost"
-                ]
-            interval: 10s
-            timeout: 5s
-            retries: 10
+#    mysql1:
+#        image: mysql:5.7
+#        #mem_limit: 350m
+#        ports:
+#            - "3307:3306"
+#        environment:
+#            - MYSQL_ROOT_PASSWORD=rootpwd
+#            - MYSQL_DATABASE=visits-db
+#            - MYSQL_USER=user
+#            - MYSQL_PASSWORD=pwd
+#        volumes:
+#            - ./data/mysql1:/var/lib/mysql1
+#            - ./data/init.d:/docker-entrypoint-initdb.d
+#        healthcheck:
+#            test:
+#                [
+#                    "CMD",
+#                    "mysqladmin",
+#                    "ping",
+#                    "-uuser",
+#                    "-ppwd",
+#                    "-h",
+#                    "localhost"
+#                ]
+#            interval: 10s
+#            timeout: 5s
+#            retries: 10
 
     mysql3:
         image: mysql:5.7

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,13 +1,10 @@
 include 'customers-service'
 include 'customers-service-reactive'
 include 'vets-service'
-include 'visits-service'
 include 'api-gateway'
 include 'billing-service'
 include 'auth-service'
 include 'visits-service-new'
 include 'vet-service'
 include 'inventory-service'
-
-
-
+//include 'visits-service'

--- a/visits-service-new/build.gradle
+++ b/visits-service-new/build.gradle
@@ -19,35 +19,37 @@ configurations {
 repositories {
     mavenCentral()
 }
+ext {
+    mapstructVersion = "1.4.1.Final"
+}
 dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    implementation("org.mapstruct:mapstruct:${mapstructVersion}")
+    compileOnly "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+    annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+    testAnnotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
     testImplementation 'io.projectreactor:reactor-test'
 
 }
 
-
-
-tasks.named('test') {
-    useJUnitPlatform()
-}
 jacoco {
     toolVersion = "0.8.8"
-    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
 }
 
 jacocoTestReport {
     dependsOn test
-
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: [
-                    "com/petclinic/**/AuthServiceApplication.class",
+                    "com/petclinic/visits/visitsservicenew/VisitsServiceNewApplication.class",
             ])
         }))
     }
@@ -68,6 +70,7 @@ check.dependsOn jacocoTestCoverageVerification
 
 
 test {
+    jvmArgs '--enable-preview'
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
@@ -52,7 +52,6 @@ public class VisitServiceImpl implements VisitService {
                 )
                 .flatMap(repo::save)
                 .map(EntityDtoUtil::toDTO);
-
     }
 
     @Override

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -41,7 +41,7 @@ public class VisitController {
 
     @DeleteMapping("/{visitId}")
     public Mono<Void> deleteVisit(@PathVariable("visitId") String visitId) {
-         return visitService.deleteVisit(visitId);
+        return visitService.deleteVisit(visitId);
     }
 
     @GetMapping("practitioner/{practitionerId}/{month}")

--- a/visits-service-new/src/main/resources/application.yml
+++ b/visits-service-new/src/main/resources/application.yml
@@ -1,6 +1,5 @@
-server:
-  error:
-    include-message: always
+server.port: 7001
+server.error.include-message: always
 
 logging:
   level:


### PR DESCRIPTION
JIRA: link to jira ticket
## Context: [VIST-CPC-769-edit-files-to-disable-non-reactive-version-of-visits-service](https://champlainsaintlambert.atlassian.net/browse/CPC-769)
What is the ticket about and why are we doing this change.
## Changes 
Removed unused imports.
Files updated to support the reactive visists-service. This affects only the VisitsServiceClient by starting the process of using the reactive visits-service.
Disabled 2 containers, the old non-reactive visits-service and its connected database mysql1, making the project quicker to build.
## Before and After UI (Required for UI-impacting PRs)
No UI change.
## Dev notes (Optional)
The VisitsServiceClient is now using the reactive visits-service but still needs to be worked on to make it fully reactive. The non-reactive visits-service is disabled.
- Specific technical changes that should be noted
Disabled the non-reactive visists-service, replacing it in the api-gateway with the reactive version of it.
## Linked pull requests (Optional)
- pull request link
