### PR TITLE
bug/(VETS-CPC-848) Implement exceptions and ResponseEntity for ratings and vets + Fix front-end for update rating

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -49,6 +49,7 @@ public class VetsServiceClient {
                         .get()
                         .uri(vetsServiceUrl + "/" + vetId + "/ratings")
                         .retrieve()
+
                         .onStatus(HttpStatusCode::is4xxClientError, error->{
                             HttpStatusCode statusCode = error.statusCode();
                             if(statusCode.equals(HttpStatus.NOT_FOUND))

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/exceptions/ExistingRatingNotFoundException.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/exceptions/ExistingRatingNotFoundException.java
@@ -1,0 +1,16 @@
+package com.petclinic.bffapigateway.exceptions;
+
+import lombok.Data;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+public class ExistingRatingNotFoundException extends RuntimeException{
+    public ExistingRatingNotFoundException() {}
+
+    public ExistingRatingNotFoundException(String message) { super(message); }
+
+    public ExistingRatingNotFoundException(Throwable cause) { super(cause); }
+
+    public ExistingRatingNotFoundException(String message, Throwable cause) { super(message, cause); }
+}

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -263,14 +263,18 @@ public class BFFApiGatewayController {
     }
 
     @PostMapping(value = "vets/{vetId}/ratings")
-    public Mono<RatingResponseDTO> addRatingToVet(@PathVariable String vetId, @RequestBody Mono<RatingRequestDTO> ratingRequestDTO) {
-        return vetsServiceClient.addRatingToVet(vetId, ratingRequestDTO);
+    public Mono<ResponseEntity<RatingResponseDTO>> addRatingToVet(@PathVariable String vetId, @RequestBody Mono<RatingRequestDTO> ratingRequestDTO) {
+        return vetsServiceClient.addRatingToVet(vetId, ratingRequestDTO)
+                .map(r->ResponseEntity.status(HttpStatus.CREATED).body(r))
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
     @DeleteMapping(value = "vets/{vetId}/ratings/{ratingId}")
-    public Mono<Void> deleteRatingByRatingId(@PathVariable String vetId,
+    public Mono<ResponseEntity<Void>> deleteRatingByRatingId(@PathVariable String vetId,
                                              @PathVariable String ratingId){
-        return vetsServiceClient.deleteRating(vetId,ratingId);
+        return vetsServiceClient.deleteRating(vetId,ratingId)
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
     @GetMapping(value = "vets/{vetId}/ratings/average")
@@ -317,8 +321,10 @@ public class BFFApiGatewayController {
     }
 
     @PostMapping(value = "/vets",consumes = "application/json",produces = "application/json")
-    public Mono<VetDTO> insertVet(@RequestBody Mono<VetDTO> vetDTOMono) {
-        return vetsServiceClient.createVet(vetDTOMono);
+    public Mono<ResponseEntity<VetDTO>> insertVet(@RequestBody Mono<VetDTO> vetDTOMono) {
+        return vetsServiceClient.createVet(vetDTOMono)
+                .map(v->ResponseEntity.status(HttpStatus.CREATED).body(v))
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
     @PutMapping(value = "/vets/{vetId}",consumes = "application/json",produces = "application/json")
@@ -329,8 +335,10 @@ public class BFFApiGatewayController {
     }
 
     @DeleteMapping(value = "/vets/{vetId}")
-    public Mono<Void> deleteVet(@PathVariable String vetId) {
-        return vetsServiceClient.deleteVet(VetsEntityDtoUtil.verifyId(vetId));
+    public Mono<ResponseEntity<Void>> deleteVet(@PathVariable String vetId) {
+        return vetsServiceClient.deleteVet(VetsEntityDtoUtil.verifyId(vetId))
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
 

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
@@ -67,6 +67,10 @@ angular.module('vetDetails')
 
             const updateContainer=document.getElementById("ratingUpdate"+ratingId)
             const selectedValue=parseInt(document.getElementById("ratingOptions"+ratingId).value)
+            if(selectedValue<1||selectedValue>5){
+                alert("rateScore should be between 1 and 5" + selectedValue)
+                return
+            }
             const updatedDescription= document.getElementById("updateDescription"+ratingId).value
 
             if(updateContainer.style.display=="none"){
@@ -134,6 +138,10 @@ angular.module('vetDetails')
         self.submitRatingForm = function (rating) {
             rating.vetId = $stateParams.vetId;
             rating.rateScore = document.getElementById("ratingScore").value;
+            if(rating.rateScore<1||rating.rateScore>5){
+                alert("rateScore should be between 1 and 5" + selectedValue)
+                return
+            }
             rating.rateDescription = document.getElementById("ratingDescription").value;
             var currentDate = new Date();
             var readableDate = currentDate.toLocaleDateString();

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
@@ -63,38 +63,40 @@ angular.module('vetDetails')
         };
 
         self.updateRating = function (ratingId, rating) {
-            const btn = document.getElementById("updateRatingBtn");
+            const btn = document.getElementById("updateRatingBtn"+ratingId);
 
-            const updateContainer=document.getElementById("ratingUpdate")
-            const selectedValue=parseInt(document.getElementById("ratingOptions").value)
-            const updatedDescription= document.getElementById("updateDescription").value
+            const updateContainer=document.getElementById("ratingUpdate"+ratingId)
+            const selectedValue=parseInt(document.getElementById("ratingOptions"+ratingId).value)
+            const updatedDescription= document.getElementById("updateDescription"+ratingId).value
 
             if(updateContainer.style.display=="none"){
                 updateContainer.style.display="block"
                 btn.textContent="Save"
             }
             else if(btn.textContent=="Save"){
-                rating.rateScore=selectedValue
-                rating.vetId=$stateParams.vetId
-                rating.rateDescription=updatedDescription
-                rating.rateDate = Date.now().toString()
-                console.log(rating.rateScore);
-                updateContainer.style.display="none"
-                btn.textContent="Update"
+                const updatedRating = {
+                    rateScore: selectedValue,
+                    vetId: $stateParams.vetId,
+                    rateDescription: updatedDescription,
+                    rateDate: Date.now().toString()
+                };
+                console.log(updatedRating.rateScore)
 
-                $http.put("api/gateway/vets/" + $stateParams.vetId + "/ratings/"+ratingId, rating).then(function (resp){
+                $http.put("api/gateway/vets/" + $stateParams.vetId + "/ratings/" + ratingId, updatedRating).then(function (resp) {
                     console.log(resp.data)
-                    self.rating = resp.data;
+                    rating = resp.data;
                     alert('Your review was successfully updated!');
                     //refresh list
                     $http.get('api/gateway/vets/' + $stateParams.vetId + '/ratings').then(function (resp) {
                         console.log(resp.data)
                         self.ratings = resp.data;
-                        arr = resp.data;
                     });
                     //refresh percentages
                     percentageOfRatings();
                 });
+
+                updateContainer.style.display="none"
+                btn.textContent="Update"
             }
         }
 

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
@@ -67,10 +67,12 @@ angular.module('vetDetails')
 
             const updateContainer=document.getElementById("ratingUpdate"+ratingId)
             const selectedValue=parseInt(document.getElementById("ratingOptions"+ratingId).value)
+
             if(selectedValue<1||selectedValue>5){
                 alert("rateScore should be between 1 and 5" + selectedValue)
                 return
             }
+
             const updatedDescription= document.getElementById("updateDescription"+ratingId).value
 
             if(updateContainer.style.display=="none"){

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
@@ -149,9 +149,9 @@
 
                                     <!-- Rating Update Form -->
                                     <td>
-                                        <form enctype="multipart/form-data" id="updateForm" name="updateForm">
-                                            <div class="col-sm-12" name="ratingUpdate" id="ratingUpdate" style="display: none">
-                                                <select name="ratingOptions" id="ratingOptions">
+                                        <form enctype="multipart/form-data" id="updateForm{{rating.ratingId}}" name="updateForm">
+                                            <div class="col-sm-12" name="ratingUpdate" id="ratingUpdate{{rating.ratingId}}" style="display: none">
+                                                <select name="ratingOptions" id="ratingOptions{{rating.ratingId}}">
                                                     <option value="1">1/5</option>
                                                     <option value="2">2/5</option>
                                                     <option value="3">3/5</option>
@@ -160,14 +160,15 @@
                                                 </select>
                                                 <br />
                                                 <h5 class="form-label">Review Description</h5>
-                                                <textarea class="form-control" id="updateDescription" maxlength="350" name="updateDescription"
+                                                <textarea class="form-control" id="updateDescription{{rating.ratingId}}" maxlength="350" name="updateDescription"
                                                           ng-model="rating.rateDescription" pattern="^(.*)" placeholder="Update Description"
                                                           title="Maximum of 350 characters."></textarea>
                                             </div>
                                         </form>
 
-                                        <button class="update-vet-button btn btn-success" id="updateRatingBtn"
-                                                ng-click="$ctrl.updateRating(rating.ratingId, updateForm)">
+                                        <button class="update-vet-button btn btn-success"
+                                                id="updateRatingBtn{{rating.ratingId}}" 
+                                                ng-click="$ctrl.updateRating(rating.ratingId, updateForm+rating.ratingId)">
                                             Update
                                         </button>
                                     </td>

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
@@ -81,10 +81,6 @@
             </div>
         </div>
         <hr>
-
-        <!-- Ratings and Add Rating -->
-        <div class="row g-5">
-
             <!-- Percentage of ratings -->
             <div class="col-md-6" style="margin-top: 64px">
                 <h3 class="form-label-rating">Percentages of Ratings:</h3>

--- a/api-gateway/src/main/resources/static/scripts/vet-form/vet-form.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-form/vet-form.controller.js
@@ -60,11 +60,19 @@ angular.module('vetForm')
             vet.firstName = document.getElementById("firstName").value;
             vet.lastName = document.getElementById("lastName").value;
             vet.email = document.getElementById("email").value;
+            if(vet.email.length>320){
+                alert("email length over 320: "+vet.email)
+                return
+            }
             vet.resume = document.getElementById("vetResume").value;
             vet.workday = document.getElementById("workDays").value;
 
             let basePhoneNumber = "(514)-634-8276 #";
             vet.phoneNumber = basePhoneNumber + document.getElementById("phoneNumber").value;
+            if(vet.phoneNumber.length>20){
+                alert("phoneNumber length over 15: "+vet.phoneNumber)
+                return
+            }
 
             let isAct = document.getElementsByClassName("isActiveRadio");
             vet.active = isAct[0].checked;

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.petclinic.bffapigateway.dtos.Vets.RatingRequestDTO;
 import com.petclinic.bffapigateway.dtos.Vets.RatingResponseDTO;
 import com.petclinic.bffapigateway.dtos.Vets.VetDTO;
+import com.petclinic.bffapigateway.exceptions.ExistingVetNotFoundException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.webjars.NotFoundException;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
@@ -21,6 +23,7 @@ import java.util.function.Consumer;
 
 import static io.netty.handler.codec.http.HttpHeaders.setHeader;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
@@ -72,6 +75,63 @@ class VetsServiceClientIntegrationTest {
     }
 
     @Test
+    void getAllRatingsByInvalidVetId_shouldNotSucceed() throws JsonProcessingException {
+        String invalidVetId="123";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(404)
+                .setBody("vetId not found: "+invalidVetId));
+
+        final RatingResponseDTO rating = vetsServiceClient.getRatingsByVetId(invalidVetId).onErrorResume(throwable -> {
+            if (throwable instanceof NotFoundException && throwable.getMessage().equals("vetId not found: "+invalidVetId)) {
+                return Mono.empty();
+            } else {
+                return Mono.error(throwable);
+            }
+        }).blockFirst();
+
+        assertNull(rating);
+    }
+
+    @Test
+    void getAllRatingsByVetId_IllegalArgumentException500() throws IllegalArgumentException {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(400)
+                .setBody("Something went wrong"));
+
+        final RatingResponseDTO rating = vetsServiceClient.getRatingsByVetId("678910").onErrorResume(throwable -> {
+            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                return Mono.empty();
+            } else {
+                return Mono.error(throwable);
+            }
+        }).blockFirst();
+
+        assertNull(rating);
+    }
+
+    @Test
+    void getAllRatingsByVetId_IllegalArgumentException400() throws IllegalArgumentException {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final RatingResponseDTO rating = vetsServiceClient.getRatingsByVetId("678910").onErrorResume(throwable -> {
+            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                return Mono.empty();
+            } else {
+                return Mono.error(throwable);
+            }
+        }).blockFirst();
+
+        assertNull(rating);
+    }
+
+
+    @Test
     void getNumberOfRatingsByVetId() throws JsonProcessingException {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
@@ -81,6 +141,41 @@ class VetsServiceClientIntegrationTest {
         assertEquals(5, numberOfRatings);
     }
 
+    @Test
+    void getNumberOfRatingsByVetId_IllegalArgumentException400() throws IllegalArgumentException {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(400)
+                .setBody("Something went wrong"));
+
+        final Integer ratingNumber = vetsServiceClient.getNumberOfRatingsByVetId("678910").onErrorResume(throwable -> {
+            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                return Mono.empty();
+            } else {
+                return Mono.error(throwable);
+            }
+        }).block();
+
+        assertNull(ratingNumber);
+    }
+
+    @Test
+    void getNumberOfRatingsByVetId_IllegalArgumentException500() throws IllegalArgumentException {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final Integer ratingNumber = vetsServiceClient.getNumberOfRatingsByVetId("678910").onErrorResume(throwable -> {
+            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                return Mono.empty();
+            } else {
+                return Mono.error(throwable);
+            }
+        }).block();
+
+        assertNull(ratingNumber);
+    }
 
     @Test
     void getAverageRatingsByVetId() throws JsonProcessingException {
@@ -90,11 +185,81 @@ class VetsServiceClientIntegrationTest {
                 .setBody("4.5"));
 
         final Double averageRating =
-                vetsServiceClient.getAverageRatingByVetId(vetDTO.getVetId()).block();
+                vetsServiceClient.getAverageRatingByVetId(vetDTO.getVetId())
+                        .onErrorResume(throwable -> {
+                            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                                return Mono.empty();
+                            } else {
+                                return Mono.error(throwable);
+                            }
+                        })
+                        .block();
         assertEquals(4.5, averageRating);
 
     }
 
+    @Test
+    void getAverageRatingsByVetId_shouldNotSucceed()throws ExistingVetNotFoundException{
+        String invalidVetId="123";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(404)
+                .setBody("vetId not found: "+invalidVetId));
+
+        final Double averageRating =
+                vetsServiceClient.getAverageRatingByVetId(invalidVetId)
+                        .onErrorResume(throwable -> {
+                            if (throwable instanceof ExistingVetNotFoundException && throwable.getMessage().equals("vetId not found: "+invalidVetId)) {
+                                return Mono.empty();
+                            } else {
+                                return Mono.error(throwable);
+                            }
+                        })
+                        .block();
+
+        assertNull(averageRating);
+    }
+
+    @Test
+    void getAverageRatingsByVetId_IllegalArgument400() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(400)
+                .setBody("Something went wrong"));
+
+        final Double averageRating =
+                vetsServiceClient.getAverageRatingByVetId(vetDTO.getVetId())
+                        .onErrorResume(throwable -> {
+                            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                                return Mono.empty();
+                            } else {
+                                return Mono.error(throwable);
+                            }
+                        })
+                        .block();
+        assertNull(averageRating);
+    }
+
+    @Test
+    void getAverageRatingsByVetId_IllegalArgument500() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final Double averageRating =
+                vetsServiceClient.getAverageRatingByVetId(vetDTO.getVetId())
+                        .onErrorResume(throwable -> {
+                            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                                return Mono.empty();
+                            } else {
+                                return Mono.error(throwable);
+                            }
+                        })
+                        .block();
+        assertNull(averageRating);
+    }
 
     @Test
     void getRatingPercentagesByVetId() throws JsonProcessingException {
@@ -106,9 +271,71 @@ class VetsServiceClientIntegrationTest {
         assertEquals("{\"1.0\":0.0,\"2.0\":0.0,\"4.0\":0.0,\"5.0\":1.0,\"3.0\":0.0}", ratingPercentages);
     }
 
+    @Test
+    void getRatingPercentagesByInvalidVetId_shouldNotSucceed() throws ExistingVetNotFoundException{
+        String invalidVetId="123";
 
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(404)
+                .setBody("vetId not found: "+invalidVetId));
+
+        final String ratingPercentages = vetsServiceClient.getPercentageOfRatingsByVetId(invalidVetId)
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof ExistingVetNotFoundException && throwable.getMessage().equals("vetId not found: "+invalidVetId)) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(ratingPercentages);
+    }
+
+    @Test
+    void getRatingPercentagesByValidVetId_IllegalException400() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(400)
+                .setBody("Something went wrong"));
+
+        final String ratingPercentages =
+                vetsServiceClient.getPercentageOfRatingsByVetId("678910")
+                        .onErrorResume(throwable -> {
+                            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                                return Mono.empty();
+                            } else {
+                                return Mono.error(throwable);
+                            }
+                        })
+                        .block();
+
+        assertNull(ratingPercentages);
+    }
+
+    @Test
+    void getRatingPercentagesByValidVetId_IllegalException500() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final String ratingPercentages =
+                vetsServiceClient.getPercentageOfRatingsByVetId("678910")
+                        .onErrorResume(throwable -> {
+                            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                                return Mono.empty();
+                            } else {
+                                return Mono.error(throwable);
+                            }
+                        })
+                        .block();
+
+        assertNull(ratingPercentages);
+    }
   
