### PR TITLE
feat(VETS-CPC-744): Update rating for vet by vetId and ratingId implemented

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -72,6 +72,19 @@ public class VetsServiceClient {
 
         return ratingResponseDTOMono;
     }
+    public Mono<RatingResponseDTO> updateRatingByVetIdAndByRatingId(String vetId, String ratingId, Mono<RatingRequestDTO> ratingRequestDTOMono){
+        Mono<RatingResponseDTO> ratingResponseDTOMono =
+                webClientBuilder
+                        .build()
+                        .put()
+                        .uri(vetsServiceUrl+"/"+vetId+"/ratings/"+ratingId)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .body(ratingRequestDTOMono, RatingResponseDTO.class)
+                        .retrieve()
+                        .bodyToMono(RatingResponseDTO.class);
+
+        return ratingResponseDTOMono;
+    }
 
     public Mono<Void> deleteRating(String vetId, String ratingId) {
         Mono<Void> result = webClientBuilder
@@ -93,6 +106,7 @@ public class VetsServiceClient {
                         .bodyToMono(Double.class);
         return averageRating;
     }
+
 
 
 

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -242,7 +242,14 @@ public class BFFApiGatewayController {
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
-  
+
+    @PutMapping(value="vets/{vetId}/ratings/{ratingId}")
+    public Mono<ResponseEntity<RatingResponseDTO>> updateRatingByVetIdAndRatingId(@PathVariable String vetId, @PathVariable String ratingId, @RequestBody Mono<RatingRequestDTO> ratingRequestDTOMono){
+        return vetsServiceClient.updateRatingByVetIdAndByRatingId(vetId, ratingId, ratingRequestDTOMono)
+                .map(r->ResponseEntity.status(HttpStatus.OK).body(r))
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
+    }
+
     @GetMapping("/vets/{vetId}")
     public Mono<ResponseEntity<VetDTO>> getVetByVetId(@PathVariable String vetId) {
         return vetsServiceClient.getVetByVetId(VetsEntityDtoUtil.verifyId(vetId))

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
@@ -18,6 +18,7 @@ angular.module('vetDetails')
             console.log(resp.data)
             self.ratings = resp.data;
         });
+
         $scope.deleteVetRating = function (ratingId) { //added $scope in this class
             let varIsConf = confirm('Are you sure you want to delete this ratingId: ' + ratingId + '?');
             if (varIsConf) {
@@ -42,6 +43,39 @@ angular.module('vetDetails')
                 }
             }
         };
