### PR TITLE
bug(BILL-CPC-743): made date visible and change Date type to LocalDate

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillDetails.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillDetails.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -14,7 +15,7 @@ import static java.util.stream.Collectors.toList;
 @Data
 public class BillDetails {
     private String billId;
-    private Date date;
+    private LocalDate date;
     private int customerId;
     private String vetId;
     private String visitType;

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillRequestDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillRequestDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.Date;
 
 @Data
@@ -16,6 +17,6 @@ public class BillRequestDTO {
     private int customerId;
     private String visitType;
     private String vetId;
-    private Date date;
+    private LocalDate date;
     private double amount;
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillResponseDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.Date;
 
 @Data
@@ -17,6 +18,6 @@ public class BillResponseDTO {
     private int customerId;
     private String visitType;
     private String vetId;
-    private Date date;
+    private LocalDate date;
     private double amount;
 }

--- a/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.template.html
+++ b/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.template.html
@@ -17,7 +17,7 @@
             <td>Vet. Id</td>
             <td>Visit Type</td>
             <td>Amount</td>
-            <td>Date/Time</td>
+            <td>Date</td>
             <td>Details</td>
             <td>Delete</td>
         </tr>

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 
+import java.time.LocalDate;
 import java.util.Date;
 
 @Data
@@ -19,7 +20,6 @@ public class Bill {
     private int customerId;
     private String visitType;
     private String vetId;
-    @JsonFormat(pattern = "yyyy-MM-dd")
-    private Date visitDate = new Date();
+    private LocalDate date;
     private double amount;
 }

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillDTO.java
@@ -3,6 +3,7 @@ package com.petclinic.billing.datalayer;
 import lombok.*;
 import org.springframework.lang.Nullable;
 
+import java.time.LocalDate;
 import java.util.Date;
 
 @Data
@@ -16,10 +17,10 @@ public class BillDTO {
     private int customerId;
     private String visitType;
     private String vetId;
-    private Date date;
+    private LocalDate date;
     private double amount;
 
-    public BillDTO(int customerId, String visitType, String vetId, Date date, double amount) {
+    public BillDTO(int customerId, String visitType, String vetId, LocalDate date, double amount) {
         this.customerId = customerId;
         this.visitType = visitType;
         this.vetId = vetId;

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillRequestDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillRequestDTO.java
@@ -2,6 +2,7 @@ package com.petclinic.billing.datalayer;
 
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.Date;
 
 @Data
@@ -13,10 +14,10 @@ public class BillRequestDTO {
     private int customerId;
     private String visitType;
     private String vetId;
-    private Date date;
+    private LocalDate date;
     private double amount;
 
-    public BillRequestDTO(int customerId, String visitType, String vetId, Date date, double amount) {
+    public BillRequestDTO(int customerId, String visitType, String vetId, LocalDate date, double amount) {
         this.customerId = customerId;
         this.visitType = visitType;
         this.vetId = vetId;

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillResponseDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillResponseDTO.java
@@ -2,6 +2,7 @@ package com.petclinic.billing.datalayer;
 
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.Date;
 
 @Data
@@ -15,10 +16,10 @@ public class BillResponseDTO {
     private int customerId;
     private String visitType;
     private String vetId;
-    private Date date;
+    private LocalDate date;
     private double amount;
 
-    public BillResponseDTO(int customerId, String visitType, String vetId, Date date, double amount) {
+    public BillResponseDTO(int customerId, String visitType, String vetId, LocalDate date, double amount) {
         this.customerId = customerId;
         this.visitType = visitType;
         this.vetId = vetId;

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/DataSetupService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/DataSetupService.java
@@ -8,6 +8,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.sql.Date;
+import java.time.LocalDate;
 
 
 @Service
@@ -20,11 +21,11 @@ public class DataSetupService implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-       BillRequestDTO b1 = new BillRequestDTO( 1, "general", "1", Date.valueOf("2021-09-19"),59.99);
-        BillRequestDTO b3 = new BillRequestDTO( 3, "operation", "1", Date.valueOf("2021-09-21"), 199.99);
-        BillRequestDTO b4 = new BillRequestDTO( 4, "injury", "1", Date.valueOf("2021-09-22"), 199.99);
-        BillRequestDTO b2 = new BillRequestDTO( 2, "operation", "2", Date.valueOf("2021-09-20"), 199.99);
-        BillRequestDTO b5 = new BillRequestDTO( 5, "chronic", "3", Date.valueOf("2021-09-23"), 199.99);
+       BillRequestDTO b1 = new BillRequestDTO( 1, "general", "1", LocalDate.of(2021,9,19),59.99);
+        BillRequestDTO b3 = new BillRequestDTO( 3, "operation", "1", LocalDate.of(2021,9,21), 199.99);
+        BillRequestDTO b4 = new BillRequestDTO( 4, "injury", "1",  LocalDate.of(2021,9,22), 199.99);
+        BillRequestDTO b2 = new BillRequestDTO( 2, "operation", "2", LocalDate.of(2021,9,20), 199.99);
+        BillRequestDTO b5 = new BillRequestDTO( 5, "chronic", "3",  LocalDate.of(2021,9,23), 199.99);
 
         Flux.just(b1,b2,b3,b4,b5)
                 .flatMap(b -> billService.CreateBill(Mono.just(b))

--- a/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
@@ -17,6 +17,8 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import org.springframework.beans.BeanUtils;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.*;
 
 
@@ -201,17 +203,21 @@ public class BillServiceImplTest {
 
         Calendar calendar = Calendar.getInstance();
         calendar.set(2022, Calendar.SEPTEMBER, 25);
-        Date date = calendar.getTime();
+        LocalDate date = calendar.getTime().toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();;
 
 
-        return Bill.builder().id("Id").billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").visitDate(date).amount(13.37).build();
+        return Bill.builder().id("Id").billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
     }
 
     private BillDTO buildBillDTO(){
 
         Calendar calendar = Calendar.getInstance();
         calendar.set(2022, Calendar.SEPTEMBER, 25);
-        Date date = calendar.getTime();
+        LocalDate date = calendar.getTime().toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();;
 
 
         return BillDTO.builder().billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
@@ -221,7 +227,9 @@ public class BillServiceImplTest {
 
         Calendar calendar = Calendar.getInstance();
         calendar.set(2022, Calendar.SEPTEMBER, 25);
-        Date date = calendar.getTime();
+        LocalDate date = calendar.getTime().toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();;
 
 
         return BillRequestDTO.builder().customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();

--- a/billing-service/src/test/java/com/petclinic/billing/datalayer/BillServicePersistenceTests.java
+++ b/billing-service/src/test/java/com/petclinic/billing/datalayer/BillServicePersistenceTests.java
@@ -9,6 +9,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -159,9 +161,11 @@ public class BillServicePersistenceTests {
 
         Calendar calendar = Calendar.getInstance();
         calendar.set(2022, Calendar.SEPTEMBER, 25);
-        Date date = calendar.getTime();
+        LocalDate date = calendar.getTime().toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();;
 
 
-        return Bill.builder().id("Id").billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").visitDate(date).amount(13.37).build();
+        return Bill.builder().id("Id").billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
     }
 }

--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillResourceIntegrationTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillResourceIntegrationTest.java
@@ -13,6 +13,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.test.StepVerifier;
 import static reactor.core.publisher.Mono.just;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -277,9 +280,11 @@ class BillResourceIntegrationTest {
 
         Calendar calendar = Calendar.getInstance();
         calendar.set(2022, Calendar.SEPTEMBER, 25);
-        Date date = calendar.getTime();
+        LocalDate date = calendar.getTime().toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();;
 
 
-        return Bill.builder().id("Id").billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").visitDate(date).amount(13.37).build();
+        return Bill.builder().id("Id").billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
     }
 }

--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillResourceUnitTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillResourceUnitTest.java
@@ -19,6 +19,9 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -192,7 +195,9 @@ class BillResourceUnitTest {
 
         Calendar calendar = Calendar.getInstance();
         calendar.set(2022, Calendar.SEPTEMBER, 25);
-        Date date = calendar.getTime();
+        LocalDate date = calendar.getTime().toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();;
 
 
         return BillDTO.builder().billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
@@ -202,7 +207,9 @@ class BillResourceUnitTest {
 
         Calendar calendar = Calendar.getInstance();
         calendar.set(2022, Calendar.SEPTEMBER, 25);
-        Date date = calendar.getTime();
+        LocalDate date = calendar.getTime().toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();;
 
 
         return BillResponseDTO.builder().billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();


### PR DESCRIPTION
JIRA: [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-743)
## Context:
I needed to make the date visible when looking at the bills
## Changes

- I changed the name of the date variable from visitsDate to date, to make it match the name that was in BillDetails in the API-Gateway.

- I changed the date type to LocalDate()
- I changed the UI to only say Date 

## Before and After UI (Required for UI-impacting PRs)

- We can now see the date.

- The "Date\Time" subtitle is now changed to "Date".

Before:
![Screenshot (885)](https://github.com/cgerard321/champlain_petclinic/assets/104155362/3dae0573-89c4-4a56-8e01-307b1f3504ef)

After:
![Screenshot (886)](https://github.com/cgerard321/champlain_petclinic/assets/104155362/93b38e15-fe35-4ac9-9ac6-85fbffd8b06e)