-  @Test
+    @Test
     void deleteRatingsByRatingId() throws JsonProcessingException{
         final String ratingId = "794ac37f-1e07-43c2-93bc-61839e61d989";
 
@@ -123,6 +350,75 @@ class VetsServiceClientIntegrationTest {
         final Mono<Void> empty = vetsServiceClient.deleteRating(vetDTO.getVetId(), ratingId);
 
         assertEquals(empty.block(), null);
+    }
+
+    @Test
+    void deleteRatingsByInvalidRatingId_shouldNotSucceed() throws NotFoundException{
+        String invalidVetId="123";
+        String validRatingId="456";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(404)
+                .setBody("vetId not found "+invalidVetId+" or ratingId not found: " + validRatingId));
+
+        final Void empty = vetsServiceClient.deleteRating(invalidVetId, validRatingId)
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof NotFoundException && throwable.getMessage().equals("vetId not found "+invalidVetId+" or ratingId not found: " + validRatingId)) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(empty);
+    }
+
+    @Test
+    void deleteRatingsByRatingId_IllegalArgumentException400() throws IllegalArgumentException{
+        String validVetId="123";
+        String validRatingId="456";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(400)
+                .setBody("Something went wrong"));
+
+        final Void empty = vetsServiceClient.deleteRating(validVetId, validRatingId)
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(empty);
+    }
+
+    @Test
+    void deleteRatingsByRatingId_IllegalArgumentException500() throws IllegalArgumentException{
+        String validVetId="123";
+        String validRatingId="456";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final Void empty = vetsServiceClient.deleteRating(validVetId, validRatingId)
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(empty);
     }
 
     @Test
