### PR TITLE
feat/VETS-CPC-823_Get_Rating_Percentage_For_Vet_Ratings

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -59,6 +59,17 @@ public class VetsServiceClient {
         return numberOfRatings;
     }
 
+    public Mono<String> getPercentageOfRatingsByVetId(String vetId) {
+        Mono<String> percentageOfRatings =
+                webClientBuilder
+                        .build()
+                        .get()
+                        .uri(vetsServiceUrl + "/{vetId}/ratings/percentages", vetId)
+                        .retrieve()
+                        .bodyToMono(String.class);
+        return percentageOfRatings;
+    }
+
     public Mono<RatingResponseDTO> addRatingToVet(String vetId, Mono<RatingRequestDTO> ratingRequestDTO) {
         Mono<RatingResponseDTO> ratingResponseDTOMono =
                 webClientBuilder

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -215,7 +215,7 @@ public class BFFApiGatewayController {
 
     @GetMapping(value = "vets/{vetId}/ratings")
     public Flux<RatingResponseDTO> getRatingsByVetId(@PathVariable String vetId) {
-        return vetsServiceClient.getRatingsByVetId(vetId);
+        return vetsServiceClient.getRatingsByVetId(VetsEntityDtoUtil.verifyId(vetId));
     }
 
     @GetMapping("/vets/{vetId}/ratings/count")
@@ -248,6 +248,13 @@ public class BFFApiGatewayController {
         return vetsServiceClient.updateRatingByVetIdAndByRatingId(vetId, ratingId, ratingRequestDTOMono)
                 .map(r->ResponseEntity.status(HttpStatus.OK).body(r))
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
+    }
+
+    @GetMapping("/vets/{vetId}/ratings/percentages")
+    public Mono<ResponseEntity<String>> getPercentageOfRatingsByVetId(@PathVariable String vetId) {
+        return vetsServiceClient.getPercentageOfRatingsByVetId(VetsEntityDtoUtil.verifyId(vetId))
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/vets/{vetId}")

--- a/api-gateway/src/main/resources/static/css/vets/ratings.css
+++ b/api-gateway/src/main/resources/static/css/vets/ratings.css
@@ -1,0 +1,8 @@
+.form-label-rating {
+    text-align: center;
+    font-size: 20px;
+}
+
+.ratingButton {
+    margin: 5px;
+}

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
@@ -19,6 +19,22 @@ angular.module('vetDetails')
             self.ratings = resp.data;
         });
 
+        $http.get('api/gateway/vets/' + $stateParams.vetId + '/ratings/percentages')
+            .then(function (resp) {
+                const ratingsData = resp.data;
+                const ratingsContainer = document.getElementById('ratings-list');
+                let html = '';
+                for (const key in ratingsData) {
+                    if (ratingsData.hasOwnProperty(key)) {
+                        const percentage = ratingsData[key] * 100; // Convert fraction to percentage
+                        html += key + ' stars - ' + percentage.toFixed(0) + '%';
+                        html += '<br>';
+                    }
+                }
+                ratingsContainer.innerHTML = html.slice(0, -2);
+            });
+
+
         $scope.deleteVetRating = function (ratingId) { //added $scope in this class
             let varIsConf = confirm('Are you sure you want to delete this ratingId: ' + ratingId + '?');
             if (varIsConf) {
@@ -35,6 +51,8 @@ angular.module('vetDetails')
                         self.ratings = resp.data;
                         arr = resp.data;
                     });
+                    //refresh percentages
+                    percentageOfRatings();
                 }
 
                 function errorCallback(error) {
@@ -68,11 +86,14 @@ angular.module('vetDetails')
                     console.log(resp.data)
                     self.rating = resp.data;
                     alert('Your review was successfully updated!');
+                    //refresh list
                     $http.get('api/gateway/vets/' + $stateParams.vetId + '/ratings').then(function (resp) {
                         console.log(resp.data)
                         self.ratings = resp.data;
                         arr = resp.data;
                     });
+                    //refresh percentages
+                    percentageOfRatings();
                 });
             }
         }
