### PR TITLE
Feat(VETS-CPC-728): get number of vet ratings for each vet

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -44,6 +44,19 @@ public class VetsServiceClient {
 
         return  ratingResponseDTOFlux;
     }
+
+    public Mono<Integer> getNumberOfRatingsByVetId(String vetId) {
+        Mono<Integer> numberOfRatings =
+                webClientBuilder
+                        .build()
+                        .get()
+                        .uri(vetsServiceUrl + "/{vetId}/ratings/count", vetId)
+                        .retrieve()
+                        .bodyToMono(Integer.class);
+
+        return numberOfRatings;
+    }
+
     public Flux<VetDTO> getVets() {
         Flux<VetDTO> vetDTOFlux =
                webClientBuilder

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -208,6 +208,14 @@ public class BFFApiGatewayController {
     public Flux<RatingResponseDTO> getRatingsByVetId(@PathVariable String vetId) {
         return vetsServiceClient.getRatingsByVetId(vetId);
     }
+
+    @GetMapping("/vets/{vetId}/ratings/count")
+    public Mono<ResponseEntity<Integer>> getNumberOfRatingsByVetId(@PathVariable String vetId) {
+        return vetsServiceClient.getNumberOfRatingsByVetId(VetsEntityDtoUtil.verifyId(vetId))
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+
     @GetMapping("/vets/{vetId}")
     public Mono<ResponseEntity<VetDTO>> getVetByVetId(@PathVariable String vetId) {
         return vetsServiceClient.getVetByVetId(VetsEntityDtoUtil.verifyId(vetId))

--- a/api-gateway/src/main/resources/static/scripts/vet-list/vet-list.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-list/vet-list.controller.js
@@ -30,10 +30,40 @@ angular.module('vetList')
             child.classList.add("modalOff");
         }
 
+        /*$http.get('api/gateway/vets').then(function (resp) {
+            self.vetList = resp.data;
+            arr = resp.data;
+        });*/
+        $scope.vetList = [];
+
         $http.get('api/gateway/vets').then(function (resp) {
             self.vetList = resp.data;
             arr = resp.data;
+
+            $scope.vetList = resp.data;
+
+            // Call displayVetRating for each vet to set the rating display flag and update ratings
+            angular.forEach($scope.vetList, function(vet) {
+                displayVetRating(vet);
+                getCountOfRatings(vet)
+            });
         });
+        function displayVetRating(vet) {
+            console.log("Hello " + vet.vetId);
+            $http.get('api/gateway/vets/' + vet.vetId + "/ratings").then(function (resp) {
+                console.log(resp.data);
+                vet.showRating = true;
+                vet.rating = parseFloat(resp.data.toFixed(1));
+            });
+        }
+
+        function getCountOfRatings(vet) {
+            $http.get('api/gateway/vets/' + vet.vetId + "/ratings/count").then(function (resp) {
+                console.log(resp.data)
+                vet.count = resp.data;
+            });
+        }
+
         $scope.deleteVet = function (vetId) {
             let varIsConf = confirm('Want to delete vet with vetId:' + vetId + '. Are you sure?');
             if (varIsConf) {
@@ -58,7 +88,6 @@ angular.module('vetList')
                 }
             }
         };
-
         $scope.refreshList = self.vetList;
 
         $scope.ReloadData = function () {

--- a/api-gateway/src/main/resources/static/scripts/vet-list/vet-list.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-list/vet-list.controller.js
@@ -30,10 +30,6 @@ angular.module('vetList')
             child.classList.add("modalOff");
         }
 
-        /*$http.get('api/gateway/vets').then(function (resp) {
-            self.vetList = resp.data;
-            arr = resp.data;
-        });*/
         $scope.vetList = [];
 
         $http.get('api/gateway/vets').then(function (resp) {

--- a/api-gateway/src/main/resources/static/scripts/vet-list/vet-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/vet-list/vet-list.template.html
@@ -1,3 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Veterinarians Page</title>
+    <style>
+        .centered-count {
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
 <h2>Veterinarians</h2>
 <form onsubmit="void(0)" style="max-width: 20em; margin-top: 2em;">
     <div class="form-group">
@@ -11,15 +24,12 @@
 
 <div style="margin-bottom: 1%; margin-top: 1%">
     <label for="filterOption">Filter</label>
-
     <select id="filterOption" ng-change="ReloadData()" ng-model="refreshList">
         <option selected value="All">All</option>
         <option value="Active">Active</option>
         <option value="Inactive">Inactive</option>
     </select>
 </div>
-
-
 
 <table class="table table-striped">
     <thead>
@@ -28,6 +38,7 @@
         <th class="vet_phone">Phone</th>
         <th class="vet_email">Email</th>
         <th class="vet_speciality">Specialties</th>
+        <th class="getCountOfRatings">Number of Ratings</th>
         <th>Delete</th>
     </tr>
     </thead>
@@ -38,24 +49,26 @@
                 class="info v{{vet.vetId}}" ng-mouseenter="$ctrl.show($event,vet.vetId)"
                 ng-mouseleave="$ctrl.hide($event,vet.vetId)">{{vet.firstName}} {{vet.lastName}}</span></a></td>
         <td class="vet_phone"><span>{{vet.phoneNumber}}</span></td>
+
         <td class="vet_email"><span>{{vet.email}}</span></td>
         <td class="vet_speciality"><span ng-repeat="specialty in vet.specialties">{{specialty.name + ' '}}</span></td>
-
+        <td class="vet-rating v{{vet.vetId}} centered-count"><span>{{vet.count}}</span></td>
         <td><a class="btn btn-danger" href="javascript:void(0)" ng-click="deleteVet(vet.vetId)">Delete Vet</a></td>
-
     </tr>
+
     <div class="modal m{{vet.vetId}} modalOff" ng-repeat="vet in $ctrl.vetList">
-        <span class="modal_image"><img ng-if="vet.image != null" src="data:image/png;base64,{{vet.image}}"/><img
-                ng-if="vet.image == null" src="images/vet_default.jpg"/></span>
+            <span class="modal_image"><img ng-if="vet.image != null" src="data:image/png;base64,{{vet.image}}"/><img
+                    ng-if="vet.image == null" src="images/vet_default.jpg"/></span>
         <span class="modal_name"><b>Name:</b> {{vet.firstName}} {{vet.lastName}}</span>
         <span class="modal_phone"><b>Phone:</b> {{vet.phoneNumber}}</span>
         <div class="modal_specialty">
             <span class="modal_specialty_title"><b>Specialization(s):</b></span>
             <span class="modal_specialty_items" ng-repeat="specialty in vet.specialties">
-                {{(specialty.name != null) ? '  -' + specialty.name + ' ' : 'no specialties'}}
-            </span>
+                    {{(specialty.name != null) ? '  -' + specialty.name + ' ' : 'no specialties'}}
+                </span>
         </div>
         <span class="modal_email"><b>Email:</b> <br/> {{vet.email}}</span>
-
     </div>
 </table>
+</body>
+</html>

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
@@ -72,6 +72,16 @@ class VetsServiceClientIntegrationTest {
         assertEquals(4.5, rating.getRateScore());
     }
 
+    @Test
+    void getNumberOfRatingsByVetId() throws JsonProcessingException {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setBody("5"));
+
+        final Integer numberOfRatings = vetsServiceClient.getNumberOfRatingsByVetId("678910").block();
+        assertEquals(5, numberOfRatings);
+    }
+
 //    @Test
 //    void getRatingsByVetId_ExistingVetNotFound_ShouldThrowException() {
 //        prepareResponse(response -> response

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -111,6 +111,22 @@ class ApiGatewayControllerTest {
                 .expectBody()
                 .jsonPath("$.message").isEqualTo("This id is not valid");
     }
+
+    @Test
+    void getNumberOfRatingsPerVet_ByVetId() {
+        when(vetsServiceClient.getNumberOfRatingsByVetId(anyString()))
+                .thenReturn(Mono.just(1));
+
+        client
+                .get()
+                .uri("/api/gateway/vets/" + VET_ID + "/ratings/count")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$").isEqualTo(1);
+    }
+
     @Test
     void getAllVets() {
         when(vetsServiceClient.getVets())

--- a/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/RatingRepository.java
+++ b/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/RatingRepository.java
@@ -8,4 +8,6 @@ import reactor.core.publisher.Mono;
 @Repository
 public interface RatingRepository extends ReactiveMongoRepository<Rating, String> {
     Flux<Rating> findAllByVetId(String vetId);
+
+    Mono<Long> countAllByVetId(String vetId);
 }

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -36,6 +36,13 @@ public class VetController {
         return ratingService.getAllRatingsByVetId(vetId);
     }
 
+    @GetMapping("{vetId}/ratings/count")
+    public Mono<ResponseEntity<Integer>> getNumberOfRatingsByVetId(@PathVariable String vetId){
+        return ratingService.getNumberOfRatingsByVetId(vetId)
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+
     @GetMapping()
     public Flux<VetDTO> getAllVets() {
         return vetService.getAll();

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingService.java
@@ -1,7 +1,10 @@
 package com.petclinic.vet.servicelayer;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface RatingService {
     Flux<RatingResponseDTO> getAllRatingsByVetId(String vetId);
+
+    Mono<Integer> getNumberOfRatingsByVetId(String vetId);
 }

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingServiceImpl.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingServiceImpl.java
@@ -19,4 +19,10 @@ public class RatingServiceImpl implements RatingService {
                 .map(EntityDtoUtil::toDTO);
     }
 
+    @Override
+    public Mono<Integer> getNumberOfRatingsByVetId(String vetId) {
+        return  ratingRepository.countAllByVetId(vetId)
+                .map(Long::intValue);
+    }
+
 }

--- a/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/RatingRepositoryTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/RatingRepositoryTest.java
@@ -57,5 +57,17 @@ class RatingRepositoryTest {
                 .verifyComplete();
     }
 
+    @Test
+    public void getNumberOfRatingOfAVet_ShouldSucceed(){
+        Publisher<Long> find = ratingRepository.countAllByVetId("1");
+
+        StepVerifier
+                .create(find)
+                .consumeNextWith(foundRating -> {
+                    assertEquals(1, foundRating);
+                })
+                .verifyComplete();
+    }
+
 
 }

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -78,6 +78,30 @@ class VetControllerIntegrationTest {
                 });
     }
 
+    @Test
+    void getNumberOfRatingsForAVet_WithValidVetId_ShouldSucceed() {
+        Publisher<Rating> setup = ratingRepository.deleteAll()
+                .thenMany(ratingRepository.save(rating1))
+                .thenMany(ratingRepository.save(rating2));
+
+        StepVerifier
+                .create(setup)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        client
+                .get()
+                .uri("/vets/" + VET_ID + "/ratings/count")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(Integer.class)
+                .value((count) -> {
+                    assertEquals(2, count);
+                });
+    }
+
 //    @Test
 //    void getAllRatingsForAVet_WithInvalidVetId_ShouldReturnNotFound() {
 //        Publisher<Rating> setup = ratingRepository.deleteAll()

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -84,6 +84,23 @@ class VetControllerIntegrationTest {
         Publisher<Rating> setup = ratingRepository.deleteAll()
                 .thenMany(ratingRepository.save(rating1))
                 .thenMany(ratingRepository.save(rating2));
+
+        StepVerifier
+                .create(setup)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        client
+                .get()
+                .uri("/vets/" + VET_ID + "/ratings/count")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(Integer.class)
+                .value((count) -> {
+                    assertEquals(2, count);
+                });
     }
   
     @Test

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -69,6 +69,24 @@ class VetControllerUnitTest {
     }
 
     @Test
+    void getNumberOfRatingsByVetId_ShouldSucceed() {
+        when(ratingService.getNumberOfRatingsByVetId(anyString()))
+                .thenReturn(Mono.just(1));
+
+        client
+                .get()
+                .uri("/vets/" + VET_ID + "/ratings/count")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$").isEqualTo(1);
+
+        Mockito.verify(ratingService, times(1))
+                .getNumberOfRatingsByVetId(VET_ID);
+    }
+
+    @Test
     void getAllVets() {
         when(vetService.getAll())
                 .thenReturn(Flux.just(vetDTO));


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-728?atlOrigin=eyJpIjoiNmQ3OTU5Y2VkNmU3NDk3NGE2MDBlZWQzZjExYmQyYzQiLCJwIjoiaiJ9
## Context:
We want to display the total number of ratings each vet has. Doing this allows the user to quickly see how many ratings a certain vet has. 
## Changes
- Implementation of a get number of ratings per vet in Api-Gateway
- Implementation of get number of ratings per vet in the Vet-Service
- 90% + testing in Api-gateway
- 90% + testing in Vet-Service
- Front-end Implementation: now displays the number of ratings per vet next to the vet's information
## Before and After UI (Required for UI-impacting PRs)
![image](https://github.com/cgerard321/champlain_petclinic/assets/104159293/4b59d5b3-05b3-44b5-85d2-a37b4f4403dd)
![image](https://github.com/cgerard321/champlain_petclinic/assets/104159293/cd601aa7-397c-4b96-97d4-544c1df5c724)

