### PR TITLE
bug(VIST-CPC-759): fixed visits repository to use String data type as document identifier

### DIFF
--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/VisitRepo.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/VisitRepo.java
@@ -7,7 +7,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Repository
-public interface VisitRepo extends ReactiveMongoRepository<Visit, Integer> {
+public interface VisitRepo extends ReactiveMongoRepository<Visit, String> {
 
     Flux<Visit> findByPetId(int petId);
 


### PR DESCRIPTION
JIRA: [CPC-759](https://champlainsaintlambert.atlassian.net/browse/CPC-759)
## Context:
A String document type should be used instead of Integer.
## Changes
Changed the visits repo type to String.
No UI change.
## Dev notes
This was separate in its own pull request since multiple people rely on this change for the database to work properly.