@@ -118,6 +139,14 @@ angular.module('vetDetails')
                 console.log(resp.data)
                 self.rating = resp.data;
                 alert('Your review was successfully added!');
+                //refresh list
+                $http.get('api/gateway/vets/' + $stateParams.vetId + '/ratings').then(function (resp) {
+                    console.log(resp.data)
+                    self.ratings = resp.data;
+                    arr = resp.data;
+                });
+                //refresh percentages
+                percentageOfRatings();
             }, function (response) {
                 let error = "Missing rating, please input a rating.";
                 alert(error);
@@ -128,4 +157,26 @@ angular.module('vetDetails')
                 (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
             );
         };
+
+        function percentageOfRatings() {
+            $http.get('api/gateway/vets/' + $stateParams.vetId + '/ratings/percentages')
+                .then(function (resp) {
+                    const ratingsData = resp.data;
+                    const ratingsContainer = document.getElementById('ratings-list');
+                    let html = '';
+                    const ratingsArray = [];
+                    for (const key in ratingsData) {
+                        if (ratingsData.hasOwnProperty(key)) {
+                            const percentage = ratingsData[key] * 100;
+                            ratingsArray.push({ rating: parseFloat(key), percentage });
+                        }
+                    }
+                    for (const ratingObj of ratingsArray) {
+                        console.log("RATING" + ratingObj.percentage);
+                        html += ratingObj.rating + ' stars - ' + ratingObj.percentage.toFixed(0) + '%';
+                        html += '<br>';
+                    }
+                    ratingsContainer.innerHTML = html.slice(0, -2);
+                });
+        }
     }]);

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
@@ -3,6 +3,7 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">
 <link href="form.css" rel="stylesheet" type="text/css"/>
 <link href="/css/ownerdetail.css" rel="stylesheet" type="text/css"/>
+<link href="/css/vets/ratings.css" rel="stylesheet" type="text/css"/>
 
 
 
@@ -119,34 +120,33 @@
 
                 <div class="row g-3">
                     <div class="col-sm-12">
-                        <h5 class="form-label">Ratings</h5>
-                        <div ng-if="$ctrl.ratings.length === 0">
+                        <h3 class="form-label-rating text-center">Ratings</h3>
+                        <div ng-if="$ctrl.ratings.length === 0" style="text-align: center">
                             This vet has no ratings.
                         </div>
                         <div ng-repeat="rating in $ctrl.ratings track by rating.ratingId" ng-if="$ctrl.ratings.length > 0">
-                            <div class="rating-item">
+                            <div class="rating-item d-flex justify-content-center align-items-center">
                                 <span class="rating-value">{{ rating.rateScore }} / 5</span>
-                                <a class="btn btn-danger" href="javascript:void(0)" ng-click="deleteVetRating(rating.ratingId)">Delete Rating</a>
-
                                 <form enctype="multipart/form-data" id="updateForm" name="updateForm">
-                                    <button class="update-vet-button btn btn-success" id="updateRatingBtn" ng-click="$ctrl.updateRating(rating.ratingId, updateForm)">
-                                        Update
-                                    </button>
-
                                     <div class="col-sm-12" name="ratingUpdate" id="ratingUpdate" style="display: none">
                                         <select name="ratingOptions" id="ratingOptions">
-                                            <option value="1">1</option>
-                                            <option value="2">2</option>
-                                            <option value="3">3</option>
-                                            <option value="4">4</option>
-                                            <option value="5">5</option>
+                                            <option value="1">1/5</option>
+                                            <option value="2">2/5</option>
+                                            <option value="3">3/5</option>
+                                            <option value="4">4/5</option>
+                                            <option value="5">5/5</option>
                                         </select>
