### PR TITLE
feat(VETS-CPC-938): get all educations of a vet

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -1,5 +1,6 @@
 package com.petclinic.bffapigateway.domainclientlayer;
 
+import com.petclinic.bffapigateway.dtos.Vets.EducationResponseDTO;
 import com.petclinic.bffapigateway.dtos.Vets.RatingRequestDTO;
 import com.petclinic.bffapigateway.dtos.Vets.RatingResponseDTO;
 import com.petclinic.bffapigateway.dtos.Vets.VetDTO;
@@ -219,6 +220,18 @@ public class VetsServiceClient {
                 .bodyToMono(VetDTO.class);
 
         return vetDTOMono;
+    }
+
+    public Flux<EducationResponseDTO> getEducationsByVetId(String vetId) {
+        Flux<EducationResponseDTO> educationResponseDTOFlux =
+                webClientBuilder
+                        .build()
+                        .get()
+                        .uri(vetsServiceUrl + "/" + vetId + "/educations")
+                        .retrieve()
+                        .bodyToFlux(EducationResponseDTO.class);
+
+        return educationResponseDTOFlux;
     }
 
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/EducationRequestDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/EducationRequestDTO.java
@@ -1,0 +1,19 @@
+package com.petclinic.bffapigateway.dtos.Vets;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EducationRequestDTO {
+    private String vetId;
+    private String schoolName;
+    private String degree;
+    private String fieldOfStudy;
+    private String startDate;
+    private String endDate;
+}

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/EducationResponseDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/EducationResponseDTO.java
@@ -1,0 +1,20 @@
+package com.petclinic.bffapigateway.dtos.Vets;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EducationResponseDTO {
+    private String educationId;
+    private String vetId;
+    private String schoolName;
+    private String degree;
+    private String fieldOfStudy;
+    private String startDate;
+    private String endDate;
+}

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -16,10 +16,7 @@ import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerResponseDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetRequestDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetResponseDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetType;
-import com.petclinic.bffapigateway.dtos.Vets.RatingRequestDTO;
-import com.petclinic.bffapigateway.dtos.Vets.PhotoDetails;
-import com.petclinic.bffapigateway.dtos.Vets.RatingResponseDTO;
-import com.petclinic.bffapigateway.dtos.Vets.VetDTO;
+import com.petclinic.bffapigateway.dtos.Vets.*;
 import com.petclinic.bffapigateway.dtos.Visits.VisitRequestDTO;
 import com.petclinic.bffapigateway.utils.Security.Annotations.SecuredEndpoint;
 import com.petclinic.bffapigateway.dtos.Visits.VisitDetails;
@@ -570,4 +567,8 @@ public class BFFApiGatewayController {
         return inventoryServiceClient.deleteAllInventories();
     }
 
+    @GetMapping(value = "vets/{vetId}/educations")
+    public Flux<EducationResponseDTO> getEducationsByVetId(@PathVariable String vetId) {
+        return vetsServiceClient.getEducationsByVetId(VetsEntityDtoUtil.verifyId(vetId));
+    }
 }

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
@@ -19,6 +19,11 @@ angular.module('vetDetails')
             self.ratings = resp.data;
         });
 
