### PR TITLE
bug(BILL_CPC-746): change display id to names

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClient.java
@@ -1,6 +1,5 @@
 package com.petclinic.bffapigateway.domainclientlayer;
 
-import com.petclinic.bffapigateway.dtos.Bills.BillDetails;
 import com.petclinic.bffapigateway.dtos.Bills.BillRequestDTO;
 import com.petclinic.bffapigateway.dtos.Bills.BillResponseDTO;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,7 +14,7 @@ import reactor.core.publisher.Mono;
 public class BillServiceClient {
 
     private final WebClient.Builder webClientBuilder;
-    private String billServiceUrl;
+    private final String billServiceUrl;
 
 
     public BillServiceClient(
@@ -35,7 +34,7 @@ public class BillServiceClient {
                 .retrieve()
                 .bodyToMono(BillResponseDTO.class);
     }
-    public Flux<BillResponseDTO> getBillsByOwnerId(final int customerId) {
+    public Flux<BillResponseDTO> getBillsByOwnerId(final String customerId) {
         return webClientBuilder.build().get()
                 .uri(billServiceUrl + "/customer/{customerId}", customerId)
                 .retrieve()
@@ -78,7 +77,7 @@ public class BillServiceClient {
                 .bodyToFlux(Void.class);
     }
 
-    public Flux<Void> deleteBillsByCustomerId(final int customerId) {
+    public Flux<Void> deleteBillsByCustomerId(final String customerId) {
         return webClientBuilder.build()
                 .delete()
                 .uri(billServiceUrl + "/customer/{customerId}", customerId)

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillDetails.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillDetails.java
@@ -1,22 +1,16 @@
 package com.petclinic.bffapigateway.dtos.Bills;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import static java.util.stream.Collectors.toList;
 
 @Builder
 @Data
 public class BillDetails {
     private String billId;
     private LocalDate date;
-    private int customerId;
+    private String customerId;
     private String vetId;
     private String visitType;
     private double amount;

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillRequestDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillRequestDTO.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @Builder
 public class BillRequestDTO {
 
-    private int customerId;
+    private String customerId;
     private String visitType;
     private String vetId;
     private LocalDate date;

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillResponseDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillResponseDTO.java
@@ -6,7 +6,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 @Data
 @AllArgsConstructor
@@ -15,7 +14,7 @@ import java.util.Date;
 public class BillResponseDTO {
 
     private String billId;
-    private int customerId;
+    private String customerId;
     private String visitType;
     private String vetId;
     private LocalDate date;

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -82,7 +82,7 @@ public class BFFApiGatewayController {
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.VET})
     @GetMapping(value = "bills/customer/{customerId}", produces= MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<BillResponseDTO> getBillsByOwnerId(final @PathVariable int customerId)
+    public Flux<BillResponseDTO> getBillsByOwnerId(final @PathVariable String customerId)
     {
         return billServiceClient.getBillsByOwnerId(customerId);
     }
@@ -104,7 +104,7 @@ public class BFFApiGatewayController {
     }
 
     @DeleteMapping(value = "bills/customer/{customerId}")
-    public Flux<Void> deleteBillsByCustomerId(final @PathVariable int customerId){
+    public Flux<Void> deleteBillsByCustomerId(final @PathVariable String customerId){
         return billServiceClient.deleteBillsByCustomerId(customerId);
     }
 

--- a/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.controller.js
@@ -6,6 +6,26 @@ angular.module('billHistory')
         let self = this;
         self.billHistory = []
 
+        self.owners = [
+            { ownerId: '1', firstName: 'George', lastName: 'Franklin' },
+            { ownerId: '2', firstName: 'Betty', lastName: 'Davis' },
+            { ownerId: '3', firstName: 'Eduardo', lastName: 'Rodriguez' },
+            { ownerId: '4', firstName: 'Harold', lastName: 'Davis' },
+            { ownerId: '5', firstName: 'Peter', lastName: 'McTavish' },
+            { ownerId: '6', firstName: 'Jean', lastName: 'Coleman' },
+            { ownerId: '7', firstName: 'Jeff', lastName: 'Black' },
+            { ownerId: '8', firstName: 'Maria', lastName: 'Escobito' },
+            { ownerId: '9', firstName: 'David', lastName: 'Schroeder' },
+            { ownerId: '10', firstName: 'Carlos', lastName: 'Esteban' }
+        ];
+
+        self.customerNameMap = {};
+
+        self.owners.forEach(function (customer) {
+            // The customer's ownerId is used as the key, and their full name as the value
+            self.customerNameMap[customer.ownerId] = customer.firstName + ' ' + customer.lastName;
+        });
+
         let eventSource = new EventSource("api/gateway/bills")
         eventSource.addEventListener('message',function (event){
             $scope.$apply(function (){
@@ -43,17 +63,25 @@ angular.module('billHistory')
             }
         };
 
+        // $scope.getCustomerDetails = function(customerId) {
+        //     const customer = self.owners.find(function(customer) {
+        //         return customer.ownerId === customerId;
+        //     });
+        //
+        //     if (customer) {
+        //         return customer.firstName + ' ' + customer.lastName;
+        //     } else {
+        //         return 'Unknown Customer';
+        //     }
+        // }
         $scope.getCustomerDetails = function(customerId) {
-            const customer = self.owners.find(function(customer) {
-                return customer.id === customerId;
-            });
-
-            if (customer) {
-                return customer.firstName + ' ' + customer.lastName;
+            const customerName = self.customerNameMap[customerId];
+            if (customerName) {
+                return customerName;
             } else {
                 return 'Unknown Customer';
             }
-        }
+        };
 
         $scope.deleteBill = function (billId) {
             let varIsConf = confirm('You are about to delete billId ' + billId + '. Is it what you want to do ? ');

--- a/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.controller.js
@@ -21,19 +21,39 @@ angular.module('billHistory')
             }
         }
 
-        // $http.get('api/gateway/bills').then(function (resp) {
-        //     self.billHistory = resp.data;
-        // });
-/*
-        $scope.getVetByVetId = function (vetId) {
-            $http.get('api/gateway/vets/'+vetId).then(function (resp1) {
-                self.vetName = resp1.firstName + ' ' + resp1.lastName;
-                //{{vet.firstName}} {{vet.lastName}}
-                console.log(self.vetName)
-            });
-        }
-*/
+        $http.get('api/gateway/vets').then(function (resp) {
+            self.vetList = resp.data;
+            arr = resp.data;
+        });
 
+        $http.get('api/gateway/owners').then(function (owners) {
+            self.owners = owners.data;
+            console.log(owners)
+        });
+
+        $scope.getVetDetails = function(vetId) {
+            const vet = self.vetList.find(function(vet) {
+                return vet.vetBillId === vetId;
+            });
+
+            if (vet) {
+                return vet.firstName + ' ' + vet.lastName;
+            } else {
+                return 'Unknown Vet';
+            }
+        };
+
+        $scope.getCustomerDetails = function(customerId) {
+            const customer = self.owners.find(function(customer) {
+                return customer.ownerId === customerId;
+            });
+
+            if (customer) {
+                return customer.firstName + ' ' + customer.lastName;
+            } else {
+                return 'Unknown Customer';
+            }
+        }
 
         $scope.deleteBill = function (billId) {
             let varIsConf = confirm('You are about to delete billId ' + billId + '. Is it what you want to do ? ');

--- a/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.controller.js
@@ -45,7 +45,7 @@ angular.module('billHistory')
 
         $scope.getCustomerDetails = function(customerId) {
             const customer = self.owners.find(function(customer) {
-                return customer.ownerId === customerId;
+                return customer.id === customerId;
             });
 
             if (customer) {

--- a/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.template.html
+++ b/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.template.html
@@ -18,7 +18,7 @@
     <thead>
         <tr>
             <td>Bill ID</td>
-            <td>Owner ID</td>
+            <td>Owner Name</td>
             <td>Owner Details</td>
             <td>Vet Name</td>
             <td>Visit Type</td>

--- a/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.template.html
+++ b/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.template.html
@@ -20,7 +20,7 @@
             <td>Bill ID</td>
             <td>Owner ID</td>
             <td>Owner Details</td>
-            <td>Vet. Id</td>
+            <td>Vet Name</td>
             <td>Visit Type</td>
             <td>Amount</td>
             <td>Date</td>
@@ -34,9 +34,11 @@
     <tr ng-repeat="bill in $ctrl.billHistory | filter:search:strict">
         <td>{{bill.billId}}</td>
         <td>{{bill.customerId}}</td>
+<!--        <td>{{ getCustomerDetails(bill.customerId) }}</td>-->
         <td><a href="http://localhost:8080/#!/owners/details/{{bill.customerId}}">Owner details</a></td>
 <!--        <td ng-app="billHistory" ng-controller="BillHistoryController">{{getVetByVetId(bill.vetId)}}</td>-->
-        <td>{{bill.vetId}}</td>
+<!--        <td>{{bill.vetId}}</td>-->
+    <td>{{ getVetDetails(bill.vetId) }}</td>
         <td>{{bill.visitType}}</td>
         <td>{{bill.amount}}</td>
         <td>{{bill.date}}</td>

--- a/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.template.html
+++ b/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.template.html
@@ -33,8 +33,8 @@
     <tr id="billId" ng-repeat="bill in $ctrl.billHistory | filter:$ctrl.query track by bill.billId">
     <tr ng-repeat="bill in $ctrl.billHistory | filter:search:strict">
         <td>{{bill.billId}}</td>
-        <td>{{bill.customerId}}</td>
-<!--        <td>{{ getCustomerDetails(bill.customerId) }}</td>-->
+<!--        <td>{{bill.customerId}}</td>-->
+        <td>{{ getCustomerDetails(bill.customerId) }}</td>
         <td><a href="http://localhost:8080/#!/owners/details/{{bill.customerId}}">Owner details</a></td>
 <!--        <td ng-app="billHistory" ng-controller="BillHistoryController">{{getVetByVetId(bill.vetId)}}</td>-->
 <!--        <td>{{bill.vetId}}</td>-->

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientIntegrationTest.java
@@ -66,7 +66,7 @@ class BillServiceClientIntegrationTest {
     private final BillResponseDTO billResponseDTO = BillResponseDTO.builder()
             .billId("1")
             .amount(100.0)
-            .customerId(1)
+            .customerId("1")
             .vetId("1")
             .visitType("Check up")
             .date(null)
@@ -75,7 +75,7 @@ class BillServiceClientIntegrationTest {
     private final BillResponseDTO billResponseDTO2 = BillResponseDTO.builder()
             .billId("2")
             .amount(150.0)
-            .customerId(2)
+            .customerId("2")
             .vetId("2")
             .visitType("Check up")
             .date(null)
@@ -84,7 +84,7 @@ class BillServiceClientIntegrationTest {
     private final BillResponseDTO billResponseDTO3 = BillResponseDTO.builder()
             .billId("3")
             .amount(250.0)
-            .customerId(3)
+            .customerId("3")
             .vetId("3")
             .visitType("Check up")
             .date(null)
@@ -117,9 +117,9 @@ class BillServiceClientIntegrationTest {
         server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .setBody(mapper.writeValueAsString(billResponseDTO)).addHeader("Content-Type", "application/json"));
 
-        Flux<BillResponseDTO> billResponseDTOMono = billServiceClient.getBillsByOwnerId(1);
+        Flux<BillResponseDTO> billResponseDTOMono = billServiceClient.getBillsByOwnerId("1");
         StepVerifier.create(billResponseDTOMono)
-                .expectNextMatches(returnedBillResponseDTO1 -> returnedBillResponseDTO1.getCustomerId() == 1)
+                .expectNextMatches(returnedBillResponseDTO1 -> returnedBillResponseDTO1.getCustomerId() == "1")
                 .verifyComplete();
     }
 
@@ -128,7 +128,7 @@ class BillServiceClientIntegrationTest {
         final BillDetails bill = BillDetails.builder()
                 .billId(UUID.randomUUID().toString())
                 .vetId("15")
-                .customerId(2)
+                .customerId("2")
                 .date(null)
                 .amount(100)
                 .visitType("Check")
@@ -149,7 +149,7 @@ class BillServiceClientIntegrationTest {
         final BillDetails bill = BillDetails.builder()
                 .billId(UUID.randomUUID().toString())
                 .vetId("15")
-                .customerId(2)
+                .customerId("2")
                 .date(null)
                 .amount(100)
                 .visitType("Check")
@@ -172,7 +172,7 @@ class BillServiceClientIntegrationTest {
         final BillDetails bill = BillDetails.builder()
                 .billId(UUID.randomUUID().toString())
                 .vetId("15")
-                .customerId(2)
+                .customerId("2")
                 .date(null)
                 .amount(100)
                 .visitType("Check")
@@ -195,7 +195,7 @@ class BillServiceClientIntegrationTest {
         // Create a sample BillRequestDTO object to send in the request
         BillRequestDTO billRequest = new BillRequestDTO();
         billRequest.setVetId("1");
-        billRequest.setCustomerId(1);
+        billRequest.setCustomerId("1");
         billRequest.setDate(null);
         billRequest.setAmount(100.0);
         billRequest.setVisitType("Check up");

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientIntegrationTest.java
@@ -119,7 +119,7 @@ class BillServiceClientIntegrationTest {
 
         Flux<BillResponseDTO> billResponseDTOMono = billServiceClient.getBillsByOwnerId("1");
         StepVerifier.create(billResponseDTOMono)
-                .expectNextMatches(returnedBillResponseDTO1 -> returnedBillResponseDTO1.getCustomerId() == "1")
+                .expectNextMatches(returnedBillResponseDTO1 -> returnedBillResponseDTO1.getCustomerId().equals("1"))
                 .verifyComplete();
     }
 

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -1,11 +1,9 @@
 package com.petclinic.bffapigateway.presentationlayer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.petclinic.bffapigateway.config.GlobalExceptionHandler;
 import com.petclinic.bffapigateway.domainclientlayer.*;
 import com.petclinic.bffapigateway.dtos.Auth.*;
-import com.petclinic.bffapigateway.dtos.Bills.BillDetails;
 import com.petclinic.bffapigateway.dtos.Bills.BillRequestDTO;
 import com.petclinic.bffapigateway.dtos.Bills.BillResponseDTO;
 import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerRequestDTO;
@@ -13,7 +11,6 @@ import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerResponseDTO;
 import com.petclinic.bffapigateway.dtos.Inventory.*;
 import com.petclinic.bffapigateway.dtos.Inventory.InventoryRequestDTO;
 import com.petclinic.bffapigateway.dtos.Inventory.InventoryResponseDTO;
-import com.petclinic.bffapigateway.dtos.Inventory.InventoryType;
 import com.petclinic.bffapigateway.dtos.Inventory.ProductResponseDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetResponseDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetType;
@@ -22,14 +19,12 @@ import com.petclinic.bffapigateway.dtos.Visits.VisitDetails;
 import com.petclinic.bffapigateway.dtos.Visits.VisitResponseDTO;
 import com.petclinic.bffapigateway.exceptions.ExistingVetNotFoundException;
 import com.petclinic.bffapigateway.exceptions.GenericHttpException;
-import com.petclinic.bffapigateway.exceptions.InvalidInputException;
 import com.petclinic.bffapigateway.utils.Security.Filters.JwtTokenFilter;
 import com.petclinic.bffapigateway.utils.Security.Filters.RoleFilter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
@@ -48,18 +43,10 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.util.MultiValueMapAdapter;
-
-
-import org.springframework.web.reactive.function.BodyInserters;
-
-
-
 
 import org.webjars.NotFoundException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.function.Tuples;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -69,7 +56,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static com.petclinic.bffapigateway.dtos.Inventory.InventoryType.internal;
 
 import static org.junit.Assert.*;
-import static org.assertj.core.util.Lists.list;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -1173,7 +1159,7 @@ class ApiGatewayControllerTest {
 
         entity.setAmount(599);
 
-        entity.setCustomerId(2);
+        entity.setCustomerId("2");
 
         entity.setVisitType("Consultation");
 
@@ -1203,7 +1189,7 @@ class ApiGatewayControllerTest {
     public void getBillsByOwnerId(){
         BillResponseDTO bill = new BillResponseDTO();
         bill.setBillId(UUID.randomUUID().toString());
-        bill.setCustomerId(1);
+        bill.setCustomerId("1");
         bill.setAmount(499);
         bill.setVisitType("Test");
 

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillService.java
@@ -17,11 +17,11 @@ public interface BillService {
 
     Mono<Void> DeleteBill(@RequestParam(value = "billId", required = true) String billId);
 
-    Flux<BillResponseDTO> GetBillsByCustomerId(@RequestParam(value = "customerId", required = true) int customerId);
+    Flux<BillResponseDTO> GetBillsByCustomerId(@RequestParam(value = "customerId", required = true) String customerId);
     Flux<BillResponseDTO> GetBillsByVetId(@RequestParam(value = "vetId", required = true) String vetId);
 
     Flux<Void> DeleteBillsByVetId(@RequestParam(value="vetId", required = true) String vetId);
-    Flux<Void> DeleteBillsByCustomerId(@RequestParam(value="customerId", required = true)int customerId);
+    Flux<Void> DeleteBillsByCustomerId(@RequestParam(value="customerId", required = true)String customerId);
 
     Mono<BillDTO> updateBill(String billId, Mono<BillDTO> billDTOMono);
 

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -71,7 +71,7 @@ public class BillServiceImpl implements BillService{
     }
 
     @Override
-    public Flux<BillResponseDTO> GetBillsByCustomerId(int customerId) {
+    public Flux<BillResponseDTO> GetBillsByCustomerId(String customerId) {
 /**/
         return billRepository.findByCustomerId(customerId).map(EntityDtoUtil::toBillResponseDto);
     }
@@ -85,7 +85,7 @@ public class BillServiceImpl implements BillService{
 
 
     @Override
-    public Flux<Void> DeleteBillsByCustomerId(int customerId){
+    public Flux<Void> DeleteBillsByCustomerId(String customerId){
         return billRepository.deleteBillsByCustomerId(customerId);
 
     }

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -1,6 +1,7 @@
 package com.petclinic.billing.businesslayer;
 
 import com.petclinic.billing.datalayer.*;
+import com.petclinic.billing.domainclientlayer.VetClient;
 import com.petclinic.billing.exceptions.InvalidInputException;
 import com.petclinic.billing.exceptions.NotFoundException;
 import com.petclinic.billing.util.EntityDtoUtil;
@@ -18,6 +19,7 @@ import java.util.List;
 public class BillServiceImpl implements BillService{
 
     private final BillRepository billRepository;
+//    private final VetClient vetClient;
 
     public BillServiceImpl(BillRepository billRepository) {
         this.billRepository = billRepository;
@@ -89,4 +91,11 @@ public class BillServiceImpl implements BillService{
         return billRepository.deleteBillsByCustomerId(customerId);
 
     }
+
+//    private Mono<RequestContextAdd> vetRequestResponse(RequestContextAdd rc) {
+//        return
+//                this.vetClient.getVetByVetId(rc.getVetDTO().getVetId())
+//                        .doOnNext(rc::setVetDTO)
+//                        .thenReturn(rc);
+//    }
 }

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -17,15 +17,13 @@ import java.util.HashMap;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class BillServiceImpl implements BillService{
 
     private final BillRepository billRepository;
-//    private final VetClient vetClient;
-//    private final OwnerClient ownerClient;
+    private final VetClient vetClient;
+    private final OwnerClient ownerClient;
 
-    public BillServiceImpl(BillRepository billRepository) {
-        this.billRepository = billRepository;
-    }
     @Override
     public Mono<BillResponseDTO> GetBill(String billUUID) {
 
@@ -46,6 +44,7 @@ public class BillServiceImpl implements BillService{
 //                    .map(RequestContextAdd::new)
 //                    .flatMap(this::vetRequestResponse)
 //                    .flatMap(this::ownerRequestResponse)
+//                    .map(EntityDtoUtil::toBillEntityRC)
                     .map(EntityDtoUtil::toBillEntity)
                     .doOnNext(e -> e.setBillId(EntityDtoUtil.generateUUIDString()))
                     .flatMap(billRepository::insert)

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -40,9 +40,12 @@ public class BillServiceImpl implements BillService{
     }
 
     @Override
-    public Mono<BillResponseDTO> CreateBill(Mono<BillRequestDTO> model) {
+    public Mono<BillResponseDTO> CreateBill(Mono<BillRequestDTO> billRequestDTO) {
 
-            return model
+            return billRequestDTO
+//                    .map(RequestContextAdd::new)
+//                    .flatMap(this::vetRequestResponse)
+//                    .flatMap(this::ownerRequestResponse)
                     .map(EntityDtoUtil::toBillEntity)
                     .doOnNext(e -> e.setBillId(EntityDtoUtil.generateUUIDString()))
                     .flatMap(billRepository::insert)

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -1,6 +1,7 @@
 package com.petclinic.billing.businesslayer;
 
 import com.petclinic.billing.datalayer.*;
+import com.petclinic.billing.domainclientlayer.OwnerClient;
 import com.petclinic.billing.domainclientlayer.VetClient;
 import com.petclinic.billing.exceptions.InvalidInputException;
 import com.petclinic.billing.exceptions.NotFoundException;
@@ -20,6 +21,7 @@ public class BillServiceImpl implements BillService{
 
     private final BillRepository billRepository;
 //    private final VetClient vetClient;
+//    private final OwnerClient ownerClient;
 
     public BillServiceImpl(BillRepository billRepository) {
         this.billRepository = billRepository;
@@ -96,6 +98,12 @@ public class BillServiceImpl implements BillService{
 //        return
 //                this.vetClient.getVetByVetId(rc.getVetDTO().getVetId())
 //                        .doOnNext(rc::setVetDTO)
+//                        .thenReturn(rc);
+//    }
+//    private Mono<RequestContextAdd> ownerRequestResponse(RequestContextAdd rc) {
+//        return
+//                this.ownerClient.getOwnerByOwnerId(rc.getOwnerResponseDTO().getOwnerId())
+//                        .doOnNext(rc::setOwnerResponseDTO)
 //                        .thenReturn(rc);
 //    }
 }

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -1,28 +1,22 @@
 package com.petclinic.billing.businesslayer;
 
 import com.petclinic.billing.datalayer.*;
-import com.petclinic.billing.domainclientlayer.OwnerClient;
-import com.petclinic.billing.domainclientlayer.VetClient;
-import com.petclinic.billing.exceptions.InvalidInputException;
-import com.petclinic.billing.exceptions.NotFoundException;
+//import com.petclinic.billing.domainclientlayer.OwnerClient;
+//import com.petclinic.billing.domainclientlayer.VetClient;
 import com.petclinic.billing.util.EntityDtoUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.dao.DuplicateKeyException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.HashMap;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class BillServiceImpl implements BillService{
 
     private final BillRepository billRepository;
-    private final VetClient vetClient;
-    private final OwnerClient ownerClient;
+//    private final VetClient vetClient;
+//    private final OwnerClient ownerClient;
 
     @Override
     public Mono<BillResponseDTO> GetBill(String billUUID) {

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/RequestContextAdd.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/RequestContextAdd.java
@@ -1,0 +1,22 @@
+package com.petclinic.billing.businesslayer;
+
+import com.petclinic.billing.datalayer.Bill;
+import com.petclinic.billing.datalayer.BillRequestDTO;
+import com.petclinic.billing.datalayer.VetDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestContextAdd {
+
+    private BillRequestDTO billRequestDTO;
+    private Bill bill;
+    private VetDTO vetDTO;
+
+    public RequestContextAdd(BillRequestDTO billRequestDTO) {
+        this.billRequestDTO = billRequestDTO;
+    }
+}

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/RequestContextAdd.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/RequestContextAdd.java
@@ -2,6 +2,7 @@ package com.petclinic.billing.businesslayer;
 
 import com.petclinic.billing.datalayer.Bill;
 import com.petclinic.billing.datalayer.BillRequestDTO;
+import com.petclinic.billing.datalayer.OwnerResponseDTO;
 import com.petclinic.billing.datalayer.VetDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -15,6 +16,7 @@ public class RequestContextAdd {
     private BillRequestDTO billRequestDTO;
     private Bill bill;
     private VetDTO vetDTO;
+    private OwnerResponseDTO ownerResponseDTO;
 
     public RequestContextAdd(BillRequestDTO billRequestDTO) {
         this.billRequestDTO = billRequestDTO;

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 
-import java.time.LocalDate;
 import java.util.Date;
 
 @Data
@@ -20,6 +19,9 @@ public class Bill {
     private int customerId;
     private String visitType;
     private String vetId;
-    private LocalDate date;
+    private String vetFirstName;
+    private String vetLastName;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private Date visitDate = new Date();
     private double amount;
 }

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
@@ -15,7 +15,7 @@ public class Bill {
     @Id
     private String id;
     private String billId;              // Should be renamed to BillUUID
-    private int customerId;
+    private String customerId;
     private String visitType;
     private String vetId;
     private String vetFirstName;

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
@@ -1,10 +1,9 @@
 package com.petclinic.billing.datalayer;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 @Data
 @ToString
@@ -21,7 +20,6 @@ public class Bill {
     private String vetId;
     private String vetFirstName;
     private String vetLastName;
-    @JsonFormat(pattern = "yyyy-MM-dd")
-    private Date visitDate = new Date();
+    private LocalDate date;
     private double amount;
 }

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillDTO.java
@@ -1,10 +1,8 @@
 package com.petclinic.billing.datalayer;
 
 import lombok.*;
-import org.springframework.lang.Nullable;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 @Data
 @ToString
@@ -14,13 +12,13 @@ import java.util.Date;
 public class BillDTO {
 
     private String billId;
-    private int customerId;
+    private String customerId;
     private String visitType;
     private String vetId;
     private LocalDate date;
     private double amount;
 
-    public BillDTO(int customerId, String visitType, String vetId, LocalDate date, double amount) {
+    public BillDTO(String customerId, String visitType, String vetId, LocalDate date, double amount) {
         this.customerId = customerId;
         this.visitType = visitType;
         this.vetId = vetId;

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillRepository.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillRepository.java
@@ -15,7 +15,7 @@ public interface BillRepository extends ReactiveMongoRepository<Bill, String> {
     Mono<Bill> findByBillId(String billId);
 
     @Transactional(readOnly = true)
-    Flux<Bill> findByCustomerId(int customerId);
+    Flux<Bill> findByCustomerId(String customerId);
 
     @Transactional(readOnly = true)
     Flux<Bill> findByVetId(String vetId);
@@ -23,6 +23,6 @@ public interface BillRepository extends ReactiveMongoRepository<Bill, String> {
     Mono<Void>deleteBillByBillId(String billId);
 
     Flux<Void> deleteBillsByVetId(String vetId);
-    Flux<Void> deleteBillsByCustomerId(int customerId);
+    Flux<Void> deleteBillsByCustomerId(String customerId);
 
 }

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillRequestDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillRequestDTO.java
@@ -3,7 +3,6 @@ package com.petclinic.billing.datalayer;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 @Data
 @ToString
@@ -11,13 +10,13 @@ import java.util.Date;
 @NoArgsConstructor
 public class BillRequestDTO {
 
-    private int customerId;
+    private String customerId;
     private String visitType;
     private String vetId;
     private LocalDate date;
     private double amount;
 
-    public BillRequestDTO(int customerId, String visitType, String vetId, LocalDate date, double amount) {
+    public BillRequestDTO(String customerId, String visitType, String vetId, LocalDate date, double amount) {
         this.customerId = customerId;
         this.visitType = visitType;
         this.vetId = vetId;

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillResponseDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillResponseDTO.java
@@ -3,7 +3,6 @@ package com.petclinic.billing.datalayer;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 @Data
 @ToString
@@ -13,13 +12,13 @@ import java.util.Date;
 public class BillResponseDTO {
 
     private String billId;
-    private int customerId;
+    private String customerId;
     private String visitType;
     private String vetId;
     private LocalDate date;
     private double amount;
 
-    public BillResponseDTO(int customerId, String visitType, String vetId, LocalDate date, double amount) {
+    public BillResponseDTO(String customerId, String visitType, String vetId, LocalDate date, double amount) {
         this.customerId = customerId;
         this.visitType = visitType;
         this.vetId = vetId;

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/DataSetupService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/DataSetupService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.sql.Date;
 import java.time.LocalDate;
 
 
@@ -22,15 +21,15 @@ public class DataSetupService implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
 //       BillRequestDTO b1 = new BillRequestDTO( "1", "general", "1", LocalDate.of(2021,9,19),59.99);
-        BillRequestDTO b1 = new BillRequestDTO( "f470653d-05c5-4c45-b7a0-7d70f003d2ac", "general", "1", LocalDate.of(2021,9,19),59.99);
+        BillRequestDTO b1 = new BillRequestDTO( "1", "general", "1", LocalDate.of(2021,9,19),59.99);
 //        BillRequestDTO b3 = new BillRequestDTO( "3", "operation", "1", LocalDate.of(2021,9,21), 199.99);
-        BillRequestDTO b3 = new BillRequestDTO( "3f59dca2-903e-495c-90c3-7f4d01f3a2aa", "operation", "1", LocalDate.of(2021,9,21), 199.99);
+        BillRequestDTO b3 = new BillRequestDTO( "3", "operation", "1", LocalDate.of(2021,9,21), 199.99);
 //        BillRequestDTO b4 = new BillRequestDTO( "4", "injury", "1",  LocalDate.of(2021,9,22), 199.99);
-        BillRequestDTO b4 = new BillRequestDTO( "a6e0e5b0-5f60-45f0-8ac7-becd8b330486", "injury", "1",  LocalDate.of(2021,9,22), 199.99);
+        BillRequestDTO b4 = new BillRequestDTO( "4", "injury", "1",  LocalDate.of(2021,9,22), 199.99);
 //        BillRequestDTO b2 = new BillRequestDTO( "2", "operation", "2", LocalDate.of(2021,9,20), 199.99);
-        BillRequestDTO b2 = new BillRequestDTO( "e6c7398e-8ac4-4e10-9ee0-03ef33f0361a", "operation", "2", LocalDate.of(2021,9,20), 199.99);
+        BillRequestDTO b2 = new BillRequestDTO( "2", "operation", "2", LocalDate.of(2021,9,20), 199.99);
 //        BillRequestDTO b5 = new BillRequestDTO( "5", "chronic", "3",  LocalDate.of(2021,9,23), 199.99);
-        BillRequestDTO b5 = new BillRequestDTO( "c6a0fb9d-fc6f-4c21-95fc-4f5e7311d0e2", "chronic", "3",  LocalDate.of(2021,9,23), 199.99);
+        BillRequestDTO b5 = new BillRequestDTO( "5", "chronic", "3",  LocalDate.of(2021,9,23), 199.99);
 
         Flux.just(b1,b2,b3,b4,b5)
                 .flatMap(b -> billService.CreateBill(Mono.just(b))

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/DataSetupService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/DataSetupService.java
@@ -21,11 +21,16 @@ public class DataSetupService implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-       BillRequestDTO b1 = new BillRequestDTO( 1, "general", "1", LocalDate.of(2021,9,19),59.99);
-        BillRequestDTO b3 = new BillRequestDTO( 3, "operation", "1", LocalDate.of(2021,9,21), 199.99);
-        BillRequestDTO b4 = new BillRequestDTO( 4, "injury", "1",  LocalDate.of(2021,9,22), 199.99);
-        BillRequestDTO b2 = new BillRequestDTO( 2, "operation", "2", LocalDate.of(2021,9,20), 199.99);
-        BillRequestDTO b5 = new BillRequestDTO( 5, "chronic", "3",  LocalDate.of(2021,9,23), 199.99);
+//       BillRequestDTO b1 = new BillRequestDTO( "1", "general", "1", LocalDate.of(2021,9,19),59.99);
+        BillRequestDTO b1 = new BillRequestDTO( "f470653d-05c5-4c45-b7a0-7d70f003d2ac", "general", "1", LocalDate.of(2021,9,19),59.99);
+//        BillRequestDTO b3 = new BillRequestDTO( "3", "operation", "1", LocalDate.of(2021,9,21), 199.99);
+        BillRequestDTO b3 = new BillRequestDTO( "3f59dca2-903e-495c-90c3-7f4d01f3a2aa", "operation", "1", LocalDate.of(2021,9,21), 199.99);
+//        BillRequestDTO b4 = new BillRequestDTO( "4", "injury", "1",  LocalDate.of(2021,9,22), 199.99);
+        BillRequestDTO b4 = new BillRequestDTO( "a6e0e5b0-5f60-45f0-8ac7-becd8b330486", "injury", "1",  LocalDate.of(2021,9,22), 199.99);
+//        BillRequestDTO b2 = new BillRequestDTO( "2", "operation", "2", LocalDate.of(2021,9,20), 199.99);
+        BillRequestDTO b2 = new BillRequestDTO( "e6c7398e-8ac4-4e10-9ee0-03ef33f0361a", "operation", "2", LocalDate.of(2021,9,20), 199.99);
+//        BillRequestDTO b5 = new BillRequestDTO( "5", "chronic", "3",  LocalDate.of(2021,9,23), 199.99);
+        BillRequestDTO b5 = new BillRequestDTO( "c6a0fb9d-fc6f-4c21-95fc-4f5e7311d0e2", "chronic", "3",  LocalDate.of(2021,9,23), 199.99);
 
         Flux.just(b1,b2,b3,b4,b5)
                 .flatMap(b -> billService.CreateBill(Mono.just(b))

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/OwnerResponseDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/OwnerResponseDTO.java
@@ -1,0 +1,25 @@
+package com.petclinic.billing.datalayer;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OwnerResponseDTO {
+
+    private String ownerId;
+    private String firstName;
+    private String lastName;
+    private String address;
+    private String city;
+    private String telephone;
+    private String photoId;
+    private Photo photo;
+    private List<PetDTO> pets;
+}

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/PetDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/PetDTO.java
@@ -1,0 +1,25 @@
+package com.petclinic.billing.datalayer;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PetDTO {
+
+    private String id;
+    private String ownerId;
+    private String name;
+    private Date birthDate;
+    private String petTypeId;
+    private String photoId;
+//    private PetType petType;
+    private Photo photo;
+
+}

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/PetType.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/PetType.java
@@ -4,22 +4,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.Date;
+import org.springframework.data.annotation.Id;
 
 @Data
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class PetDTO {
+@Builder
+public class PetType {
 
+    @Id
     private String id;
-    private String ownerId;
     private String name;
-    private Date birthDate;
-    private String petTypeId;
-    private String photoId;
-    private PetType petType;
-    private Photo photo;
 
 }

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/Photo.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/Photo.java
@@ -1,0 +1,21 @@
+package com.petclinic.billing.datalayer;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@Data
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class Photo {
+
+    @Id
+    private String id;
+    private String name;
+    private String type;
+    private String photo;
+
+}

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/SpecialtyDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/SpecialtyDTO.java
@@ -1,0 +1,16 @@
+package com.petclinic.billing.datalayer;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SpecialtyDTO {
+    private String specialtyId;
+    private String name;
+}

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/VetDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/VetDTO.java
@@ -1,0 +1,38 @@
+package com.petclinic.billing.datalayer;
+/**
+ @author Kamilah Hatteea & Brandon Levis : Vet-Service
+  * Worked together with (Code with Friends) on IntelliJ IDEA
+  * <p>
+  * User: @Kamilah Hatteea
+  * Date: 2022-09-22
+  * Ticket: feat(VVS-CPC-554): edit veterinarian
+  * User: Brandon Levis
+  * Date: 2022-09-22
+  * Ticket: feat(VVS-CPC-553): add veterinarian
+ */
+
+import lombok.*;
+
+import java.util.Set;
+
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VetDTO {
+    private String vetId;
+    private String vetBillId;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String phoneNumber;
+    private String imageId;
+    private String resume;
+    private String workday;
+    private boolean active;
+    private Set<SpecialtyDTO> specialties;
+
+
+}

--- a/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/OwnerClient.java
+++ b/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/OwnerClient.java
@@ -1,27 +1,27 @@
-package com.petclinic.billing.domainclientlayer;
-
-import com.petclinic.billing.datalayer.OwnerResponseDTO;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
-
-@Service
-public class OwnerClient {
-    private final WebClient webClient;
-    private final String ownerClientServiceBaseURL;
-
-    private OwnerClient(@Value("${app.customers-service.host}") String ownerServiceHost,
-                        @Value("${app.customers-service.port}") String ownerServicePort) {
-        ownerClientServiceBaseURL = "http://" + ownerServiceHost + ":" + ownerServicePort + "/owners";
-        this.webClient = WebClient.builder()
-                .baseUrl(ownerClientServiceBaseURL).build();
-    }
-    public Mono<OwnerResponseDTO> getOwnerByOwnerId(final String ownerId) {
-        return this.webClient
-                .get()
-                .uri("/{ownerId}", ownerId)
-                .retrieve()
-                .bodyToMono(OwnerResponseDTO.class);
-    }
-}
+//package com.petclinic.billing.domainclientlayer;
+//
+//import com.petclinic.billing.datalayer.OwnerResponseDTO;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.stereotype.Service;
+//import org.springframework.web.reactive.function.client.WebClient;
+//import reactor.core.publisher.Mono;
+//
+//@Service
+//public class OwnerClient {
+//    private final WebClient webClient;
+//    private final String ownerClientServiceBaseURL;
+//
+//    private OwnerClient(@Value("${app.customers-service.host}") String ownerServiceHost,
+//                        @Value("${app.customers-service.port}") String ownerServicePort) {
+//        ownerClientServiceBaseURL = "http://" + ownerServiceHost + ":" + ownerServicePort + "/owners";
+//        this.webClient = WebClient.builder()
+//                .baseUrl(ownerClientServiceBaseURL).build();
+//    }
+//    public Mono<OwnerResponseDTO> getOwnerByOwnerId(final String ownerId) {
+//        return this.webClient
+//                .get()
+//                .uri("/{ownerId}", ownerId)
+//                .retrieve()
+//                .bodyToMono(OwnerResponseDTO.class);
+//    }
+//}

--- a/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/OwnerClient.java
+++ b/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/OwnerClient.java
@@ -1,0 +1,27 @@
+package com.petclinic.billing.domainclientlayer;
+
+import com.petclinic.billing.datalayer.OwnerResponseDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class OwnerClient {
+    private final WebClient webClient;
+    private final String ownerClientServiceBaseURL;
+
+    private OwnerClient(@Value("${app.owners-service.host}") String ownerServiceHost,
+                        @Value("${app.owners-service.port}") String ownerServicePort) {
+        ownerClientServiceBaseURL = "http://" + ownerServiceHost + ":" + ownerServicePort + "/owners";
+        this.webClient = WebClient.builder()
+                .baseUrl(ownerClientServiceBaseURL).build();
+    }
+    public Mono<OwnerResponseDTO> getOwnerByOwnerId(final String ownerId) {
+        return this.webClient
+                .get()
+                .uri("/{ownerId}", ownerId)
+                .retrieve()
+                .bodyToMono(OwnerResponseDTO.class);
+    }
+}

--- a/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/OwnerClient.java
+++ b/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/OwnerClient.java
@@ -1,27 +1,27 @@
-//package com.petclinic.billing.domainclientlayer;
-//
-//import com.petclinic.billing.datalayer.OwnerResponseDTO;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.stereotype.Service;
-//import org.springframework.web.reactive.function.client.WebClient;
-//import reactor.core.publisher.Mono;
-//
-//@Service
-//public class OwnerClient {
-//    private final WebClient webClient;
-//    private final String ownerClientServiceBaseURL;
-//
-//    private OwnerClient(@Value("${app.owners-service.host}") String ownerServiceHost,
-//                        @Value("${app.owners-service.port}") String ownerServicePort) {
-//        ownerClientServiceBaseURL = "http://" + ownerServiceHost + ":" + ownerServicePort + "/owners";
-//        this.webClient = WebClient.builder()
-//                .baseUrl(ownerClientServiceBaseURL).build();
-//    }
-//    public Mono<OwnerResponseDTO> getOwnerByOwnerId(final String ownerId) {
-//        return this.webClient
-//                .get()
-//                .uri("/{ownerId}", ownerId)
-//                .retrieve()
-//                .bodyToMono(OwnerResponseDTO.class);
-//    }
-//}
+package com.petclinic.billing.domainclientlayer;
+
+import com.petclinic.billing.datalayer.OwnerResponseDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class OwnerClient {
+    private final WebClient webClient;
+    private final String ownerClientServiceBaseURL;
+
+    private OwnerClient(@Value("${app.customers-service.host}") String ownerServiceHost,
+                        @Value("${app.customers-service.port}") String ownerServicePort) {
+        ownerClientServiceBaseURL = "http://" + ownerServiceHost + ":" + ownerServicePort + "/owners";
+        this.webClient = WebClient.builder()
+                .baseUrl(ownerClientServiceBaseURL).build();
+    }
+    public Mono<OwnerResponseDTO> getOwnerByOwnerId(final String ownerId) {
+        return this.webClient
+                .get()
+                .uri("/{ownerId}", ownerId)
+                .retrieve()
+                .bodyToMono(OwnerResponseDTO.class);
+    }
+}

--- a/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/OwnerClient.java
+++ b/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/OwnerClient.java
@@ -1,27 +1,27 @@
-package com.petclinic.billing.domainclientlayer;
-
-import com.petclinic.billing.datalayer.OwnerResponseDTO;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
-
-@Service
-public class OwnerClient {
-    private final WebClient webClient;
-    private final String ownerClientServiceBaseURL;
-
-    private OwnerClient(@Value("${app.owners-service.host}") String ownerServiceHost,
-                        @Value("${app.owners-service.port}") String ownerServicePort) {
-        ownerClientServiceBaseURL = "http://" + ownerServiceHost + ":" + ownerServicePort + "/owners";
-        this.webClient = WebClient.builder()
-                .baseUrl(ownerClientServiceBaseURL).build();
-    }
-    public Mono<OwnerResponseDTO> getOwnerByOwnerId(final String ownerId) {
-        return this.webClient
-                .get()
-                .uri("/{ownerId}", ownerId)
-                .retrieve()
-                .bodyToMono(OwnerResponseDTO.class);
-    }
-}
+//package com.petclinic.billing.domainclientlayer;
+//
+//import com.petclinic.billing.datalayer.OwnerResponseDTO;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.stereotype.Service;
+//import org.springframework.web.reactive.function.client.WebClient;
+//import reactor.core.publisher.Mono;
+//
+//@Service
+//public class OwnerClient {
+//    private final WebClient webClient;
+//    private final String ownerClientServiceBaseURL;
+//
+//    private OwnerClient(@Value("${app.owners-service.host}") String ownerServiceHost,
+//                        @Value("${app.owners-service.port}") String ownerServicePort) {
+//        ownerClientServiceBaseURL = "http://" + ownerServiceHost + ":" + ownerServicePort + "/owners";
+//        this.webClient = WebClient.builder()
+//                .baseUrl(ownerClientServiceBaseURL).build();
+//    }
+//    public Mono<OwnerResponseDTO> getOwnerByOwnerId(final String ownerId) {
+//        return this.webClient
+//                .get()
+//                .uri("/{ownerId}", ownerId)
+//                .retrieve()
+//                .bodyToMono(OwnerResponseDTO.class);
+//    }
+//}

--- a/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/VetClient.java
+++ b/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/VetClient.java
@@ -1,32 +1,32 @@
-package com.petclinic.billing.domainclientlayer;
-
-import com.petclinic.billing.datalayer.VetDTO;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
-
-@Service
-public class VetClient {
-
-    private final WebClient webClient;
-
-    private final String vetClientServiceBaseURL;
-
-    private VetClient(@Value("${app.vet-service.host}") String vetServiceHost,
-                      @Value("${app.vet-service.port}") String vetServicePort) {
-        vetClientServiceBaseURL = "http://" + vetServiceHost + ":" + vetServicePort + "/vets";
-
-        this.webClient = WebClient.builder()
-                .baseUrl(vetClientServiceBaseURL)
-                .build();
-    }
-
-    public Mono<VetDTO> getVetByVetId(final String vetId) {
-        return this.webClient
-                .get()
-                .uri("/{vetId}", vetId)
-                .retrieve()
-                .bodyToMono(VetDTO.class);
-    }
-}
+//package com.petclinic.billing.domainclientlayer;
+//
+//import com.petclinic.billing.datalayer.VetDTO;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.stereotype.Service;
+//import org.springframework.web.reactive.function.client.WebClient;
+//import reactor.core.publisher.Mono;
+//
+//@Service
+//public class VetClient {
+//
+//    private final WebClient webClient;
+//
+//    private final String vetClientServiceBaseURL;
+//
+//    private VetClient(@Value("${app.vet-service.host}") String vetServiceHost,
+//                      @Value("${app.vet-service.port}") String vetServicePort) {
+//        vetClientServiceBaseURL = "http://" + vetServiceHost + ":" + vetServicePort + "/vets";
+//
+//        this.webClient = WebClient.builder()
+//                .baseUrl(vetClientServiceBaseURL)
+//                .build();
+//    }
+//
+//    public Mono<VetDTO> getVetByVetId(final String vetId) {
+//        return this.webClient
+//                .get()
+//                .uri("/{vetId}", vetId)
+//                .retrieve()
+//                .bodyToMono(VetDTO.class);
+//    }
+//}

--- a/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/VetClient.java
+++ b/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/VetClient.java
@@ -1,32 +1,32 @@
-//package com.petclinic.billing.domainclientlayer;
-//
-//import com.petclinic.billing.datalayer.VetDTO;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.stereotype.Service;
-//import org.springframework.web.reactive.function.client.WebClient;
-//import reactor.core.publisher.Mono;
-//
-//@Service
-//public class VetClient {
-//
-//    private final WebClient webClient;
-//
-//    private final String vetClientServiceBaseURL;
-//
-//    private VetClient(@Value("${app.vets-service.host}") String vetServiceHost,
-//                      @Value("${app.vets-service.port}") String vetServicePort) {
-//        vetClientServiceBaseURL = "http://" + vetServiceHost + ":" + vetServicePort + "/vets";
-//
-//        this.webClient = WebClient.builder()
-//                .baseUrl(vetClientServiceBaseURL)
-//                .build();
-//    }
-//
-//    public Mono<VetDTO> getVetByVetId(final String vetId) {
-//        return this.webClient
-//                .get()
-//                .uri("/{vetId}", vetId)
-//                .retrieve()
-//                .bodyToMono(VetDTO.class);
-//    }
-//}
+package com.petclinic.billing.domainclientlayer;
+
+import com.petclinic.billing.datalayer.VetDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class VetClient {
+
+    private final WebClient webClient;
+
+    private final String vetClientServiceBaseURL;
+
+    private VetClient(@Value("${app.vet-service.host}") String vetServiceHost,
+                      @Value("${app.vet-service.port}") String vetServicePort) {
+        vetClientServiceBaseURL = "http://" + vetServiceHost + ":" + vetServicePort + "/vets";
+
+        this.webClient = WebClient.builder()
+                .baseUrl(vetClientServiceBaseURL)
+                .build();
+    }
+
+    public Mono<VetDTO> getVetByVetId(final String vetId) {
+        return this.webClient
+                .get()
+                .uri("/{vetId}", vetId)
+                .retrieve()
+                .bodyToMono(VetDTO.class);
+    }
+}

--- a/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/VetClient.java
+++ b/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/VetClient.java
@@ -1,32 +1,32 @@
-package com.petclinic.billing.domainclientlayer;
-
-import com.petclinic.billing.datalayer.VetDTO;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
-
-@Service
-public class VetClient {
-
-    private final WebClient webClient;
-
-    private final String vetClientServiceBaseURL;
-
-    private VetClient(@Value("${app.vets-service.host}") String vetServiceHost,
-                      @Value("${app.vets-service.port}") String vetServicePort) {
-        vetClientServiceBaseURL = "http://" + vetServiceHost + ":" + vetServicePort + "/vets";
-
-        this.webClient = WebClient.builder()
-                .baseUrl(vetClientServiceBaseURL)
-                .build();
-    }
-
-    public Mono<VetDTO> getVetByVetId(final String vetId) {
-        return this.webClient
-                .get()
-                .uri("/{vetId}", vetId)
-                .retrieve()
-                .bodyToMono(VetDTO.class);
-    }
-}
+//package com.petclinic.billing.domainclientlayer;
+//
+//import com.petclinic.billing.datalayer.VetDTO;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.stereotype.Service;
+//import org.springframework.web.reactive.function.client.WebClient;
+//import reactor.core.publisher.Mono;
+//
+//@Service
+//public class VetClient {
+//
+//    private final WebClient webClient;
+//
+//    private final String vetClientServiceBaseURL;
+//
+//    private VetClient(@Value("${app.vets-service.host}") String vetServiceHost,
+//                      @Value("${app.vets-service.port}") String vetServicePort) {
+//        vetClientServiceBaseURL = "http://" + vetServiceHost + ":" + vetServicePort + "/vets";
+//
+//        this.webClient = WebClient.builder()
+//                .baseUrl(vetClientServiceBaseURL)
+//                .build();
+//    }
+//
+//    public Mono<VetDTO> getVetByVetId(final String vetId) {
+//        return this.webClient
+//                .get()
+//                .uri("/{vetId}", vetId)
+//                .retrieve()
+//                .bodyToMono(VetDTO.class);
+//    }
+//}

--- a/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/VetClient.java
+++ b/billing-service/src/main/java/com/petclinic/billing/domainclientlayer/VetClient.java
@@ -1,0 +1,32 @@
+package com.petclinic.billing.domainclientlayer;
+
+import com.petclinic.billing.datalayer.VetDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class VetClient {
+
+    private final WebClient webClient;
+
+    private final String vetClientServiceBaseURL;
+
+    private VetClient(@Value("${app.vets-service.host}") String vetServiceHost,
+                      @Value("${app.vets-service.port}") String vetServicePort) {
+        vetClientServiceBaseURL = "http://" + vetServiceHost + ":" + vetServicePort + "/vets";
+
+        this.webClient = WebClient.builder()
+                .baseUrl(vetClientServiceBaseURL)
+                .build();
+    }
+
+    public Mono<VetDTO> getVetByVetId(final String vetId) {
+        return this.webClient
+                .get()
+                .uri("/{vetId}", vetId)
+                .retrieve()
+                .bodyToMono(VetDTO.class);
+    }
+}

--- a/billing-service/src/main/java/com/petclinic/billing/presentationlayer/BillResource.java
+++ b/billing-service/src/main/java/com/petclinic/billing/presentationlayer/BillResource.java
@@ -45,7 +45,7 @@ public class BillResource {
     }
 
     @GetMapping(value = "/bills/customer/{customerId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<BillResponseDTO> getBillsByCustomerId(@PathVariable("customerId") int customerId)
+    public Flux<BillResponseDTO> getBillsByCustomerId(@PathVariable("customerId") String customerId)
     {
         return SERVICE.GetBillsByCustomerId(customerId);
     }
@@ -72,7 +72,7 @@ public class BillResource {
 
     @DeleteMapping (value = "/bills/customer/{customerId}")
     @ResponseStatus (HttpStatus.NO_CONTENT)
-    public Flux<Void> deleteBillsByCustomerId (@PathVariable("customerId") int customerId){
+    public Flux<Void> deleteBillsByCustomerId (@PathVariable("customerId") String customerId){
         return SERVICE.DeleteBillsByCustomerId(customerId);
     }
 

--- a/billing-service/src/main/java/com/petclinic/billing/util/EntityDtoUtil.java
+++ b/billing-service/src/main/java/com/petclinic/billing/util/EntityDtoUtil.java
@@ -1,6 +1,7 @@
 package com.petclinic.billing.util;
 
 
+import com.petclinic.billing.businesslayer.RequestContextAdd;
 import com.petclinic.billing.datalayer.Bill;
 import com.petclinic.billing.datalayer.BillDTO;
 import com.petclinic.billing.datalayer.BillRequestDTO;
@@ -36,6 +37,20 @@ public class EntityDtoUtil {
         return bill;
     }
 
+//    public static Bill toBillEntityRC(RequestContextAdd rc){
+//        return Bill.builder()
+//                .billId(generateUUIDString())
+//                .amount(rc.getBillRequestDTO().getAmount())
+//                .visitDate(rc.getBillRequestDTO().getDate())
+//                .visitType(rc.getBillRequestDTO().getVisitType())
+//                .ownerId(rc.getOwnerResponseDTO().getOwnerId())
+//                .ownerFirstName(rc.getOwnerResponseDTO().getFirstName())
+//                .ownerLastName(rc.getOwnerResponseDTO().getLastName())
+//                .vetId(rc.getVetDTO().getVetId())
+//                .vetFirstName(rc.getVetDTO().getFirstName())
+//                .vetLastName(rc.getVetDTO().getLastName())
+//                .build();
+//    }
 
     public static String generateUUIDString(){
         return UUID.randomUUID().toString();

--- a/billing-service/src/main/resources/application.yml
+++ b/billing-service/src/main/resources/application.yml
@@ -5,7 +5,6 @@ logging:
     root: INFO
     com.petclinic: DEBUG
 
-
 spring:
   config:
     activate:

--- a/billing-service/src/main/resources/application.yml
+++ b/billing-service/src/main/resources/application.yml
@@ -18,6 +18,13 @@ spring:
     embedded:
       version: 4.0.21
 
+app:
+  vet-service:
+    host: localhost
+    port: 7002
+  customers-service:
+    host: localhost
+    port: 7003
 ---
 spring:
   config:

--- a/billing-service/src/main/resources/application.yml
+++ b/billing-service/src/main/resources/application.yml
@@ -50,7 +50,19 @@ spring:
       username: root
       password: password
       authentication-database: admin
-
+#server.port: 8080
+#app:
+#  vet-service:
+#    host: localhost
+#    port: 8080
+#  customers-service:
+#    host: localhost
+#    port: 8080
+#
+#logging:
+#  level:
+#    root: INFO
+#    com.petclinic: DEBUG
 
 #server:
 #  error:

--- a/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
@@ -151,7 +151,7 @@ public class BillServiceImplTest {
     @Test
     public void test_DeleteBillsByCustomerId(){
         Bill billEntity = buildBill();
-        when(repo.deleteBillsByCustomerId(anyInt())).thenReturn(Flux.empty());
+        when(repo.deleteBillsByCustomerId(anyString())).thenReturn(Flux.empty());
         Flux<Void> deletedObj = billService.DeleteBillsByCustomerId(billEntity.getCustomerId());
 
         StepVerifier.create(deletedObj)
@@ -163,9 +163,9 @@ public class BillServiceImplTest {
 
         Bill billEntity = buildBill();
 
-        int CUSTOMER_ID = billEntity.getCustomerId();
+        String CUSTOMER_ID = billEntity.getCustomerId();
 
-        when(repo.findByCustomerId(anyInt())).thenReturn(Flux.just(billEntity));
+        when(repo.findByCustomerId(anyString())).thenReturn(Flux.just(billEntity));
 
         Flux<BillResponseDTO> billDTOMono = billService.GetBillsByCustomerId(CUSTOMER_ID);
 
@@ -208,7 +208,7 @@ public class BillServiceImplTest {
                 .toLocalDate();;
 
 
-        return Bill.builder().id("Id").billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
+        return Bill.builder().id("Id").billId("BillUUID").customerId("1").vetId("1").visitType("Test Type").date(date).amount(13.37).build();
     }
 
     private BillDTO buildBillDTO(){
@@ -220,7 +220,7 @@ public class BillServiceImplTest {
                 .toLocalDate();;
 
 
-        return BillDTO.builder().billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
+        return BillDTO.builder().billId("BillUUID").customerId("1").vetId("1").visitType("Test Type").date(date).amount(13.37).build();
     }
 
     private BillRequestDTO buildBillRequestDTO(){
@@ -232,7 +232,7 @@ public class BillServiceImplTest {
                 .toLocalDate();;
 
 
-        return BillRequestDTO.builder().customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
+        return BillRequestDTO.builder().customerId("1").vetId("1").visitType("Test Type").date(date).amount(13.37).build();
     }
 
 

--- a/billing-service/src/test/java/com/petclinic/billing/datalayer/BillServicePersistenceTests.java
+++ b/billing-service/src/test/java/com/petclinic/billing/datalayer/BillServicePersistenceTests.java
@@ -166,6 +166,6 @@ public class BillServicePersistenceTests {
                 .toLocalDate();;
 
 
-        return Bill.builder().id("Id").billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
+        return Bill.builder().id("Id").billId("BillUUID").customerId("1").vetId("1").visitType("Test Type").date(date).amount(13.37).build();
     }
 }

--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillResourceIntegrationTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillResourceIntegrationTest.java
@@ -2,15 +2,12 @@ package com.petclinic.billing.presentationlayer;
 
 import com.petclinic.billing.datalayer.Bill;
 import com.petclinic.billing.datalayer.BillRepository;
-import com.petclinic.billing.datalayer.BillResponseDTO;
-import com.petclinic.billing.http.HttpErrorInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.test.StepVerifier;
@@ -19,11 +16,9 @@ import static reactor.core.publisher.Mono.just;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"spring.data.mongodb.port: 0"})
 @AutoConfigureWebTestClient
@@ -289,9 +284,9 @@ class BillResourceIntegrationTest {
         calendar.set(2022, Calendar.SEPTEMBER, 25);
         LocalDate date = calendar.getTime().toInstant()
                 .atZone(ZoneId.systemDefault())
-                .toLocalDate();;
+                .toLocalDate();
 
 
-        return Bill.builder().id("Id").billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
+        return Bill.builder().id("Id").billId("BillUUID").customerId("1").vetId("1").visitType("Test Type").date(date).amount(13.37).build();
     }
 }

--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillResourceUnitTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillResourceUnitTest.java
@@ -1,8 +1,6 @@
 package com.petclinic.billing.presentationlayer;
 
 import com.petclinic.billing.businesslayer.BillService;
-import com.petclinic.billing.datalayer.Bill;
-import com.petclinic.billing.datalayer.BillDTO;
 import com.petclinic.billing.datalayer.BillResponseDTO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -10,13 +8,10 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -24,21 +19,15 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static reactor.core.publisher.Mono.just;
-
 
 @WebFluxTest(controllers = BillResource.class)
 class BillResourceUnitTest {
 
-//    private BillDTO dto = buildBillDTO();
-    private BillResponseDTO responseDTO =buildBillResponseDTO();
+    private BillResponseDTO responseDTO = buildBillResponseDTO();
     private final String BILL_ID_OK = responseDTO.getBillId();
 
-    private final int CUSTOMER_ID_OK = responseDTO.getCustomerId();
+    private final String CUSTOMER_ID_OK = responseDTO.getCustomerId();
     private final String VET_ID_OK = responseDTO.getVetId();
 
     @Autowired
@@ -94,7 +83,7 @@ class BillResourceUnitTest {
     @Test
     void getBillByCustomerId() {
 
-        when(billService.GetBillsByCustomerId(anyInt())).thenReturn(Flux.just(responseDTO));
+        when(billService.GetBillsByCustomerId(anyString())).thenReturn(Flux.just(responseDTO));
 
         client.get()
                 .uri("/bills/customer/" + responseDTO.getCustomerId())
@@ -165,7 +154,7 @@ class BillResourceUnitTest {
     @Test
     void deleteBillsByCustomerId() {
 
-        when(billService.DeleteBillsByCustomerId(anyInt())).thenReturn(Flux.empty());
+        when(billService.DeleteBillsByCustomerId(anyString())).thenReturn(Flux.empty());
 
         client.delete()
                 .uri("/bills/customer/" + responseDTO.getCustomerId())
@@ -195,9 +184,9 @@ class BillResourceUnitTest {
         calendar.set(2022, Calendar.SEPTEMBER, 25);
         LocalDate date = calendar.getTime().toInstant()
                 .atZone(ZoneId.systemDefault())
-                .toLocalDate();;
+                .toLocalDate();
 
 
-        return BillResponseDTO.builder().billId("BillUUID").customerId(1).vetId("1").visitType("Test Type").date(date).amount(13.37).build();
+        return BillResponseDTO.builder().billId("BillUUID").customerId("1").vetId("1").visitType("Test Type").date(date).amount(13.37).build();
     }
 }


### PR DESCRIPTION
JIRA: link to jira ticket
## Context:
The main page for bills (bill history) displayed a user Id and vet Id which meant nothing (they aren't the ones used as parameters in requests). So I switched them to instead display the owner's and vet's full names.
## Changes
- Owner ID column changed to Owner Name
- Owner Name column now displays owner's full name in place of their ID
- Vet ID column changed to Vet Name
- Vet Name column now displays vet's full name in place of their ID
## Before and After UI (Required for UI-impacting PRs)
Before
![Screenshot 2023-09-24 201841](https://github.com/cgerard321/champlain_petclinic/assets/43860533/73c5221a-dab0-4f41-95f2-3378f6092a3f)
After
![Screenshot 2023-09-24 223349](https://github.com/cgerard321/champlain_petclinic/assets/43860533/4bd271fb-edd9-4024-abba-cb119b1d78b4)
## Dev notes (Optional)
- Everyone in billing (both the billing microservice and the API-Gateway) changed customerId from an int to a String to match the customer microservices customerId
- Originally tried going the route of a domain client layer similar to the api-gateway but realized in the end that making requests through the front-end and slightly changing the dtos would be much easier
- Added some fields to the DTOS