+
+        self.updateRating = function (ratingId, rating) {
+            const btn = document.getElementById("updateRatingBtn");
+
+            const updateContainer=document.getElementById("ratingUpdate")
+            const selectedValue=parseInt(document.getElementById("ratingOptions").value)
+            const updatedDescription= document.getElementById("updateDescription").value
+
+            if(updateContainer.style.display=="none"){
+                updateContainer.style.display="block"
+                btn.textContent="Save"
+            }
+            else if(btn.textContent=="Save"){
+                rating.rateScore=selectedValue
+                rating.vetId=$stateParams.vetId
+                rating.rateDescription=updatedDescription
+                rating.rateDate = Date.now().toString()
+                console.log(rating.rateScore);
+                updateContainer.style.display="none"
+                btn.textContent="Update"
+
+                $http.put("api/gateway/vets/" + $stateParams.vetId + "/ratings/"+ratingId, rating).then(function (resp){
+                    console.log(resp.data)
+                    self.rating = resp.data;
+                    alert('Your review was successfully updated!');
+                    $http.get('api/gateway/vets/' + $stateParams.vetId + '/ratings').then(function (resp) {
+                        console.log(resp.data)
+                        self.ratings = resp.data;
+                        arr = resp.data;
+                    });
+                });
+            }
+        }
 
         //photo
         $http.get('api/gateway/vets/photo/' + $stateParams.vetId).then(function (resp) {

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
@@ -127,6 +127,26 @@
                             <div class="rating-item">
                                 <span class="rating-value">{{ rating.rateScore }} / 5</span>
                                 <a class="btn btn-danger" href="javascript:void(0)" ng-click="deleteVetRating(rating.ratingId)">Delete Rating</a>
+
+                                <form enctype="multipart/form-data" id="updateForm" name="updateForm">
+                                    <button class="update-vet-button btn btn-success" id="updateRatingBtn" ng-click="$ctrl.updateRating(rating.ratingId, updateForm)">
+                                        Update
+                                    </button>
+
+                                    <div class="col-sm-12" name="ratingUpdate" id="ratingUpdate" style="display: none">
+                                        <select name="ratingOptions" id="ratingOptions">
+                                            <option value="1">1</option>
+                                            <option value="2">2</option>
+                                            <option value="3">3</option>
+                                            <option value="4">4</option>
+                                            <option value="5">5</option>
+                                        </select>
+                                        <h5 class="form-label">Review Description</h5>
+                                        <textarea class="form-control" id="updateDescription" maxlength="350" name="updateDescription"
+                                                  ng-model="rating.rateDescription" pattern="^(.*)" placeholder="Update Description"
+                                                  title="Maximum of 350 characters."></textarea>
+                                    </div>
+                                </form>
                             </div>
                         </div>
                     </div>
@@ -157,7 +177,7 @@
                                 </button>
                             </div>
                         </form>
-                    <div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -55,6 +55,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.*;
 
+
 import static com.petclinic.bffapigateway.dtos.Inventory.InventoryType.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -24,6 +24,7 @@ import com.petclinic.bffapigateway.exceptions.ExistingVetNotFoundException;
 import com.petclinic.bffapigateway.exceptions.GenericHttpException;
 import com.petclinic.bffapigateway.utils.Security.Filters.JwtTokenFilter;
 import com.petclinic.bffapigateway.utils.Security.Filters.RoleFilter;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
@@ -34,8 +35,10 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
@@ -53,6 +56,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 import static com.petclinic.bffapigateway.dtos.Inventory.InventoryType.internal;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.assertj.core.util.Lists.list;
 
@@ -214,6 +218,46 @@ class ApiGatewayControllerTest {
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody();
+    }
+
+    @Test
+    void updateRatingForVet(){
+        RatingRequestDTO updatedRating = RatingRequestDTO.builder()
+                .rateScore(2.0)
+                .vetId(VET_ID)
+                .rateDescription("Vet cancelled last minute.")
+                .rateDate("20/09/2023")
+                .build();
+
+        RatingResponseDTO ratingResponseDTO = RatingResponseDTO.builder()
+                .ratingId("12356789")
+                .vetId(VET_ID)
+                .rateScore(2.0)
+                .rateDescription("Vet cancelled last minute.")
+                .rateDate("20/09/2023")
+                .build();
+
+        when(vetsServiceClient.updateRatingByVetIdAndByRatingId(anyString(), anyString(), any(Mono.class)))
+                .thenReturn(Mono.just(ratingResponseDTO));
+
+        client.put()
+                .uri("/api/gateway/vets/"+VET_ID+"/ratings/"+ratingResponseDTO.getRatingId())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(updatedRating)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(RatingResponseDTO.class)
+                .value(responseDTO -> {
+                    Assertions.assertNotNull(responseDTO);
+                    Assertions.assertNotNull(responseDTO.getRatingId());
+                    assertThat(responseDTO.getRatingId()).isEqualTo(ratingResponseDTO.getRatingId());
+                    assertThat(responseDTO.getVetId()).isEqualTo(updatedRating.getVetId());
+                    assertThat(responseDTO.getRateScore()).isEqualTo(updatedRating.getRateScore());
+                    assertThat(responseDTO.getRateDescription()).isEqualTo(updatedRating.getRateDescription());
+                    assertThat(responseDTO.getRateDate()).isEqualTo(updatedRating.getRateDate());
+                });
     }
 
     @Test

--- a/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/RatingRepository.java
+++ b/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/RatingRepository.java
@@ -9,6 +9,6 @@ import reactor.core.publisher.Mono;
 public interface RatingRepository extends ReactiveMongoRepository<Rating, String> {
     Flux<Rating> findAllByVetId(String vetId);
     Mono<Long> countAllByVetId(String vetId);
-    Mono<Rating> findByRatingId(String ratingId);
     Mono<Rating> findByVetIdAndRatingId(String vetId, String ratingId);
+    Mono<Rating> findByRatingId(String ratingId);
 }

--- a/vet-service/src/main/java/com/petclinic/vet/exceptions/GlobalControllerExceptionHandler.java
+++ b/vet-service/src/main/java/com/petclinic/vet/exceptions/GlobalControllerExceptionHandler.java
@@ -31,6 +31,12 @@ public class GlobalControllerExceptionHandler {
         return createHttpErrorInfo(UNPROCESSABLE_ENTITY, request, ex);
     }
 
+    @ResponseStatus(NOT_FOUND)
+    @ExceptionHandler(NotFoundException.class)
+    public HttpErrorInfo handleNotFoundException(ServerHttpRequest request, Exception ex){
+        return createHttpErrorInfo(NOT_FOUND, request, ex);
+    }
+
 //    @ResponseStatus(NOT_FOUND)
 //    @ExceptionHandler(ExistingVetNotFoundException.class)
 //    public HttpErrorInfo handleExistingVetNotFoundException(ServerHttpRequest request, Exception ex){

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -14,6 +14,7 @@ package com.petclinic.vet.presentationlayer;
 import com.petclinic.vet.servicelayer.*;
 import com.petclinic.vet.util.EntityDtoUtil;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
@@ -57,6 +58,19 @@ public class VetController {
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
+
+    @PutMapping("{vetId}/ratings/{ratingId}")
+    public Mono<ResponseEntity<RatingResponseDTO>> updateRatingByVetIdAndRatingId(@PathVariable String vetId, @PathVariable String ratingId, @RequestBody Mono<RatingRequestDTO> ratingRequestDTOMono){
+        return ratingService.updateRatingByVetIdAndRatingId(vetId, ratingId, ratingRequestDTOMono)
+                .map(r->ResponseEntity.status(HttpStatus.OK).body(r))
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
+    }
+
+    /*@PutMapping("{vetId}/ratings/{ratingId}")
+    public Mono<RatingResponseDTO> updateRatingByVetIdAndRatingId(@PathVariable String vetId, @PathVariable String ratingId, @RequestBody Mono<RatingRequestDTO> ratingRequestDTOMono){
+        return ratingService.updateRating(vetId, ratingId, ratingRequestDTOMono);
+    }*/
+
     @GetMapping()
     public Flux<VetDTO> getAllVets() {
         return vetService.getAll();

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingService.java
@@ -7,8 +7,7 @@ public interface RatingService {
     Flux<RatingResponseDTO> getAllRatingsByVetId(String vetId);
     Mono<Integer> getNumberOfRatingsByVetId(String vetId);
     Mono<RatingResponseDTO> addRatingToVet(String vetId, Mono<RatingRequestDTO> ratingRequestDTO);
+    Mono<RatingResponseDTO> updateRatingByVetIdAndRatingId(String vetId, String ratingId, Mono<RatingRequestDTO> ratingRequestDTOMono);
     Mono<Void> deleteRatingByRatingId(String vetId, String ratingId);
     Mono<Double> getAverageRatingByVetId(String vetId);
-
-
 }

--- a/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/RatingRepositoryTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/RatingRepositoryTest.java
@@ -92,8 +92,17 @@ class RatingRepositoryTest {
 
     @Test
     public void updateRatingOfVet_ShouldSucceed(){
+        String existingRatingId="2";
+
+        Publisher<Rating> exisingRating = ratingRepository.findByRatingId(existingRatingId);
+
+        StepVerifier
+                .create(exisingRating)
+                .expectNextCount(1)
+                .verifyComplete();
+
         Rating rating = Rating.builder()
-                .ratingId("2")
+                .ratingId(existingRatingId)
                 .vetId("2")
                 .rateScore(2.0)
                 .rateDescription("Vet cancelled last minute.")

--- a/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/RatingRepositoryTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/RatingRepositoryTest.java
@@ -19,12 +19,16 @@ class RatingRepositoryTest {
             .ratingId("1")
             .vetId("1")
             .rateScore(5.0)
+            .rateDate("21/09/2023")
+            .rateDescription("Vet was very gentle with my hamster.")
             .build();
 
     Rating rating2 = Rating.builder()
             .ratingId("2")
             .vetId("2")
             .rateScore(4.0)
+            .rateDate("10/09/2023")
+            .rateDescription("Vet very kind, but a bit slow.")
             .build();
     @BeforeEach
     void setUp() {
@@ -91,10 +95,20 @@ class RatingRepositoryTest {
         Rating rating = Rating.builder()
                 .ratingId("2")
                 .vetId("2")
-                .rateScore(1.0)
-                .rateDescription("My dog wouldn't stop crying after his appointment")
-                .rateDate("13/09/2023")
+                .rateScore(2.0)
+                .rateDescription("Vet cancelled last minute.")
+                .rateDate("20/09/2023")
                 .build();
+
+        StepVerifier.create(ratingRepository.save(rating))
+                .consumeNextWith(updatedRating -> {
+                    assertEquals(rating.getRatingId(), updatedRating.getRatingId());
+                    assertEquals(rating.getVetId(), updatedRating.getVetId());
+                    assertEquals(rating.getRateScore(), updatedRating.getRateScore());
+                    assertEquals(rating.getRateDescription(), updatedRating.getRateDescription());
+                    assertEquals(rating.getRateDate(), updatedRating.getRateDate());
+                })
+                .verifyComplete();
     }
 
     @Test

--- a/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/RatingRepositoryTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/RatingRepositoryTest.java
@@ -87,6 +87,17 @@ class RatingRepositoryTest {
     }
 
     @Test
+    public void updateRatingOfVet_ShouldSucceed(){
+        Rating rating = Rating.builder()
+                .ratingId("2")
+                .vetId("2")
+                .rateScore(1.0)
+                .rateDescription("My dog wouldn't stop crying after his appointment")
+                .rateDate("13/09/2023")
+                .build();
+    }
+
+    @Test
     public void getNumberOfRatingOfAVet_ShouldSucceed(){
         Publisher<Long> find = ratingRepository.countAllByVetId("1");
 

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -4,9 +4,7 @@ import com.petclinic.vet.dataaccesslayer.Vet;
 import com.petclinic.vet.servicelayer.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -14,10 +12,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
 import java.util.HashSet;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
@@ -38,7 +36,7 @@ class VetControllerUnitTest {
     VetDTO vetDTO = buildVetDTO();
     VetDTO vetDTO2 = buildVetDTO2();
 
-    RatingResponseDTO ratingDTO = buildRatingDTO();
+    RatingResponseDTO ratingDTO = buildRatingResponseDTO("Vet was super calming with my pet",5.0);
     Vet vet = buildVet();
     String VET_ID = vet.getVetId();
     String VET_BILL_ID = vet.getVetBillId();
@@ -111,6 +109,49 @@ class VetControllerUnitTest {
     }
 
     @Test
+    void updateRatingWithValidVetIdAndValidRatingId_withValidValues_shouldSucceed(){
+        RatingRequestDTO updatedRating = RatingRequestDTO.builder()
+                .rateScore(2.0)
+                .vetId(VET_ID)
+                .rateDescription("Vet cancelled last minute.")
+                .rateDate("20/09/2023")
+                .build();
+
+        RatingResponseDTO ratingResponse = RatingResponseDTO.builder()
+                .ratingId("2")
+                .rateScore(2.0)
+                .vetId(VET_ID)
+                .rateDescription("Vet cancelled last minute.")
+                .rateDate("20/09/2023")
+                .build();
+
+        when(ratingService.updateRatingByVetIdAndRatingId(anyString(), anyString(), any(Mono.class)))
+                .thenReturn(Mono.just(ratingResponse));
+
+        client.put()
+                .uri("/vets/"+VET_ID+"/ratings/"+ratingResponse.getRatingId())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(updatedRating)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(RatingResponseDTO.class)
+                .value(ratingResponseDTO -> {
+                    assertNotNull(ratingResponseDTO);
+                    assertNotNull(ratingResponseDTO.getRatingId());
+                    assertThat(ratingResponseDTO.getRatingId()).isEqualTo(ratingResponse.getRatingId());
+                    assertThat(ratingResponseDTO.getVetId()).isEqualTo(updatedRating.getVetId());
+                    assertThat(ratingResponseDTO.getRateScore()).isEqualTo(updatedRating.getRateScore());
+                    assertThat(ratingResponseDTO.getRateDescription()).isEqualTo(updatedRating.getRateDescription());
+                    assertThat(ratingResponseDTO.getRateDate()).isEqualTo(updatedRating.getRateDate());
+                });
+
+        Mockito.verify(ratingService, times(1))
+                .updateRatingByVetIdAndRatingId(anyString(), anyString(), any(Mono.class));
+    }
+
+    @Test
     void getNumberOfRatingsByVetId_ShouldSucceed() {
         when(ratingService.getNumberOfRatingsByVetId(anyString()))
                 .thenReturn(Mono.just(1));
@@ -132,7 +173,7 @@ class VetControllerUnitTest {
     @Test
     void getAverageRatingForEachVetByVetId_ShouldSucceed(){
 
-        String vetId = "1";
+        String vetId = "678910";
         Double averageRating = 5.0;
 
         when(vetService.getVetByVetId(vetId))
@@ -452,17 +493,10 @@ class VetControllerUnitTest {
                 .build();
     }
 
-    private RatingResponseDTO buildRatingDTO() {
-        return RatingResponseDTO.builder()
-                .ratingId("1")
-                .vetId("1")
-                .rateScore(5.0)
-                .build();
-    }
     private RatingResponseDTO buildRatingResponseDTO(String description, double score) {
         return RatingResponseDTO.builder()
                 .ratingId("2")
-                .vetId(VET_ID)
+                .vetId("678910")
                 .rateScore(score)
                 .rateDescription(description)
                 .rateDate("16/09/2023")


### PR DESCRIPTION
Update rating for vet by vetId and ratingId implemented

JIRA: link to jira ticket
CPC-744
https://champlainsaintlambert.atlassian.net/browse/CPC-744

## Context:
This ticket implements the update rating of a vet by vetId and ratingId in the vet-service and api-gateway. The user is now able to edit their ratings if they want to go back on them. Although they aren't able to see the rating description they added yet, it will be displayed in the near future. 

## Changes
- The "updateRatingByVetIdAndByRatingId" method was implemented in VetsServiceClient, BFFApiGatewayController, VetController, RatingService, and RatingServiceImpl.
- The "vet-details.component.js" has been updated to be able to update an existing rating with its ratingId and rating data from the update form fields.
- The "vet-details.template.html" has been updated to have a button "Edit" at the bottom of each rating. After being clicked, the form to update the rating is displayed and the button text becomes "Save". After the button was clicked again, the form is hidden, the button text changes back to "Edit" and the new rating score is displayed.
- The Rating Repository has been tested.
- The Rating Service Impl has been tested (100%).
- The "updateRatingByVetIdAndByRatingId" method has been tested (100%) in the controller integration test.
- The "updateRatingByVetIdAndByRatingId" method has been tested in the api-gateway added.
- The "handleNotFoundException" method was added in the GlobalControllerExceptionHandler.

## Before 
![image](https://github.com/cgerard321/champlain_petclinic/assets/80173588/1409b25f-c5f8-4073-badd-28a41aea686c)

## After
![image](https://github.com/cgerard321/champlain_petclinic/assets/80173588/55dd50aa-aa23-49e0-bd84-2d1cfe43275d)

## Dev notes (Optional)
- Specific technical changes that should be noted
## Linked pull requests (Optional)
- pull request link