+                                        <br/>
                                         <h5 class="form-label">Review Description</h5>
                                         <textarea class="form-control" id="updateDescription" maxlength="350" name="updateDescription"
                                                   ng-model="rating.rateDescription" pattern="^(.*)" placeholder="Update Description"
                                                   title="Maximum of 350 characters."></textarea>
                                     </div>
                                 </form>
+                                <button class="update-vet-button btn btn-success" id="updateRatingBtn" ng-click="$ctrl.updateRating(rating.ratingId, updateForm)">
+                                    Update
+                                </button>
+                                <a class="btn btn-danger ratingButton" href="javascript:void(0)" ng-click="deleteVetRating(rating.ratingId)">Delete Rating</a>
                             </div>
                         </div>
                     </div>
@@ -154,10 +154,10 @@
 
                 <div class="row g-3">
                     <div class="col-sm-12">
-                        <h4 class="form-label">Add A Rating</h4>
+                        <h3 class="form-label-rating">Add A Rating</h3>
                         <form enctype="multipart/form-data" id="ratingForm" name="ratingForm">
                             <div class="row-3">
-                                <div class="col-sm-12">
+                                <div class="col-sm-12 form-label-rating">
                                     <select name="rateScore" id="ratingScore" ng-model="rating.rateScore">
                                         <option value="1">1/5</option>
                                         <option value="2">2/5</option>
@@ -172,11 +172,18 @@
                                               ng-model="rating.rateDescription" pattern="^(.*)" placeholder="Description"
                                               title="Maximum of 350 characters."></textarea>
                                 </div>
-                                <button class="btn btn-primary" ng-click="$ctrl.submitRatingForm(ratingForm)" type="submit">
+                                <br/>
+                                <button class="btn btn-primary ratingButton" ng-click="$ctrl.submitRatingForm(ratingForm)" type="submit">
                                     Submit
                                 </button>
                             </div>
                         </form>
+                    </div>
+                    <div class="row g-3" ng-if="$ctrl.ratings.length > 0">
+                        <div class="col-sm-12">
+                            <h3 class="form-label-rating">Percentages of ratings:</h3>
+                            <div id="ratings-list"></div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
@@ -56,7 +56,7 @@ class VetsServiceClientIntegrationTest {
     }
 
     @Test