@@ -149,6 +445,95 @@ class VetsServiceClientIntegrationTest {
         assertEquals(ratingRequestDTO.getRateScore(), rating.getRateScore());
         assertEquals(ratingRequestDTO.getRateDescription(), rating.getRateDescription());
         assertEquals(ratingRequestDTO.getRateDate(), rating.getRateDate());
+    }
+
+    @Test
+    void addRatingToVet_withInvalidVetId_shouldNotSucceed() throws ExistingVetNotFoundException {
+        String invalidVetId="123";
+
+        RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
+                .vetId("678910")
+                .rateScore(3.5)
+                .rateDescription("The vet was decent but lacked table manners.")
+                .rateDate("16/09/2023")
+                .build();
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(404)
+                .setBody("vetId not found: "+invalidVetId));
+
+        final RatingResponseDTO rating = vetsServiceClient.addRatingToVet(invalidVetId, Mono.just(ratingRequestDTO))
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof ExistingVetNotFoundException && throwable.getMessage().equals("vetId not found: "+invalidVetId)) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(rating);
+    }
+
+    @Test
+    void addRatingToVet_IllegalArgumentException400() throws IllegalArgumentException {
+        RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
+                .vetId("678910")
+                .rateScore(3.5)
+                .rateDescription("The vet was decent but lacked table manners.")
+                .rateDate("16/09/2023")
+                .build();
+
+        String validVetId="678910";
+        String validRatingId="12345";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(400)
+                .setBody("Something went wrong"));
+
+        final Void empty = vetsServiceClient.deleteRating(validVetId, validRatingId)
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(empty);
+    }
+
+    @Test
+    void addRatingToVet_IllegalArgumentException500() throws IllegalArgumentException {
+        RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
+                .vetId("678910")
+                .rateScore(3.5)
+                .rateDescription("The vet was decent but lacked table manners.")
+                .rateDate("16/09/2023")
+                .build();
+
+        String validVetId="678910";
+        String validRatingId="12345";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final Void empty = vetsServiceClient.deleteRating(validVetId, validRatingId)
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(empty);
     }
 
     @Test
@@ -180,6 +565,93 @@ class VetsServiceClientIntegrationTest {
     }
 
     @Test
