### PR TITLE
feat(VIST-CPC-787): Implementing delete visit functionality in the front-end

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
@@ -24,6 +24,7 @@ import static java.util.stream.Collectors.joining;
 
 @Component
 public class VisitsServiceClient {
+
     private final WebClient webClient;
 
     @Autowired
@@ -132,6 +133,10 @@ public class VisitsServiceClient {
                 .retrieve()
                 .bodyToMono(Void.class);
     }
+
+
+
+
 
     private String joinIds(List<Integer> petIds) {
         return petIds.stream().map(Object::toString).collect(joining(","));

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -209,6 +209,9 @@ public class BFFApiGatewayController {
     public Mono<Void> deleteVisitsByVisitId(final @PathVariable String visitId){
         return visitsServiceClient.deleteVisitByVisitId(visitId);
     }
+    /**
+     * End of Visit Methods
+     **/
 
     @GetMapping(value = "vets")
     public Flux<VetDTO> getAllVets() {

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 angular.module('visitList')
     .controller('VisitListController', ['$http', '$scope', function ($http, $scope) {
-        let self = this
+        let self = this;
         // Lists holding visits for the tables to display
         self.upcomingVisits = []
         self.previousVisits = []
@@ -20,7 +20,37 @@ angular.module('visitList')
                 console.log("EventSource error: "+error)
             }
         }
-    }])
+
+        $scope.deleteVisit = function (visitId) {
+            let varIsConf = confirm('You are about to delete visit ' + visitId + '. Is this what you want to do ? ');
+            if (varIsConf) {
+
+                $http.delete('api/gateway/visits/' + visitId)
+                    .then(successCallback, errorCallback)
+
+                function successCallback(response) {
+                    $scope.errors = [];
+                    alert(visitId + " visit was deleted successfully");
+                    console.log(response, 'res');
+                    delayedReload();
+                }
+
+                function errorCallback(error) {
+                    alert(data.errors);
+                    console.log(error, 'Could not receive data');
+                }
+            }
+
+            function delayedReload() {
+                var loadingIndicator = document.getElementById('loadingIndicator');
+                loadingIndicator.style.display = 'block';
+                setTimeout(function() {
+                    location.reload();
+                }, 1000); //delay by 1 second
+            }
+        };
+    }]);
+
 //     // self.sortFetchedVisits = function() {
     //     //     let currentDate = getCurrentDate()
     //     //     $.each(self.visits, function(i, visit) {

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.js
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.js
@@ -8,4 +8,9 @@ angular.module('visitList', ['ui.router'])
                 url: '/visitList',
                 template: '<visit-list></visit-list>'
             })
+            .state('deleteVisit', {
+                parent: 'app',
+                url: '/visits/:visitId/deleteVisit',
+                template: '<visit-list></visit-list>'
+            })
     }]);

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
@@ -65,10 +65,16 @@
         <td class="status-text" style="white-space: pre-line"></td>
         <td style="text-align:center; vertical-align:middle"><button class="btn btn-default cancel-button" type="button" style="background-color: orangered; color: white" ng-click="$ctrl.showConfirmationModal($event, v.visitId, v.status, v.practitionerId, v.description)">{{$ctrl.setCancelButtonText(v.status)}}</button></td>
         <td style="text-align:center; vertical-align:middle"><button class="btn btn-default" type="button" style="background-color: royalblue; color: white" ng-click="$ctrl.switchToUpdateForm($event, v.practitionerId, v.description, v.visitId, v.status)">Edit Visit</button></td>
-        <td style="text-align:center; vertical-align:middle"><button class="btn btn-danger" type="button" ng-click="$ctrl.showConfirmationModal($event, v.visitId)">Delete visit</button></td>
+        <!--<td style="text-align:center; vertical-align:middle"><button class="btn btn-danger" href="javascript:void(0)" ng-click="deleteVisit(v.visitId)">Delete visit</button></td> -->
+        <td><a class="btn btn-danger" href="javascript:void(0)" ng-click="deleteVisit(v.visitId)">Delete Visit</a></td>
+
+
     </tr>
     </tbody>
 </table><h3 style="margin-top: 6px">Previous Visits</h3>
+
+<div id="loadingIndicator" style="display: none;">Loading...</div> <!--Page loading message-->
+
 <table class="table">
     <thead>
     <tr>


### PR DESCRIPTION
JIRA: link to jira ticket
https://champlainsaintlambert.atlassian.net/browse/CPC-787
## Context:
This ticket is about fixing and properly implementing the delete visit by visitId functionality in the front-end.
## Changes
- Changes made to visit-list script files to enable delete visit functionality via the front-end
- Tests added to ApiGatewayControllerTest file
## Before and After UI (Required for UI-impacting PRs)

 Delete visit message pop-up
![DeleteVisit_Button_Message](https://github.com/cgerard321/champlain_petclinic/assets/77695020/6ed3247a-1dac-4532-ba8c-5cc868509f34)

Delete success pop-up
![Success_Message](https://github.com/cgerard321/champlain_petclinic/assets/77695020/0a9c190f-716b-4ee5-87bf-c56b21b67219)

Updated visit list
![Updated_Listpng](https://github.com/cgerard321/champlain_petclinic/assets/77695020/46ddded8-0a41-4254-a5d3-8aef4ece45b5)