-    void getRatingsByVetId() throws JsonProcessingException {
+    void getAllRatingsByVetId_ValidId() throws JsonProcessingException {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
@@ -97,7 +97,19 @@ class VetsServiceClientIntegrationTest {
 
 
     @Test
-    void deleteRatingsByRatingId() throws JsonProcessingException {
+    void getRatingPercentagesByVetId() throws JsonProcessingException {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"1.0\":0.0,\"2.0\":0.0,\"4.0\":0.0,\"5.0\":1.0,\"3.0\":0.0}"));
+
+        final String ratingPercentages = vetsServiceClient.getPercentageOfRatingsByVetId("678910").block();
+        assertEquals("{\"1.0\":0.0,\"2.0\":0.0,\"4.0\":0.0,\"5.0\":1.0,\"3.0\":0.0}", ratingPercentages);
+    }
+
+
+  
+  @Test
+    void deleteRatingsByRatingId() throws JsonProcessingException{
         final String ratingId = "794ac37f-1e07-43c2-93bc-61839e61d989";
 
         prepareResponse(response -> response

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -100,7 +100,7 @@ class ApiGatewayControllerTest {
 
 
     @Test
-    void getAllRatingsForVet() {
+    void getAllRatingsForVet_ValidId() {
         RatingResponseDTO ratingResponseDTO = buildRatingResponseDTO();
         when(vetsServiceClient.getRatingsByVetId(anyString()))
                 .thenReturn(Flux.just(ratingResponseDTO));
@@ -145,7 +145,7 @@ class ApiGatewayControllerTest {
                 .uri("/api/gateway/vets/" + INVALID_VET_ID + "/ratings")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isEqualTo(NOT_FOUND)
+                .expectStatus().isEqualTo(INTERNAL_SERVER_ERROR)
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
                 .jsonPath("$.message").isEqualTo("This id is not valid");
@@ -189,6 +189,21 @@ class ApiGatewayControllerTest {
                 .value(resp->
                         assertEquals(rating.getRateScore(), ratingResponseDTO.getRateScore()));
 
+    }
+
+    @Test
+    void getPercentageOfRatingsPerVet_ByVetId() {
+        when(vetsServiceClient.getPercentageOfRatingsByVetId(anyString()))
+                .thenReturn(Mono.just("1"));
+
+        client
+                .get()
+                .uri("/api/gateway/vets/" + VET_ID + "/ratings/percentages")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$").isEqualTo("1");
     }
 
 

--- a/vet-service/src/main/java/com/petclinic/vet/exceptions/ExistingVetNotFoundException.java
+++ b/vet-service/src/main/java/com/petclinic/vet/exceptions/ExistingVetNotFoundException.java
@@ -1,5 +1,0 @@
-package com.petclinic.vet.exceptions;
-
-public class ExistingVetNotFoundException extends RuntimeException{
-    //public ExistingVetNotFoundException(String message) { super(message); }
-}

--- a/vet-service/src/main/java/com/petclinic/vet/exceptions/GlobalControllerExceptionHandler.java
+++ b/vet-service/src/main/java/com/petclinic/vet/exceptions/GlobalControllerExceptionHandler.java
@@ -43,7 +43,6 @@ public class GlobalControllerExceptionHandler {
 //        return createHttpErrorInfo(NOT_FOUND, request, ex);
 //    }
 
-
     private HttpErrorInfo createHttpErrorInfo(HttpStatus httpStatus, ServerHttpRequest request, Exception ex) {
         final String path = request.getPath().pathWithinApplication().value();
         final String message = ex.getMessage();

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -31,7 +31,8 @@ public class VetController {
     RatingService ratingService;
     @GetMapping("{vetId}/ratings")
     public Flux<RatingResponseDTO> getAllRatingsByVetId(@PathVariable String vetId) {
-        return ratingService.getAllRatingsByVetId(vetId);
+        return ratingService.getAllRatingsByVetId(EntityDtoUtil.verifyId(vetId));
+
     }
 
     @GetMapping("{vetId}/ratings/count")
@@ -70,6 +71,13 @@ public class VetController {
     public Mono<RatingResponseDTO> updateRatingByVetIdAndRatingId(@PathVariable String vetId, @PathVariable String ratingId, @RequestBody Mono<RatingRequestDTO> ratingRequestDTOMono){
         return ratingService.updateRating(vetId, ratingId, ratingRequestDTOMono);
     }*/
+
+    @GetMapping("{vetId}/ratings/percentages")
+    public Mono<ResponseEntity<String>> getPercentageOfRatingsByVetId(@PathVariable String vetId){
+        return ratingService.getRatingPercentagesByVetId(EntityDtoUtil.verifyId(vetId))
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
 
     @GetMapping()
     public Flux<VetDTO> getAllVets() {

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingService.java
@@ -10,4 +10,5 @@ public interface RatingService {
     Mono<RatingResponseDTO> updateRatingByVetIdAndRatingId(String vetId, String ratingId, Mono<RatingRequestDTO> ratingRequestDTOMono);
     Mono<Void> deleteRatingByRatingId(String vetId, String ratingId);
     Mono<Double> getAverageRatingByVetId(String vetId);
+    Mono<String> getRatingPercentagesByVetId(String vetId);
 }

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingServiceImpl.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingServiceImpl.java
@@ -1,5 +1,8 @@
 package com.petclinic.vet.servicelayer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petclinic.vet.dataaccesslayer.Rating;
 import com.petclinic.vet.dataaccesslayer.RatingRepository;
 import com.petclinic.vet.exceptions.NotFoundException;
 
@@ -10,15 +13,20 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
 public class RatingServiceImpl implements RatingService {
 
     private final RatingRepository ratingRepository;
+    private final ObjectMapper objectMapper;
 
-    public RatingServiceImpl(RatingRepository ratingRepository) {
+    public RatingServiceImpl(RatingRepository ratingRepository, ObjectMapper objectMapper) {
         this.ratingRepository = ratingRepository;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -69,8 +77,8 @@ public class RatingServiceImpl implements RatingService {
         return this.ratingRepository.findByRatingId(ratingId)
                 .switchIfEmpty(Mono.error(new NotFoundException("Rating with id " + ratingId + " not found.")))
                 .flatMap(rating -> ratingRequestDTOMono
-                        .flatMap(r->{
-                            if (r.getRateScore()<1||r.getRateScore()>5)
+                        .flatMap(r -> {
+                            if (r.getRateScore() < 1 || r.getRateScore() > 5)
                                 return Mono.error(new InvalidInputException("rateScore should be between 1 and 5" + r.getRateScore()));
                             return Mono.just(r);
                         })
@@ -79,5 +87,31 @@ public class RatingServiceImpl implements RatingService {
                         .doOnNext(e -> e.setRatingId(rating.getRatingId()))
                         .flatMap(ratingRepository::save)
                         .map(EntityDtoUtil::toDTO));
+    }
+
+    @Override
+    public Mono<String> getRatingPercentagesByVetId(String vetId) {
+        Flux<Rating> ratingFlux = ratingRepository.findAllByVetId(vetId);
+        Map<Double, Integer> ratingCount = new HashMap<>();
+        for(double i = 1.0; i <= 5.0; i += 1.0) {
+            ratingCount.put(i, 0);
+        }
+        return ratingFlux
+                .map(EntityDtoUtil::toDTO)
+                .map(RatingResponseDTO::getRateScore)
+                .doOnNext(rating -> ratingCount.put(rating, ratingCount.get(rating) + 1))
+                .then(Mono.just(ratingCount))
+                .map(ratingCountMap -> {
+                    Map<Double, Double> ratingPercentages = new LinkedHashMap<>();
+                    for(double i = 1.0; i <= 5.0; i += 1.0) {
+                        ratingPercentages.put(i, ratingCountMap.get(i) / (double) ratingCountMap.values().stream().mapToInt(Integer::intValue).sum());
+                    }
+                    try {
+                       String ratingPercentageJson = objectMapper.writeValueAsString(ratingPercentages);
+                        return ratingPercentageJson;
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
     }
 }

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -286,6 +286,28 @@ class VetControllerIntegrationTest {
     }
 
     @Test
+    void getPercentageOfRatingsByVetId_ShouldSucceed(){
+        Publisher<Rating> setup = ratingRepository.deleteAll()
+                .thenMany(ratingRepository.save(rating1))
+                .thenMany(ratingRepository.save(rating2));
+        StepVerifier
+                .create(setup)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        client.get()
+                .uri("/vets/" + VET_ID + "/ratings" + "/percentages")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON_UTF8)
+                .expectBody(String.class)
+                .value(resp ->{
+                    assertEquals("{\"1.0\":0.0,\"2.0\":0.0,\"3.0\":0.0,\"4.0\":0.5,\"5.0\":0.5}", resp);
+                });
+    }
+
+    @Test
     void getAllVets() {
         Publisher<Vet> setup = vetRepository.deleteAll().thenMany(vetRepository.save(vet));
 

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -199,6 +199,23 @@ class VetControllerUnitTest {
 
     }
 
+    @Test
+    void getPercentageOfRatingsByVetId_ShouldSucceed() {
+        when(ratingService.getRatingPercentagesByVetId(anyString()))
+                .thenReturn(Mono.just("{\"1.0\":0.0,\"2.0\":0.0,\"4.0\":0.0,\"5.0\":1.0,\"3.0\":0.0}"));
+        client
+                .get()
+                .uri("/vets/" + VET_ID + "/ratings/percentages")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .value(string -> {
+                    assertEquals("{\"1.0\":0.0,\"2.0\":0.0,\"4.0\":0.0,\"5.0\":1.0,\"3.0\":0.0}", string);
+                });
+        Mockito.verify(ratingService, times(1))
+                .getRatingPercentagesByVetId(VET_ID);
+    }
 
     @Test
     void getAllVets() {

--- a/vet-service/src/test/java/com/petclinic/vet/servicelayer/RatingServiceImplTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/servicelayer/RatingServiceImplTest.java
@@ -1,0 +1,152 @@
+package com.petclinic.vet.servicelayer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petclinic.vet.dataaccesslayer.Rating;
+import com.petclinic.vet.dataaccesslayer.RatingRepository;
+import com.petclinic.vet.exceptions.NotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class RatingServiceImplTest {
+
+    @Autowired
+    RatingService ratingService;
+
+    @MockBean
+    RatingRepository ratingRepository;
+
+    @MockBean
+    ObjectMapper objectMapper;
+
+    String VET_ID = "vetId";
+    Rating rating = buildRating();
+    RatingRequestDTO ratingRequestDTO = buildRatingRequestDTO();
+    @Test
+    void getAllRatingsByVetId() {
+        when(ratingRepository.findAllByVetId(anyString())).thenReturn(Flux.just(rating));
+
+        Flux<RatingResponseDTO> ratingResponseDTO = ratingService.getAllRatingsByVetId("vetId");
+
+        StepVerifier
+                .create(ratingResponseDTO)
+                .consumeNextWith(foundRating -> {
+                    assertEquals(rating.getRatingId(), foundRating.getRatingId());
+                    assertEquals(rating.getVetId(), foundRating.getVetId());
+                    assertEquals(rating.getRateScore(), foundRating.getRateScore());
+                })
+
+                .verifyComplete();
+    }
+
+    @Test
+    void deleteRatingByRatingId() {
+        when(ratingRepository.findByVetIdAndRatingId(anyString(), anyString())).thenReturn(Mono.just(rating));
+        when(ratingRepository.delete(any())).thenReturn(Mono.empty());
+
+        Mono<Void> deletedRating = ratingService.deleteRatingByRatingId(rating.getVetId(), rating.getRatingId());
+
+        StepVerifier
+                .create(deletedRating)
+                .verifyComplete();
+    }
+
+    @Test
+    void addRatingToVet() {
+        ratingService.addRatingToVet(rating.getVetId(), Mono.just(ratingRequestDTO))
+                .map(ratingResponseDTO -> {
+                    assertEquals(ratingResponseDTO.getVetId(), ratingRequestDTO.getVetId());
+                    assertEquals(ratingResponseDTO.getRateScore(), ratingRequestDTO.getRateScore());
+                    assertNotNull(ratingResponseDTO.getRatingId());
+                    return ratingResponseDTO;
+                });
+    }
+
+    @Test
+    void getNumberOfRatingsByVetId() {
+        when(ratingRepository.countAllByVetId(anyString())).thenReturn(Mono.just(1L));
+
+        Mono<Integer> numberOfRatings = ratingService.getNumberOfRatingsByVetId(rating.getVetId());
+
+        StepVerifier
+                .create(numberOfRatings)
+                .consumeNextWith(foundRating -> {
+                    assertEquals(1, foundRating);
+                })
+
+                .verifyComplete();
+    }
+
+    @Test
+    void getAverageRatingByVetId() {
+        when(ratingRepository.countAllByVetId(anyString())).thenReturn(Mono.just(1L));
+        when(ratingRepository.findAllByVetId(anyString())).thenReturn(Flux.just(rating));
+
+        Mono<Double> averageRating = ratingService.getAverageRatingByVetId(rating.getVetId());
+
+        StepVerifier
+                .create(averageRating)
+                .consumeNextWith(foundRating -> {
+                    assertEquals(5.0, foundRating);
+                })
+
+                .verifyComplete();
+    }
+
+    @Test
+    void getRatingPercentagesByVetId() throws JsonProcessingException {
+        when(ratingRepository.findAllByVetId(anyString())).thenReturn(Flux.just(rating));
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"1.0\":0.0,\"2.0\":0.0,\"4.0\":0.0,\"5.0\":1.0,\"3.0\":0.0}");
+        Mono<String> ratingPercent = ratingService.getRatingPercentagesByVetId(rating.getVetId());
+
+        StepVerifier
+                .create(ratingPercent)
+                .consumeNextWith(foundRating -> {
+                    assertEquals("{\"1.0\":0.0,\"2.0\":0.0,\"4.0\":0.0,\"5.0\":1.0,\"3.0\":0.0}", foundRating);
+                })
+
+                .verifyComplete();
+    }
+
+    // get rating percentage error handling test
+    @Test
+    void getRatingPercentagesByVetIdError() throws JsonProcessingException {
+        when(ratingRepository.findAllByVetId(anyString())).thenReturn(Flux.empty());
+        when(objectMapper.writeValueAsString(any())).thenThrow(JsonProcessingException.class);
+        Mono<String> ratingPercent = ratingService.getRatingPercentagesByVetId(rating.getVetId());
+
+        StepVerifier
+                .create(ratingPercent)
+                .expectError(RuntimeException.class)
+                .verify();
+    }
+
+    private Rating buildRating() {
+        Rating rating = new Rating();
+        rating.setRatingId("ratingId");
+        rating.setVetId("vetId");
+        rating.setRateScore(5.0);
+        return rating;
+    }
+
+    private RatingRequestDTO buildRatingRequestDTO() {
+        RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
+                .vetId("vetId")
+                .rateScore(5.0)
+                .build();
+        return ratingRequestDTO;
+    }
+}


### PR DESCRIPTION
Add percentqage for each rating of a vet, change a bit of the front-end and added some tests
JIRA: link to jira ticket
CPC-823
https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/13?selectedIssue=CPC-823&sprints=293
## Context:
As a user, I want to be able to see the percentage of the votes between 0 and 5. For example, if a vet has 2 ratings, one is 2/5 and the other is 5/5, it means that 50% of the people who rated him gave him 2/5 and the other 50% gave him 5/5. If another rating of 3/5 is added, then the percentage displayed for 2/5 stars, 5/5 stars, and 3/5 stars is 33%.
## Changes
What are the various changes and what other modules do those changes effect.
- Add getRatingPercentagesByVetId(String vetId) method in the rating service.
- Implementing getRatingPercentagesByVetId(String vetId) method in the rating service impl.
- Implement getRatingPercentagesByVetId(String vetId) method in the vet controller.
- Implement getRatingPercentagesByVetId(String vetId) method in VetsServiceClient.
- Implement getRatingPercentagesByVetId(String vetId) method in in Api-Gateway.
- Created controller integration tests, controller unit tests, rating service impl tests, vet service client integration tests, api-gateway controller tests for getRatingPercentagesByVetId(String vetId). (90% covergae)
- Create the front-end for the percentage display (vet-details.controller.js and html modified).

## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://github.com/cgerard321/champlain_petclinic/assets/46633364/d9a3d33c-759e-4d73-9721-7c1db45fab90)

After:
![image](https://github.com/cgerard321/champlain_petclinic/assets/46633364/8414217e-fddb-447b-b596-824860d5ec62)

## Dev notes (Optional)
- Specific technical changes that should be noted
## Linked pull requests (Optional)
- pull request link