+    void updateRatingByInvalidVetIdOrInvalidRatingId() throws NotFoundException {
+        String invalidVetId="123";
+        String invalidRatingId="123";
+
+        RatingRequestDTO updatedRating = RatingRequestDTO.builder()
+                .rateScore(2.0)
+                .vetId("678910")
+                .rateDescription("Vet cancelled last minute.")
+                .rateDate("20/09/2023")
+                .build();
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(404)
+                .setBody("Rating not found for vetId: " + invalidVetId + " and ratingId: " + invalidRatingId));
+
+        final RatingResponseDTO ratingResponseDTO =
+                vetsServiceClient.updateRatingByVetIdAndByRatingId(invalidVetId,invalidRatingId, Mono.just(updatedRating))
+                        .onErrorResume(throwable -> {
+                            if (throwable instanceof NotFoundException && throwable.getMessage().equals("Rating not found for vetId: " + invalidVetId + " and ratingId: " + invalidRatingId)) {
+                                return Mono.empty();
+                            } else {
+                                return Mono.error(throwable);
+                            }
+                        })
+                        .block();
+
+        assertNull(ratingResponseDTO);
+    }
+
+    @Test
+    void updateRatingByVetIdOrRatingId_IllegalArgumentException400() throws IllegalArgumentException {
+        RatingRequestDTO updatedRating = RatingRequestDTO.builder()
+                .rateScore(2.0)
+                .vetId("678910")
+                .rateDescription("Vet cancelled last minute.")
+                .rateDate("20/09/2023")
+                .build();
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(400)
+                .setBody("Something went wrong"));
+
+        final RatingResponseDTO ratingResponseDTO =
+                vetsServiceClient.updateRatingByVetIdAndByRatingId("678910","123456", Mono.just(updatedRating))
+                        .onErrorResume(throwable -> {
+                            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                                return Mono.empty();
+                            } else {
+                                return Mono.error(throwable);
+                            }
+                        })
+                        .block();
+
+        assertNull(ratingResponseDTO);
+    }
+
+    @Test
+    void updateRatingByVetIdOrRatingId_IllegalArgumentException500() throws IllegalArgumentException {
+        RatingRequestDTO updatedRating = RatingRequestDTO.builder()
+                .rateScore(2.0)
+                .vetId("678910")
+                .rateDescription("Vet cancelled last minute.")
+                .rateDate("20/09/2023")
+                .build();
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final RatingResponseDTO ratingResponseDTO =
+                vetsServiceClient.updateRatingByVetIdAndByRatingId("678910","123456", Mono.just(updatedRating))
+                        .onErrorResume(throwable -> {
+                            if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                                return Mono.empty();
+                            } else {
+                                return Mono.error(throwable);
+                            }
+                        })
+                        .block();
+
+        assertNull(ratingResponseDTO);
+    }
+
+    @Test
     void getAllVets() throws JsonProcessingException {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
@@ -202,6 +674,26 @@ class VetsServiceClientIntegrationTest {
         assertEquals(vetDTO.getPhoneNumber(), vet.getPhoneNumber());
         assertEquals(vetDTO.getResume(), vet.getResume());
         assertEquals(vetDTO.getWorkday(), vet.getWorkday());
+    }
+
+    @Test
+    void getAllVets_IllegalArgumentException500() throws IllegalArgumentException {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final VetDTO vet = vetsServiceClient.getVets()
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .blockFirst();
+
+        assertNull(vet);
     }
 
     @Test
@@ -230,6 +722,26 @@ class VetsServiceClientIntegrationTest {
     }
 
     @Test
+    void getActiveVets_IllegalArgumentException500() throws IllegalArgumentException {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final VetDTO vet = vetsServiceClient.getActiveVets()
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .blockFirst();
+
+        assertNull(vet);
+    }
+
+    @Test
     void getInactiveVets() throws JsonProcessingException {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
@@ -254,6 +766,25 @@ class VetsServiceClientIntegrationTest {
         assertEquals(vetDTO.getWorkday(), vet.getWorkday());
     }
 
+    @Test
+    void getInactiveVets_IllegalArgumentException500() throws IllegalArgumentException {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final VetDTO vet = vetsServiceClient.getInactiveVets()
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .blockFirst();
+
+        assertNull(vet);
+    }
 
     @Test
     void getVetByVetId() throws JsonProcessingException {
@@ -278,6 +809,68 @@ class VetsServiceClientIntegrationTest {
         assertEquals(vetDTO.getPhoneNumber(), vet.getPhoneNumber());
         assertEquals(vetDTO.getResume(), vet.getResume());
         assertEquals(vetDTO.getWorkday(), vet.getWorkday());
+    }
+
+    @Test
+    void getVetByInvalidVetId_shouldNotSucceed() throws ExistingVetNotFoundException{
+        String invalidVetId="123";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(404)
+                .setBody("vetId not found: "+invalidVetId));
+
+        final VetDTO vet = vetsServiceClient.getVetByVetId(invalidVetId)
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof ExistingVetNotFoundException && throwable.getMessage().equals("vetId not found: "+invalidVetId)) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(vet);
+    }
+
+    @Test
+    void getVetByInvalidVetId_IllegalArgumentException400() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(400)
+                .setBody("Something went wrong"));
+
+        final VetDTO vet = vetsServiceClient.getVetByVetId("678910")
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(vet);
+    }
+
+    @Test
+    void getVetByInvalidVetId_IllegalArgumentException500() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final VetDTO vet = vetsServiceClient.getVetByVetId("678910")
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(vet);
     }
 
     @Test
@@ -306,6 +899,26 @@ class VetsServiceClientIntegrationTest {
     }
 
     @Test
