### PR TITLE
 conf/AUTH-CPC-802-auth-fix-spring-version-and-java-version 

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:6.9.0 as builder
+FROM gradle:7.4 as builder
 WORKDIR /usr/src/app
 COPY src ./src
 COPY build.gradle .

--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.3.10.RELEASE'
+	id 'org.springframework.boot' version '3.0.4'
 	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
 	id "io.freefair.lombok" version "6.0.0-m2"
@@ -9,7 +9,11 @@ plugins {
 
 group = 'com.petclinic.bffapigateway'
 version = '1.0.0-SNAPSHOT'
-sourceCompatibility = '1.8'
+
+
+java {
+	sourceCompatibility = '17'
+}
 
 repositories {
 	mavenCentral()

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/UserPasswordLessDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/UserPasswordLessDTO.java
@@ -14,8 +14,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotEmpty;
+
 import java.util.Set;
 
 

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -27,7 +27,12 @@ logging:
     com.petclinic: DEBUG
 
 ---
-spring.profiles: docker
+spring:
+  config:
+    activate:
+      on-profile: docker
+
+
 server.port: 8080
 
 app:


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-802?atlOrigin=eyJpIjoiYzFhZDg4ZGQxZmRlNDgxZWJlMDc2MzBjZGExNzc4OTIiLCJwIjoiaiJ9 
## Context:
I needed the new Java version and new Spring boot version to implement Spring security in the Api-Gateway.
## Changes
I simply changed the build.gradle versions for the previously mentioned components. And the dockerfile to a new version of gradle.