+        $http.get('api/gateway/vets/' + $stateParams.vetId + '/educations').then(function (resp) {
+            console.log(resp.data)
+            self.educations = resp.data;
+        });
+
         $http.get('api/gateway/vets/' + $stateParams.vetId + '/ratings/percentages')
             .then(function (resp) {
                 const ratingsData = resp.data;

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
@@ -81,7 +81,41 @@
             </div>
         </div>
         <hr>
-
+        <!-- Vet Education -->
+        <div class="row g-5">
+            <!-- Educations Header -->
+            <h3 class="form-label-rating text-center" style="margin-top: 5%">Educations</h3>
+            <div class="col-md-12" ng-if="$ctrl.educations.length > 0">
+                <div class="col-md-12">
+                    <div ng-if="$ctrl.educations.length === 0" style="text-align: center">
+                        This vet has no educations listed.
+                    </div>
+                    <!-- Education Table -->
+                    <table class="table" style="margin-bottom: 10%">
+                        <thead>
+                        <tr>
+                            <th>Degree</th>
+                            <th>Institution</th>
+                            <th>Field Of Study</th>
+                            <th>Start Year</th>
+                            <th>End Year</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr ng-repeat="educations in $ctrl.educations track by educations.educatonId">
+                                <td>{{ educations.degree }}</td>
+                                <td>{{ educations.schoolName }}</td>
+                                <td>{{ educations.fieldOfStudy }}</td>
+                                <td>{{ educations.startDate }}</td>
+                                <td>{{ educations.endDate }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <hr>
+<!-- tete -->
         <!-- Ratings and Add Rating -->
         <div class="row g-5">
 

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
@@ -2,6 +2,7 @@ package com.petclinic.bffapigateway.domainclientlayer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petclinic.bffapigateway.dtos.Vets.EducationResponseDTO;
 import com.petclinic.bffapigateway.dtos.Vets.RatingRequestDTO;
 import com.petclinic.bffapigateway.dtos.Vets.RatingResponseDTO;
 import com.petclinic.bffapigateway.dtos.Vets.VetDTO;
@@ -348,6 +349,29 @@ class VetsServiceClientIntegrationTest {
         final Mono<Void> empty = vetsServiceClient.deleteVet(vetDTO.getVetId());
 
         assertEquals(empty.block(), null);
+    }
+
+    @Test void getAllEducationsByVetId_ValidId() throws JsonProcessingException {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setBody("    {\n" +
+                        "    \"educationId\": \"123456\",\n" +
+                        "    \"vetId\": \"678910\",\n" +
+                        "    \"schoolName\": \"University of Toronto\",\n" +
+                        "    \"degree\": \"Doctor of Veterinary Medicine\",\n" +
+                        "    \"fieldOfStudy\": \"Veterinary Medicine\",\n" +
+                        "    \"startDate\": \"2015\",\n" +
+                        "    \"endDate\": \"2019\"\n" +
+                        "    }"));
+
+        final EducationResponseDTO education = vetsServiceClient.getEducationsByVetId("678910").blockFirst();
+        assertEquals("123456", education.getEducationId());
+        assertEquals("678910", education.getVetId());
+        assertEquals("University of Toronto", education.getSchoolName());
+        assertEquals("Doctor of Veterinary Medicine", education.getDegree());
+        assertEquals("Veterinary Medicine", education.getFieldOfStudy());
+        assertEquals("2015", education.getStartDate());
+        assertEquals("2019", education.getEndDate());
     }
 
     private void prepareResponse(Consumer<MockResponse> consumer) {

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -2487,6 +2487,37 @@ void deleteAllInventory_shouldSucceed() {
 
 
     }
+
+    @Test
+    void getAllEducationsByVetId_WithValidId_ShouldSucceed(){
+        EducationResponseDTO educationResponseDTO = buildEducation();
+        when(vetsServiceClient.getEducationsByVetId(anyString()))
+                .thenReturn(Flux.just(educationResponseDTO));
+
+        client
+                .get()
+                .uri("/api/gateway/vets/" + VET_ID + "/educations")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$[0].educationId").isEqualTo(educationResponseDTO.getEducationId());
+
+    }
+
+    private EducationResponseDTO buildEducation(){
+        return EducationResponseDTO.builder()
+                .educationId("1")
+                .vetId(VET_ID)
+                .degree("Doctor of Veterinary Medicine")
+                .fieldOfStudy("Veterinary Medicine")
+                .schoolName("University of Montreal")
+                .startDate("2010")
+                .endDate("2014")
+                .build();
+    }
+
 }
 
 

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -2502,7 +2502,13 @@ void deleteAllInventory_shouldSucceed() {
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
-                .jsonPath("$[0].educationId").isEqualTo(educationResponseDTO.getEducationId());
+                .jsonPath("$[0].educationId").isEqualTo(educationResponseDTO.getEducationId())
+                .jsonPath("$[0].vetId").isEqualTo(educationResponseDTO.getVetId())
+                .jsonPath("$[0].degree").isEqualTo(educationResponseDTO.getDegree())
+                .jsonPath("$[0].fieldOfStudy").isEqualTo(educationResponseDTO.getFieldOfStudy())
+                .jsonPath("$[0].schoolName").isEqualTo(educationResponseDTO.getSchoolName())
+                .jsonPath("$[0].startDate").isEqualTo(educationResponseDTO.getStartDate())
+                .jsonPath("$[0].endDate").isEqualTo(educationResponseDTO.getEndDate());
 
     }
 

--- a/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/Education.java
+++ b/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/Education.java
@@ -1,0 +1,19 @@
+package com.petclinic.vet.dataaccesslayer;
+
+import lombok.*;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class Education {
+    private String educationId;
+    private String vetId;
+    private String schoolName;
+    private String degree;
+    private String fieldOfStudy;
+    private String startDate;
+    private String endDate;
+}
+

--- a/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/EducationRepository.java
+++ b/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/EducationRepository.java
@@ -1,0 +1,11 @@
+package com.petclinic.vet.dataaccesslayer;
+
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+@Repository
+public interface EducationRepository extends ReactiveMongoRepository<Education, String> {
+
+    Flux<Education> findAllByVetId(String vetId);
+}

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -29,6 +29,11 @@ public class VetController {
 
     @Autowired
     RatingService ratingService;
+
+
+    @Autowired
+    EducationService educationService;
+
     @GetMapping("{vetId}/ratings")
     public Flux<RatingResponseDTO> getAllRatingsByVetId(@PathVariable String vetId) {
         return ratingService.getAllRatingsByVetId(EntityDtoUtil.verifyId(vetId));
@@ -123,6 +128,11 @@ public class VetController {
     @DeleteMapping("{vetId}")
     public Mono<Void> deleteVet(@PathVariable String vetId) {
         return vetService.deleteVetByVetId(EntityDtoUtil.verifyId(vetId));
+    }
+
+    @GetMapping("{vetId}/educations")
+    public Flux<EducationResponseDTO> getAllEducationsByVetId(@PathVariable String vetId) {
+        return educationService.getAllEducationsByVetId(EntityDtoUtil.verifyId(vetId));
     }
 
 

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/DataSetupService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/DataSetupService.java
@@ -20,9 +20,12 @@ public class DataSetupService implements CommandLineRunner {
 
     private final RatingRepository ratingRepository;
 
-    public DataSetupService(VetRepository vetRepository, RatingRepository ratingRepository) {
+    private final EducationRepository educationRepository;
+
+    public DataSetupService(VetRepository vetRepository, RatingRepository ratingRepository, EducationRepository educationRepository){
         this.vetRepository = vetRepository;
         this.ratingRepository = ratingRepository;
+        this.educationRepository = educationRepository;
     }
 
     @Override
@@ -159,6 +162,55 @@ public class DataSetupService implements CommandLineRunner {
                 .build();
         Flux.just(r1, r2, r3, r4)
                 .flatMap(ratingRepository::insert)
+                .log()
+                .subscribe();
+        Education e1 = Education.builder()
+                .educationId(UUID.randomUUID().toString())
+                .vetId(v1.getVetId())
+                .degree("Doctor of Veterinary Medicine")
+                .fieldOfStudy("Veterinary Medicine")
+                .schoolName("University of Montreal")
+                .startDate("2010")
+                .endDate("2014")
+                .build();
+        Education e2 = Education.builder()
+                .educationId(UUID.randomUUID().toString())
+                .vetId(v2.getVetId())
+                .degree("Doctor of Veterinary Medicine")
+                .fieldOfStudy("Veterinary Medicine")
+                .schoolName("University of Veterinary Sciences")
+                .startDate("2008")
+                .endDate("2013")
+                .build();
+        Education e3 = Education.builder()
+                .educationId(UUID.randomUUID().toString())
+                .vetId(v3.getVetId())
+                .degree("Doctor of Veterinary Medicine")
+                .fieldOfStudy("Animal Surgery")
+                .schoolName("California Veterinary College")
+                .startDate("2009")
+                .endDate("2015")
+                .build();
+        Education e4 = Education.builder()
+                .educationId(UUID.randomUUID().toString())
+                .vetId(v4.getVetId())
+                .degree("Master of Science in Veterinary Pathology")
+                .fieldOfStudy("Pathology")
+                .schoolName("Texas A&M University")
+                .startDate("2016")
+                .endDate("2018")
+                .build();
+        Education e5 = Education.builder()
+                .educationId(UUID.randomUUID().toString())
+                .vetId(v1.getVetId())
+                .degree("Bachelor of Veterinary Science")
+                .fieldOfStudy("Veterinary Genetics")
+                .schoolName("University of Sydney")
+                .startDate("2016")
+                .endDate("2018")
+                .build();
+        Flux.just(e1, e2, e3, e4, e5)
+                .flatMap(educationRepository::insert)
                 .log()
                 .subscribe();
     }

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationRequestDTO.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationRequestDTO.java
@@ -1,0 +1,19 @@
+package com.petclinic.vet.servicelayer;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EducationRequestDTO {
+    private String vetId;
+    private String schoolName;
+    private String degree;
+    private String fieldOfStudy;
+    private String startDate;
+    private String endDate;
+}

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationResponseDTO.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationResponseDTO.java
@@ -1,0 +1,20 @@
+package com.petclinic.vet.servicelayer;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EducationResponseDTO {
+    private String educationId;
+    private String vetId;
+    private String schoolName;
+    private String degree;
+    private String fieldOfStudy;
+    private String startDate;
+    private String endDate;
+}

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationService.java
@@ -1,0 +1,10 @@
+package com.petclinic.vet.servicelayer;
+
+
+import com.petclinic.vet.dataaccesslayer.EducationRepository;
+import reactor.core.publisher.Flux;
+
+public interface EducationService {
+    Flux<EducationResponseDTO> getAllEducationsByVetId(String vetId);
+
+}

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationServiceImpl.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationServiceImpl.java
@@ -1,0 +1,26 @@
+package com.petclinic.vet.servicelayer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petclinic.vet.dataaccesslayer.EducationRepository;
+import com.petclinic.vet.util.EntityDtoUtil;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+public class EducationServiceImpl implements EducationService {
+
+    private final EducationRepository educationRepository;
+    private final ObjectMapper objectMapper;
+
+    public EducationServiceImpl(EducationRepository educationRepository, ObjectMapper objectMapper) {
+        this.educationRepository = educationRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Flux<EducationResponseDTO> getAllEducationsByVetId(String vetId) {
+        return educationRepository.findAllByVetId(vetId)
+                .map(EntityDtoUtil::toDTO);
+    }
+
+}

--- a/vet-service/src/main/java/com/petclinic/vet/util/EntityDtoUtil.java
+++ b/vet-service/src/main/java/com/petclinic/vet/util/EntityDtoUtil.java
@@ -11,14 +11,12 @@ package com.petclinic.vet.util;
   * Ticket: feat(VVS-CPC-553): add veterinarian
  */
 
+import com.petclinic.vet.dataaccesslayer.Education;
 import com.petclinic.vet.dataaccesslayer.Rating;
 import com.petclinic.vet.dataaccesslayer.Specialty;
 import com.petclinic.vet.dataaccesslayer.Vet;
 import com.petclinic.vet.exceptions.InvalidInputException;
-import com.petclinic.vet.servicelayer.RatingRequestDTO;
-import com.petclinic.vet.servicelayer.RatingResponseDTO;
-import com.petclinic.vet.servicelayer.SpecialtyDTO;
-import com.petclinic.vet.servicelayer.VetDTO;
+import com.petclinic.vet.servicelayer.*;
 import lombok.Generated;
 import org.springframework.beans.BeanUtils;
 
@@ -86,6 +84,13 @@ public class EntityDtoUtil {
         BeanUtils.copyProperties(rating, dto);
         return dto;
     }
+
+    public static EducationResponseDTO toDTO(Education education) {
+        EducationResponseDTO dto = new EducationResponseDTO();
+        BeanUtils.copyProperties(education, dto);
+        return dto;
+    }
+
     public static Rating toEntity(RatingRequestDTO ratingRequestDTO) {
         Rating rating = new Rating();
         BeanUtils.copyProperties(ratingRequestDTO, rating);

--- a/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/EducationRepositoryTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/EducationRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.petclinic.vet.dataaccesslayer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import reactor.test.StepVerifier;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataMongoTest
+class EducationRepositoryTest {
+
+    @Autowired
+    EducationRepository educationRepository;
+
+    Education e1 = Education.builder()
+            .educationId("1")
+            .vetId("1")
+            .degree("Doctor of Veterinary Medicine")
+            .fieldOfStudy("Veterinary Medicine")
+            .schoolName("University of Montreal")
+            .startDate("2010")
+            .endDate("2014")
+            .build();
+    Education e2 = Education.builder()
+            .educationId("2")
+            .vetId("2")
+            .degree("Doctor of Veterinary Medicine")
+            .fieldOfStudy("Veterinary Medicine")
+            .schoolName("University of Veterinary Sciences")
+            .startDate("2008")
+            .endDate("2013")
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        Publisher<Education> setUp = educationRepository.deleteAll()
+                .thenMany(educationRepository.save(e1));
+
+        StepVerifier
+                .create(setUp)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        Publisher<Education> setUp2 = educationRepository.save(e2);
+
+        StepVerifier
+                .create(setUp2)
+                .expectNextCount(1)
+                .verifyComplete();
+    }
+
+    @Test
+    public void getAllEducationsOfAVet_ShouldSucceed(){
+        Publisher<Education> find = educationRepository.findAllByVetId("1");
+
+        StepVerifier
+                .create(find)
+                .consumeNextWith(found -> {
+                    assertEquals(e1.getEducationId(), found.getEducationId());
+                })
+                .verifyComplete();
+    }
+}

--- a/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/EducationRepositoryTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/EducationRepositoryTest.java
@@ -62,6 +62,12 @@ class EducationRepositoryTest {
                 .create(find)
                 .consumeNextWith(found -> {
                     assertEquals(e1.getEducationId(), found.getEducationId());
+                    assertEquals(e1.getVetId(), found.getVetId());
+                    assertEquals(e1.getDegree(), found.getDegree());
+                    assertEquals(e1.getSchoolName(), found.getSchoolName());
+                    assertEquals(e1.getFieldOfStudy(), found.getFieldOfStudy());
+                    assertEquals(e1.getStartDate(), found.getStartDate());
+                    assertEquals(e1.getEndDate(), found.getEndDate());
                 })
                 .verifyComplete();
     }

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -551,6 +551,12 @@ class VetControllerIntegrationTest {
                 .value((list) -> {
                     assertEquals(2, list.size());
                     assertEquals(education1.getEducationId(), list.get(0).getEducationId());
+                    assertEquals(education1.getVetId(), list.get(0).getVetId());
+                    assertEquals(education1.getDegree(), list.get(0).getDegree());
+                    assertEquals(education1.getFieldOfStudy(), list.get(0).getFieldOfStudy());
+                    assertEquals(education1.getSchoolName(), list.get(0).getSchoolName());
+                    assertEquals(education1.getStartDate(), list.get(0).getStartDate());
+                    assertEquals(education1.getEndDate(), list.get(0).getEndDate());
                 });
     }
 

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -1,9 +1,7 @@
 package com.petclinic.vet.presentationlayer;
 
-import com.petclinic.vet.dataaccesslayer.Rating;
-import com.petclinic.vet.dataaccesslayer.RatingRepository;
-import com.petclinic.vet.dataaccesslayer.Vet;
-import com.petclinic.vet.dataaccesslayer.VetRepository;
+import com.petclinic.vet.dataaccesslayer.*;
+import com.petclinic.vet.servicelayer.EducationResponseDTO;
 import com.petclinic.vet.servicelayer.RatingRequestDTO;
 import com.petclinic.vet.servicelayer.RatingResponseDTO;
 import com.petclinic.vet.servicelayer.VetDTO;
@@ -39,11 +37,17 @@ class VetControllerIntegrationTest {
     @Autowired
     RatingRepository ratingRepository;
 
+    @Autowired
+    EducationRepository educationRepository;
+
 
     Vet vet = buildVet();
     Vet vet2 = buildVet2();
     Rating rating1 = buildRating("12345", vet.getVetId(), 5.0);
     Rating rating2 = buildRating("12346", vet.getVetId(), 4.0);
+
+    Education education1 = buildEducation();
+    Education education2 = buildEducation2();
     VetDTO vetDTO = buildVetDTO();
     String VET_ID = vet.getVetId();
     String VET_BILL_ID = vet.getVetBillId();
@@ -526,6 +530,32 @@ class VetControllerIntegrationTest {
     }
 
     @Test
+    void getAllEducationForAVet_WithValidId_ShouldSucceed(){
+        Publisher<Education> setup = educationRepository.deleteAll()
+                .thenMany(educationRepository.save(education1))
+                .thenMany(educationRepository.save(education2));
+
+        StepVerifier
+                .create(setup)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        client
+                .get()
+                .uri("/vets/" + vet.getVetId() + "/educations")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBodyList(EducationResponseDTO.class)
+                .value((list) -> {
+                    assertEquals(2, list.size());
+                    assertEquals(education1.getEducationId(), list.get(0).getEducationId());
+                });
+    }
+
+
+    @Test
     void toStringBuilders() {
         System.out.println(Vet.builder());
         System.out.println(VetDTO.builder());
@@ -634,6 +664,30 @@ class VetControllerIntegrationTest {
                 .ratingId(ratingId)
                 .vetId(vetId)
                 .rateScore(rateScore)
+                .build();
+    }
+
+    private Education buildEducation(){
+        return Education.builder()
+                .educationId("1")
+                .vetId(vet.getVetId())
+                .degree("Doctor of Veterinary Medicine")
+                .fieldOfStudy("Veterinary Medicine")
+                .schoolName("University of Montreal")
+                .startDate("2010")
+                .endDate("2014")
+                .build();
+    }
+
+    private Education buildEducation2(){
+        return  Education.builder()
+                .educationId("2")
+                .vetId(vet.getVetId())
+                .degree("Doctor of Veterinary Medicine")
+                .fieldOfStudy("Veterinary Medicine")
+                .schoolName("University of Veterinary Sciences")
+                .startDate("2008")
+                .endDate("2013")
                 .build();
     }
 

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -484,7 +484,12 @@ class VetControllerUnitTest {
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
                 .jsonPath("$[0].educationId").isEqualTo(educationResponseDTO1.getEducationId())
-                .jsonPath("$[0].vetId").isEqualTo(educationResponseDTO1.getVetId());
+                .jsonPath("$[0].vetId").isEqualTo(educationResponseDTO1.getVetId())
+                .jsonPath("$[0].degree").isEqualTo(educationResponseDTO1.getDegree())
+                .jsonPath("$[0].fieldOfStudy").isEqualTo(educationResponseDTO1.getFieldOfStudy())
+                .jsonPath("$[0].schoolName").isEqualTo(educationResponseDTO1.getSchoolName())
+                .jsonPath("$[0].startDate").isEqualTo(educationResponseDTO1.getStartDate())
+                .jsonPath("$[0].endDate").isEqualTo(educationResponseDTO1.getEndDate());
 
         Mockito.verify(educationService, times(1)).getAllEducationsByVetId(VET_ID);
     }

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -1,5 +1,6 @@
 package com.petclinic.vet.presentationlayer;
 
+import com.petclinic.vet.dataaccesslayer.Education;
 import com.petclinic.vet.dataaccesslayer.Vet;
 import com.petclinic.vet.servicelayer.*;
 import org.junit.jupiter.api.Test;
@@ -33,8 +34,14 @@ class VetControllerUnitTest {
     @MockBean
     RatingService ratingService;
 
+    @MockBean
+    EducationService educationService;
+
     VetDTO vetDTO = buildVetDTO();
     VetDTO vetDTO2 = buildVetDTO2();
+
+    EducationResponseDTO educationResponseDTO1 = buildEducation();
+    EducationResponseDTO educationResponseDTO2 = buildEducation2();
 
     RatingResponseDTO ratingDTO = buildRatingResponseDTO("Vet was super calming with my pet",5.0);
     Vet vet = buildVet();
@@ -463,6 +470,25 @@ class VetControllerUnitTest {
 
     }
 
+    @Test
+    void getAllEducationForVetByVetId_ShouldSucceed() {
+        when(educationService.getAllEducationsByVetId(anyString()))
+                .thenReturn(Flux.just(educationResponseDTO1));
+
+        client
+                .get()
+                .uri("/vets/" + VET_ID + "/educations")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$[0].educationId").isEqualTo(educationResponseDTO1.getEducationId())
+                .jsonPath("$[0].vetId").isEqualTo(educationResponseDTO1.getVetId());
+
+        Mockito.verify(educationService, times(1)).getAllEducationsByVetId(VET_ID);
+    }
+
     private Vet buildVet() {
         return Vet.builder()
                 .vetId("678910")
@@ -507,6 +533,30 @@ class VetControllerUnitTest {
                 .workday("Monday")
                 .specialties(new HashSet<>())
                 .active(true)
+                .build();
+    }
+
+    private EducationResponseDTO buildEducation(){
+        return EducationResponseDTO.builder()
+                .educationId("1")
+                .vetId(VET_ID)
+                .degree("Doctor of Veterinary Medicine")
+                .fieldOfStudy("Veterinary Medicine")
+                .schoolName("University of Montreal")
+                .startDate("2010")
+                .endDate("2014")
+                .build();
+    }
+
+    private EducationResponseDTO buildEducation2(){
+        return  EducationResponseDTO.builder()
+                .educationId("2")
+                .vetId(VET_ID)
+                .degree("Doctor of Veterinary Medicine")
+                .fieldOfStudy("Veterinary Medicine")
+                .schoolName("University of Veterinary Sciences")
+                .startDate("2008")
+                .endDate("2013")
                 .build();
     }
 

--- a/vet-service/src/test/java/com/petclinic/vet/servicelayer/EducationServiceImplTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/servicelayer/EducationServiceImplTest.java
@@ -1,0 +1,62 @@
+package com.petclinic.vet.servicelayer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petclinic.vet.dataaccesslayer.Education;
+import com.petclinic.vet.dataaccesslayer.EducationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class EducationServiceImplTest {
+
+    @Autowired
+    EducationService educationService;
+
+    @MockBean
+    EducationRepository educationRepository;
+
+    @MockBean
+    ObjectMapper objectMapper;
+
+    String Vet_Id = "1";
+    Education education = buildEducation();
+
+    @Test
+    void getAllEducationsByVetId() {
+        when(educationRepository.findAllByVetId(anyString())).thenReturn(Flux.just(education));
+
+        Flux<EducationResponseDTO> educationResponseDTO = educationService.getAllEducationsByVetId("1");
+
+        StepVerifier
+                .create(educationResponseDTO)
+                .consumeNextWith(found -> {
+                    assertEquals(education.getEducationId(), found.getEducationId());
+                    assertEquals(education.getVetId(), found.getVetId());
+                })
+                .verifyComplete();
+    }
+
+    private Education buildEducation() {
+        return Education.builder()
+                .educationId("1")
+                .vetId("1")
+                .schoolName("test school")
+                .degree("test degree")
+                .fieldOfStudy("test field")
+                .startDate("test start year")
+                .endDate("test end year")
+                .build();
+    }
+
+
+}


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-938?atlOrigin=eyJpIjoiMWU4YjU0ZjBhN2UwNDU5ZTg2MzBlZGRlMDYwOWE5ZDciLCJwIjoiaiJ9
## Context:
Displays all the different educations that a vet has. 
## Changes
I created the Education entity, and implemented the get request in vets-service and api-gateway. Completed testing for getAllEducationsPerVetId in both vets service and API gateway. Implemented a working front-end that displays all the education that a vet has. 
## Before and After UI (Required for UI-impacting PRs)
![image](https://github.com/cgerard321/champlain_petclinic/assets/104159293/006fcbdd-d51a-4288-92b5-a9468dbad438)
![image](https://github.com/cgerard321/champlain_petclinic/assets/104159293/7e303431-df6b-4ab1-883b-729665ccc007)