+    void createVet_IllegalArgumentException500() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final VetDTO vet = vetsServiceClient.createVet(Mono.just(vetDTO))
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(vet);
+    }
+
+    @Test
     void updateVetByVetId() throws JsonProcessingException {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
@@ -331,6 +944,68 @@ class VetsServiceClientIntegrationTest {
     }
 
     @Test
+    void updateVetByInvalidVetId_shouldNotSucceed() throws ExistingVetNotFoundException{
+        String invalidVetId="123";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(404)
+                .setBody("vetId not found: "+invalidVetId));
+
+        final VetDTO vet = vetsServiceClient.updateVet(invalidVetId, Mono.just(vetDTO))
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof ExistingVetNotFoundException && throwable.getMessage().equals("vetId not found: "+invalidVetId)) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(vet);
+    }
+
+    @Test
+    void updateVetByValidVetId_IllegalArgumentException400() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(400)
+                .setBody("Something went wrong"));
+
+        final VetDTO vet = vetsServiceClient.updateVet("678910", Mono.just(vetDTO))
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(vet);
+    }
+
+    @Test
+    void updateVetByValidVetId_IllegalArgumentException500() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final VetDTO vet = vetsServiceClient.updateVet("678910", Mono.just(vetDTO))
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(vet);
+    }
+
+    @Test
     void deleteVetByVetId() throws JsonProcessingException {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
@@ -348,6 +1023,68 @@ class VetsServiceClientIntegrationTest {
         final Mono<Void> empty = vetsServiceClient.deleteVet(vetDTO.getVetId());
 
         assertEquals(empty.block(), null);
+    }
+
+    @Test
+    void deleteVetByInvalidVetId_shouldNotSucceed() throws ExistingVetNotFoundException{
+        String invalidVetId="123";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(404)
+                .setBody("vetId not found: "+invalidVetId));
+
+        final Void empty = vetsServiceClient.deleteVet(invalidVetId)
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof ExistingVetNotFoundException && throwable.getMessage().equals("vetId not found: "+invalidVetId)) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(empty);
+    }
+
+    @Test
+    void deleteVetByVetId_IllegalArgumentException400() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(400)
+                .setBody("Something went wrong"));
+
+        final Void empty = vetsServiceClient.deleteVet(vetDTO.getVetId())
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(empty);
+    }
+
+    @Test
+    void deleteVetByVetId_IllegalArgumentException500() throws IllegalArgumentException{
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(500)
+                .setBody("Something went wrong"));
+
+        final Void empty = vetsServiceClient.deleteVet(vetDTO.getVetId())
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
+                        return Mono.empty();
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .block();
+
+        assertNull(empty);
     }
 
     private void prepareResponse(Consumer<MockResponse> consumer) {

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -126,7 +126,7 @@ class ApiGatewayControllerTest {
                 .uri("/api/gateway/vets/" + VET_ID + "/ratings/{ratingsId}", ratingResponseDTO.getRatingId())
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk();
+                .expectStatus().isNoContent();
 
         Mockito.verify(vetsServiceClient, times(1))
                 .deleteRating(VET_ID, ratingResponseDTO.getRatingId());
@@ -221,15 +221,15 @@ class ApiGatewayControllerTest {
                 .rateDescription("The vet was decent but lacked table manners.")
                 .rateDate("16/09/2023")
                 .build();
-        when(vetsServiceClient.addRatingToVet(VET_ID, Mono.just(ratingRequestDTO)))
+        when(vetsServiceClient.addRatingToVet(anyString(), any(Mono.class)))
                 .thenReturn(Mono.just(ratingResponseDTO));
 
         client.post()
-                .uri("/api/gateway/vets/{vetId}/ratings", ratingRequestDTO.getVetId())
+                .uri("/api/gateway/vets/{vetId}/ratings", VET_ID)
                 .bodyValue(ratingRequestDTO)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody();
     }
@@ -382,7 +382,7 @@ class ApiGatewayControllerTest {
     @Test
     void createVet() {
         Mono<VetDTO> dto = Mono.just(vetDTO);
-        when(vetsServiceClient.createVet(dto))
+        when(vetsServiceClient.createVet(any(Mono.class)))
                 .thenReturn(dto);
 
         client
@@ -391,7 +391,7 @@ class ApiGatewayControllerTest {
                 .body(dto, VetDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody();
 
@@ -436,7 +436,7 @@ class ApiGatewayControllerTest {
                 .uri("/api/gateway/vets/" + VET_ID)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk();
+                .expectStatus().isNoContent();
 
         Mockito.verify(vetsServiceClient, times(1))
                 .deleteVet(VET_ID);

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -43,15 +43,18 @@ public class VetController {
     }
 
     @PostMapping("/{vetId}/ratings")
-    public Mono<RatingResponseDTO> addRatingToVet(@PathVariable String vetId, @RequestBody Mono<RatingRequestDTO> ratingRequest) {
-        return ratingService.addRatingToVet(vetId, ratingRequest);
+    public Mono<ResponseEntity<RatingResponseDTO>> addRatingToVet(@PathVariable String vetId, @RequestBody Mono<RatingRequestDTO> ratingRequest) {
+        return ratingService.addRatingToVet(vetId, ratingRequest)
+                .map(r->ResponseEntity.status(HttpStatus.CREATED).body(r))
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
     @DeleteMapping("{vetId}/ratings/{ratingId}")
-    public Mono<Void> deleteRatingByRatingId(@PathVariable String vetId,
+    public Mono<ResponseEntity<Void>> deleteRatingByRatingId(@PathVariable String vetId,
                                              @PathVariable String ratingId){
-        return ratingService.deleteRatingByRatingId(vetId, ratingId);
-
+        return ratingService.deleteRatingByRatingId(vetId, ratingId)
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
     }
     @GetMapping("{vetId}/ratings/average")
     public Mono<ResponseEntity<Double>> getAverageRatingByVetId(@PathVariable String vetId){
@@ -109,8 +112,10 @@ public class VetController {
     }
 
     @PostMapping
-    public Mono<VetDTO> insertVet(@RequestBody Mono<VetDTO> vetDTOMono) {
-        return vetService.insertVet(vetDTOMono);
+    public Mono<ResponseEntity<VetDTO>> insertVet(@RequestBody Mono<VetDTO> vetDTOMono) {
+        return vetService.insertVet(vetDTOMono)
+                .map(v->ResponseEntity.status(HttpStatus.CREATED).body(v))
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
     @PutMapping("{vetId}")
@@ -121,8 +126,10 @@ public class VetController {
     }
 
     @DeleteMapping("{vetId}")
-    public Mono<Void> deleteVet(@PathVariable String vetId) {
-        return vetService.deleteVetByVetId(EntityDtoUtil.verifyId(vetId));
+    public Mono<ResponseEntity<Void>> deleteVet(@PathVariable String vetId) {
+        return vetService.deleteVetByVetId(EntityDtoUtil.verifyId(vetId))
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
 

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingServiceImpl.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/RatingServiceImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.petclinic.vet.dataaccesslayer.Rating;
 import com.petclinic.vet.dataaccesslayer.RatingRepository;
+import com.petclinic.vet.dataaccesslayer.VetRepository;
 import com.petclinic.vet.exceptions.NotFoundException;
 
 import com.petclinic.vet.exceptions.InvalidInputException;
@@ -20,30 +21,47 @@ import java.util.UUID;
 
 @Service
 public class RatingServiceImpl implements RatingService {
-
+    private final VetRepository vetRepository;
     private final RatingRepository ratingRepository;
     private final ObjectMapper objectMapper;
 
-    public RatingServiceImpl(RatingRepository ratingRepository, ObjectMapper objectMapper) {
+    public RatingServiceImpl(RatingRepository ratingRepository, ObjectMapper objectMapper, VetRepository vetRepository) {
         this.ratingRepository = ratingRepository;
         this.objectMapper = objectMapper;
+        this.vetRepository=vetRepository;
     }
 
     @Override
     public Flux<RatingResponseDTO> getAllRatingsByVetId(String vetId) {
-        return ratingRepository.findAllByVetId(vetId)
-                .map(EntityDtoUtil::toDTO);
+        return vetRepository.findVetByVetId(vetId)
+                .switchIfEmpty(Mono.error(new NotFoundException("vetId not found: " + vetId)))
+                .flatMapMany(vet -> ratingRepository.findAllByVetId(vetId)
+                        .map(EntityDtoUtil::toDTO)
+                );
     }
+
     @Override
     public Mono<Void> deleteRatingByRatingId(String vetId, String ratingId) {
-        return ratingRepository.findByVetIdAndRatingId(vetId, ratingId)
-                //.switchIfEmpty(Mono.error(new Exception("Rating with id " + ratingId + " not found.")))
-                .flatMap(ratingRepository::delete);
+        return vetRepository.findVetByVetId(vetId)
+                .switchIfEmpty(Mono.error(new NotFoundException("vetId not found: " + vetId)))
+                .then(ratingRepository.findByVetIdAndRatingId(vetId, ratingId)
+                        .switchIfEmpty(Mono.error(new NotFoundException("ratingId not found: "+ratingId)))
+                        .flatMap(ratingRepository::delete)
+                );
     }
 
     @Override
     public Mono<RatingResponseDTO> addRatingToVet(String vetId, Mono<RatingRequestDTO> ratingRequestDTO) {
-        return ratingRequestDTO
+        return vetRepository.findVetByVetId(vetId)
+                .switchIfEmpty(Mono.error(new NotFoundException("vetId not found: "+vetId)))
+                .flatMap(r -> ratingRequestDTO.flatMap(dto -> {
+                    if (dto.getRateScore() < 1 || dto.getRateScore() > 5) {
+                        return Mono.error(new InvalidInputException("rateScore should be between 1 and 5: " + dto.getRateScore()));
+                    } else {
+                        return ratingRequestDTO;
+                    }
+                }))
+                .switchIfEmpty(Mono.error(new NotFoundException("Hello")))
                 .map(EntityDtoUtil::toEntity)
                 .doOnNext(r -> r.setRatingId(UUID.randomUUID().toString()))
                 .flatMap(ratingRepository::insert)
@@ -52,8 +70,11 @@ public class RatingServiceImpl implements RatingService {
 
     @Override
     public Mono<Integer> getNumberOfRatingsByVetId(String vetId) {
-        return  ratingRepository.countAllByVetId(vetId)
-                .map(Long::intValue);
+        return vetRepository.findVetByVetId(vetId)
+                .switchIfEmpty(Mono.error(new NotFoundException("vetId not found: " + vetId)))
+                .then(ratingRepository.countAllByVetId(vetId)
+                        .map(Long::intValue)
+                );
     }
 
     @Override
@@ -74,44 +95,52 @@ public class RatingServiceImpl implements RatingService {
 
     @Override
     public Mono<RatingResponseDTO> updateRatingByVetIdAndRatingId(String vetId, String ratingId, Mono<RatingRequestDTO> ratingRequestDTOMono) {
-        return this.ratingRepository.findByRatingId(ratingId)
-                .switchIfEmpty(Mono.error(new NotFoundException("Rating with id " + ratingId + " not found.")))
-                .flatMap(rating -> ratingRequestDTOMono
-                        .flatMap(r -> {
-                            if (r.getRateScore() < 1 || r.getRateScore() > 5)
-                                return Mono.error(new InvalidInputException("rateScore should be between 1 and 5" + r.getRateScore()));
-                            return Mono.just(r);
-                        })
-                        .map(EntityDtoUtil::toEntity)
-                        .doOnNext(e -> e.setId(rating.getId()))
-                        .doOnNext(e -> e.setRatingId(rating.getRatingId()))
-                        .flatMap(ratingRepository::save)
-                        .map(EntityDtoUtil::toDTO));
+        return vetRepository.findVetByVetId(vetId)
+                .switchIfEmpty(Mono.error(new NotFoundException("vetId not found: " + vetId)))
+                .then(ratingRepository.findByRatingId(ratingId)
+                        .switchIfEmpty(Mono.error(new NotFoundException("ratingId not found: " + ratingId)))
+                        .flatMap(rating -> ratingRequestDTOMono
+                                .flatMap(r -> {
+                                    if (r.getRateScore() < 1 || r.getRateScore() > 5)
+                                        return Mono.error(new InvalidInputException("rateScore should be between 1 and 5" + r.getRateScore()));
+                                    return Mono.just(r);
+                                })
+                                .map(EntityDtoUtil::toEntity)
+                                .doOnNext(e -> e.setId(rating.getId()))
+                                .doOnNext(e -> e.setRatingId(rating.getRatingId()))
+                                .flatMap(ratingRepository::save)
+                                .map(EntityDtoUtil::toDTO))
+                );
     }
 
     @Override
     public Mono<String> getRatingPercentagesByVetId(String vetId) {
-        Flux<Rating> ratingFlux = ratingRepository.findAllByVetId(vetId);
-        Map<Double, Integer> ratingCount = new HashMap<>();
-        for(double i = 1.0; i <= 5.0; i += 1.0) {
-            ratingCount.put(i, 0);
-        }
-        return ratingFlux
-                .map(EntityDtoUtil::toDTO)
-                .map(RatingResponseDTO::getRateScore)
-                .doOnNext(rating -> ratingCount.put(rating, ratingCount.get(rating) + 1))
-                .then(Mono.just(ratingCount))
-                .map(ratingCountMap -> {
-                    Map<Double, Double> ratingPercentages = new LinkedHashMap<>();
+        return vetRepository.findVetByVetId(vetId)
+                .switchIfEmpty(Mono.error(new NotFoundException("vetId not found: " + vetId)))
+                .then(Mono.defer(()->{
+                    Flux<Rating> ratingFlux = ratingRepository.findAllByVetId(vetId);
+                    Map<Double, Integer> ratingCount = new HashMap<>();
                     for(double i = 1.0; i <= 5.0; i += 1.0) {
-                        ratingPercentages.put(i, ratingCountMap.get(i) / (double) ratingCountMap.values().stream().mapToInt(Integer::intValue).sum());
+                        ratingCount.put(i, 0);
                     }
-                    try {
-                       String ratingPercentageJson = objectMapper.writeValueAsString(ratingPercentages);
-                        return ratingPercentageJson;
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
+                    return ratingFlux
+                            .map(EntityDtoUtil::toDTO)
+                            .map(RatingResponseDTO::getRateScore)
+                            .doOnNext(rating -> ratingCount.put(rating, ratingCount.get(rating) + 1))
+                            .then(Mono.just(ratingCount))
+                            .map(ratingCountMap -> {
+                                Map<Double, Double> ratingPercentages = new LinkedHashMap<>();
+                                for(double i = 1.0; i <= 5.0; i += 1.0) {
+                                    ratingPercentages.put(i, ratingCountMap.get(i) / (double) ratingCountMap.values().stream().mapToInt(Integer::intValue).sum());
+                                }
+                                try {
+                                    String ratingPercentageJson = objectMapper.writeValueAsString(ratingPercentages);
+                                    return ratingPercentageJson;
+                                } catch (JsonProcessingException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+                }));
+
     }
 }

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -42,10 +42,10 @@ class VetControllerIntegrationTest {
 
     Vet vet = buildVet();
     Vet vet2 = buildVet2();
-    Rating rating1 = buildRating("12345", vet.getVetId(), 5.0);
-    Rating rating2 = buildRating("12346", vet.getVetId(), 4.0);
+    Rating rating1 = buildRating("12345", "678910", 5.0);
+    Rating rating2 = buildRating("12346", "678910", 4.0);
     VetDTO vetDTO = buildVetDTO();
-    String VET_ID = vet.getVetId();
+    String VET_ID = "678910";
     String VET_BILL_ID = vet.getVetBillId();
     String INVALID_VET_ID = "mjbedf";
     RatingRequestDTO updatedRating = RatingRequestDTO.builder()
@@ -86,6 +86,20 @@ class VetControllerIntegrationTest {
     }
 
     @Test
+    void getAllRatingsForAVet_WithInvalidVetId_ShouldNotSucceed() {
+        String invalidVetId="123";
+        client
+                .get()
+                .uri("/vets/" + 123 + "/ratings")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("vetId not found: " + invalidVetId);
+    }
+
+    @Test
     void getNumberOfRatingsForAVet_WithValidVetId_ShouldSucceed() {
         Publisher<Rating> setup = ratingRepository.deleteAll()
                 .thenMany(ratingRepository.save(rating1))
@@ -110,6 +124,21 @@ class VetControllerIntegrationTest {
     }
 
     @Test
+    void getNumberOfRatingsForAVet_WithInvalidVetId_ShouldNotSucceed() {
+        String invalidVetId="123";
+
+        client
+                .get()
+                .uri("/vets/" + invalidVetId + "/ratings/count")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("vetId not found: " + invalidVetId);
+    }
+
+    @Test
     void addRatingToAVet_WithValidValues_ShouldSucceed() {
         StepVerifier
                 .create(ratingRepository.deleteAll())
@@ -129,7 +158,7 @@ class VetControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(ratingRequestDTO)
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody(RatingResponseDTO.class)
                 .value(dto -> {
@@ -141,6 +170,65 @@ class VetControllerIntegrationTest {
                     assertThat(dto.getRateDate()).isEqualTo(ratingRequestDTO.getRateDate());
                 });
 
+    }
+
+    @Test
+    void addRatingToAVet_WithInvalidVetId_ShouldNotSucceed() {
+        StepVerifier
+                .create(vetRepository.deleteAll())
+                .expectNextCount(0)
+                .verifyComplete();
+
+        StepVerifier
+                .create(ratingRepository.deleteAll())
+                .expectNextCount(0)
+                .verifyComplete();
+
+        String invalidVetId="123";
+
+        RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
+                .vetId(invalidVetId)
+                .rateScore(3.5)
+                .rateDescription("The vet was decent but lacked table manners.")
+                .rateDate("16/09/2023")
+                .build();
+
+        client.post()
+                .uri("/vets/" + invalidVetId + "/ratings")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(ratingRequestDTO)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("vetId not found: " + invalidVetId);
+    }
+
+    @Test
+    void addRatingToAVet_WithInvalidValues_ShouldNotSucceed() {
+        StepVerifier
+                .create(ratingRepository.deleteAll())
+                .expectNextCount(0)
+                .verifyComplete();
+
+        RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
+                .vetId(VET_ID)
+                .rateScore(8.0)
+                .rateDescription("The vet was decent but lacked table manners.")
+                .rateDate("16/09/2023")
+                .build();
+
+        client.post()
+                .uri("/vets/" + VET_ID + "/ratings")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(ratingRequestDTO)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("rateScore should be between 1 and 5: " + ratingRequestDTO.getRateScore());
     }
 
     @Test
@@ -176,12 +264,45 @@ class VetControllerIntegrationTest {
     }
 
     @Test
-    void updateRating_withValidVetIdAndInvalidRatingId_shouldNotSucceed() {
+    void updateRating_withInvalidVetIdAndValidRatingId_shouldNotSucceed() {
         Publisher<Rating> setup = ratingRepository.deleteAll()
                 .thenMany(ratingRepository.save(rating1));
 
         StepVerifier
                 .create(setup)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        String existingRatingId = rating1.getRatingId();
+
+        String invalidVetId="123";
+
+        client.put()
+                .uri("/vets/" + invalidVetId + "/ratings/" + existingRatingId)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(updatedRating)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("vetId not found: " + invalidVetId);
+    }
+
+    @Test
+    void updateRating_withValidVetIdAndInvalidRatingId_shouldNotSucceed() {
+        Publisher<Rating> setup1 = ratingRepository.deleteAll()
+                .thenMany(ratingRepository.save(rating1));
+
+        StepVerifier
+                .create(setup1)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        Publisher<Vet> setup2 = vetRepository.deleteAll().thenMany(vetRepository.save(vet));
+
+        StepVerifier
+                .create(setup2)
                 .expectNextCount(1)
                 .verifyComplete();
 
@@ -196,7 +317,7 @@ class VetControllerIntegrationTest {
                 .expectStatus().isNotFound()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
-                .jsonPath("$.message").isEqualTo("Rating with id " + invalidRatingId + " not found.");
+                .jsonPath("$.message").isEqualTo("ratingId not found: "+invalidRatingId);
     }
 
     @Test
@@ -232,6 +353,32 @@ class VetControllerIntegrationTest {
 
     @Test
     void deleteARatingForVet_WithValidId_ShouldSucceed() {
+        Publisher<Vet> setup1 = vetRepository.deleteAll()
+                .thenMany(vetRepository.save(vet));
+
+        StepVerifier
+                .create(setup1)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        Publisher<Rating> setup2 = ratingRepository.deleteAll()
+                .thenMany(ratingRepository.save(rating1));
+
+        StepVerifier
+                .create(setup2)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        client
+                .delete()
+                .uri("/vets/" + VET_ID + "/ratings/{ratingId}", rating1.getRatingId())
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNoContent();
+    }
+
+    @Test
+    void deleteARatingForVet_WithInvalidVetId_ShouldNotSucceed() {
         Publisher<Rating> setup = ratingRepository.deleteAll().
                 thenMany(ratingRepository.save(rating1));
 
@@ -240,15 +387,46 @@ class VetControllerIntegrationTest {
                 .expectNextCount(1)
                 .verifyComplete();
 
+        String invalidVetId="123";
+
         client
                 .delete()
-                .uri("/vets/" + vet.getVetId() + "/ratings/{ratingId}", rating1.getId())
+                .uri("/vets/" + invalidVetId + "/ratings/{ratingId}", rating1.getRatingId())
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk()
-                .expectBody();
+                .expectStatus().isNotFound()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("vetId not found: "+invalidVetId);
     }
 
+    @Test
+    void deleteARatingForVet_WithInvalidRatingId_ShouldNotSucceed() {
+        Publisher<Rating> setup1 = ratingRepository.deleteAll().
+                thenMany(ratingRepository.save(rating1));
+
+        StepVerifier
+                .create(setup1)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        Publisher<Vet> setup2 = vetRepository.deleteAll().thenMany(vetRepository.save(vet));
+
+        StepVerifier
+                .create(setup2)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        String invalidRatingId="123";
+
+        client
+                .delete()
+                .uri("/vets/" + vet.getVetId() + "/ratings/{ratingId}", invalidRatingId)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("ratingId not found: "+invalidRatingId);
+    }
 
     @Test
     void getAverageRatingByVetId_ShouldSucceed() {
@@ -305,6 +483,21 @@ class VetControllerIntegrationTest {
                 .value(resp ->{
                     assertEquals("{\"1.0\":0.0,\"2.0\":0.0,\"3.0\":0.0,\"4.0\":0.5,\"5.0\":0.5}", resp);
                 });
+    }
+
+    @Test
+    void getPercentageOfRatingsByInvalidVetId_ShouldNotSucceed(){
+        String invalidVetId="123";
+
+        client.get()
+                .uri("/vets/" + invalidVetId + "/ratings" + "/percentages")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("vetId not found: "+invalidVetId);
+
     }
 
     @Test
@@ -421,6 +614,84 @@ class VetControllerIntegrationTest {
     }
 
     @Test
+    void updateVet_withInvalidPhoneNumber_shouldNotSucceed() {
+        Publisher<Vet> setup = vetRepository.deleteAll().thenMany(vetRepository.save(vet2));
+
+        StepVerifier
+                .create(setup)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        VetDTO updatedVet=VetDTO.builder()
+                .vetId("678910")
+                .vetBillId("1")
+                .firstName("Clementine")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.com")
+                .phoneNumber("947-238-28479999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999")
+                .resume("Just became a vet")
+                .imageId("kjd")
+                .workday("Monday")
+                .specialties(new HashSet<>())
+                .active(false)
+                .build();
+
+        client
+                .put()
+                .uri("/vets/" + VET_ID)
+                .body(Mono.just(updatedVet), VetDTO.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("phoneNumber length over 20: "+updatedVet.getPhoneNumber());
+
+    }
+
+    @Test
+    void updateVet_withInvalidEmail_shouldNotSucceed() {
+        Publisher<Vet> setup = vetRepository.deleteAll().thenMany(vetRepository.save(vet2));
+
+        StepVerifier
+                .create(setup)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        VetDTO updatedVet=VetDTO.builder()
+                .vetId("678910")
+                .vetBillId("1")
+                .firstName("Clementine")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.commmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm")
+                .phoneNumber("947-238-2847")
+                .resume("Just became a vet")
+                .imageId("kjd")
+                .workday("Monday")
+                .specialties(new HashSet<>())
+                .active(false)
+                .build();
+
+        client
+                .put()
+                .uri("/vets/" + VET_ID)
+                .body(Mono.just(updatedVet), VetDTO.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("email length over 320: "+updatedVet.getPhoneNumber());
+    }
+
+    @Test
     void getVetIsActive() {
         Publisher<Vet> setup = vetRepository.deleteAll().thenMany(vetRepository.save(vet2));
 
@@ -490,7 +761,7 @@ class VetControllerIntegrationTest {
                 .body(Mono.just(vet), Vet.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody(VetDTO.class)
                 .value((dto) -> {
@@ -506,6 +777,83 @@ class VetControllerIntegrationTest {
                 });
     }
 
+    @Test
+    void createVet_withInvalidPhoneNumber() {
+        Publisher<Void> setup = vetRepository.deleteAll();
+
+        StepVerifier
+                .create(setup)
+                .expectNextCount(0)
+                .verifyComplete();
+
+        VetDTO newVet=VetDTO.builder()
+                .vetId("678910")
+                .vetBillId("1")
+                .firstName("Clementine")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.com")
+                .phoneNumber("947-238-28479999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999")
+                .resume("Just became a vet")
+                .imageId("kjd")
+                .workday("Monday")
+                .specialties(new HashSet<>())
+                .active(false)
+                .build();
+
+        client
+                .post()
+                .uri("/vets")
+                .body(Mono.just(newVet), Vet.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("phoneNumber length over 20: "+newVet.getPhoneNumber());
+    }
+
+    @Test
+    void createVet_withInvalidEmail() {
+        Publisher<Void> setup = vetRepository.deleteAll();
+
+        StepVerifier
+                .create(setup)
+                .expectNextCount(0)
+                .verifyComplete();
+
+        VetDTO newVet=VetDTO.builder()
+                .vetId("678910")
+                .vetBillId("1")
+                .firstName("Clementine")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.commmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm" +
+                        "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm")
+                .phoneNumber("947-238-2847")
+                .resume("Just became a vet")
+                .imageId("kjd")
+                .workday("Monday")
+                .specialties(new HashSet<>())
+                .active(false)
+                .build();
+
+        client
+                .post()
+                .uri("/vets")
+                .body(Mono.just(newVet), Vet.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("email length over 320: "+newVet.getEmail());
+
+    }
 
     @Test
     void deleteVet() {
@@ -521,7 +869,7 @@ class VetControllerIntegrationTest {
                 .uri("/vets/" + VET_ID)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isNoContent()
                 .expectBody();
     }
 

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -76,7 +76,7 @@ class VetControllerUnitTest {
                 .uri("/vets/" + vetId + "/ratings/{ratingId}", ratingId)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk();
+                .expectStatus().isNoContent();
 
         Mockito.verify(ratingService, times(1))
                 .deleteRatingByRatingId(vetId,ratingId);
@@ -92,7 +92,7 @@ class VetControllerUnitTest {
                         .build();
         RatingResponseDTO rating = buildRatingResponseDTO(ratingRequestDTO.getRateDescription(), ratingRequestDTO.getRateScore());
 
-        when(ratingService.addRatingToVet(VET_ID, Mono.just(ratingRequestDTO)))
+        when(ratingService.addRatingToVet(anyString(), any(Mono.class)))
                 .thenReturn(Mono.just(rating));
 
         client.post()
@@ -100,7 +100,7 @@ class VetControllerUnitTest {
                 .bodyValue(ratingRequestDTO)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody();
 
@@ -325,7 +325,7 @@ class VetControllerUnitTest {
     @Test
     void createVet() {
         Mono<VetDTO> dto = Mono.just(vetDTO);
-        when(vetService.insertVet(dto))
+        when(vetService.insertVet(any(Mono.class)))
                 .thenReturn(dto);
 
         client
@@ -334,7 +334,7 @@ class VetControllerUnitTest {
                 .body(dto, Vet.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody();
 
@@ -405,7 +405,7 @@ class VetControllerUnitTest {
                 .uri("/vets/" + VET_ID)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk();
+                .expectStatus().isNoContent();
 
         Mockito.verify(vetService, times(1))
                 .deleteVetByVetId(VET_ID);

--- a/vet-service/src/test/java/com/petclinic/vet/servicelayer/VetServiceImplTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/servicelayer/VetServiceImplTest.java
@@ -195,8 +195,14 @@ class VetServiceImplTest {
 
     @Test
     void deleteVet() {
-        vetService.deleteVetByVetId(VET_ID);
-        verify(vetRepository, times(1)).deleteVetByVetId(VET_ID);
+        when(vetRepository.findVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(vetRepository.delete(any())).thenReturn(Mono.empty());
+
+        Mono<Void> deletedVet=vetService.deleteVetByVetId(VET_ID);
+
+        StepVerifier
+                .create(deletedVet)
+                .verifyComplete();
     }
 
 


### PR DESCRIPTION
JIRA: 
https://champlainsaintlambert.atlassian.net/browse/CPC-848

## Context:
This ticket implements exceptions and ResponseEntity for the controller methods for ratings and vets and fixes the update rating front-end.

## Changes
- The VetsServiceClient methods handle NotFoundException and IllegalArgumentException.
- The ExistingRatingNotFoundException was added.
- The Vet Service Impl has been tested (100%).
- The Vet Controller has been tested (100%).
- The Rating Service Impl has been tested (100%).
- ResponseEntity has been implemented in BFFApiGatewayController and in VetController.

## Before
Bug: After having updated one rating, all next "Update" buttons pressed, displayed the form to update the rating of the first rating that was updated.
![image](https://github.com/cgerard321/champlain_petclinic/assets/80173588/d1455fde-fe49-4bc7-9745-505496ab8f10)

## After
<img width="389" alt="image" src="https://github.com/cgerard321/champlain_petclinic/assets/80173588/e455af12-9dc4-455c-a637-7718c35ff401">
<img width="392" alt="image" src="https://github.com/cgerard321/champlain_petclinic/assets/80173588/ee9f34f0-daf7-417c-9d68-598f47bd5dab">

## Dev notes (Optional)
- Specific technical changes that should be noted
## Linked pull requests (Optional)
- pull request link
