### PR TITLE
bug(VETS-CPC-849) display AverageRating and NumberOfRating when vets are filtered

### DIFF
--- a/api-gateway/src/main/resources/static/scripts/vet-list/vet-list.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-list/vet-list.controller.js
@@ -97,6 +97,13 @@ angular.module('vetList')
             $http.get(url).then(function (resp) {
                 self.vetList = resp.data;
                 arr = resp.data;
+                angular.forEach(self.vetList, function(vet) {
+                    getAverageRating(vet)
+                    getCountOfRatings(vet)
             });
+
+            });
+
         }
+
     }]);

--- a/api-gateway/src/main/resources/static/scripts/vet-list/vet-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/vet-list/vet-list.template.html
@@ -50,9 +50,9 @@
                 class="info v{{vet.vetId}}" ng-mouseenter="$ctrl.show($event,vet.vetId)"
                 ng-mouseleave="$ctrl.hide($event,vet.vetId)">{{vet.firstName}} {{vet.lastName}}</span></a></td>
         <td class="vet_phone"><span>{{vet.phoneNumber}}</span></td>
-
         <td class="vet_email"><span>{{vet.email}}</span></td>
         <td class="vet_speciality"><span ng-repeat="specialty in vet.specialties">{{specialty.name + ' '}}</span></td>
+
         <td class="vet-rating v{{vet.vetId}} centered-count"><span>{{vet.rating}}</span></td>
         <td class="vet-rating v{{vet.vetId}} centered-count"><span>{{vet.count}}</span></td>
         <td><a class="btn btn-danger" href="javascript:void(0)" ng-click="deleteVet(vet.vetId)">Delete Vet</a></td>


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/35?selectedIssue=CPC-849&sprints=293

## Context:
This bug is fixed in order to see the AverageRating and the NumberOfRating appear when choosing  a filter between All, Active or Inactive in the vetenerian main page 

## Changes:

- Modification of the ReloadData function in the veterinarian-list controller frontend

## Before and After UI (Required for UI-impacting PRs)
**ALL, ACTIVE AND INACTIVE PAGES LOOKED THE SAME**
![image](https://github.com/cgerard321/champlain_petclinic/assets/91993350/8a5b0d4d-3cbe-4173-8ad6-44e12ede70fa)

**ALL FILTER:**
![image](https://github.com/cgerard321/champlain_petclinic/assets/91993350/0549a5f0-e8a0-47a7-b5ff-ed4849280fcc)

**ACTIVE FILTER:**
![image](https://github.com/cgerard321/champlain_petclinic/assets/91993350/3ec5e7e4-7b75-451b-a7a3-cd409cd8e6c1)

**INACTIVE FILTER:**
![image](https://github.com/cgerard321/champlain_petclinic/assets/91993350/24fa49b0-ed0b-4b24-b9a1-278f8737d1b9)

