### PR TITLE
feat(VIST-CPC-949): updated datetime formatter

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitDetails.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitDetails.java
@@ -1,5 +1,6 @@
 package com.petclinic.bffapigateway.dtos.Visits;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -25,6 +26,8 @@ public class VisitDetails {
     private Integer practitionerId = null;
 
     private String date = null;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime visitDate = null;
 
     private String description = null;

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitRequestDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitRequestDTO.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Data
 @AllArgsConstructor
@@ -21,14 +22,14 @@ public class VisitRequestDTO {
     private int month;
     private int day;*/
     private String description;
-    private String petId;
+    private String petId = "1";
     private String practitionerId;
 /*    private int petId;
     private int practitionerId;*/
     private boolean status;
 
     public VisitRequestDTO(LocalDateTime now, String description, String petId, String practitionerId) {
-        this.visitDate = now;
+        this.visitDate = LocalDateTime.parse(now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
         this.description = description;
         this.petId =  petId;
         this.practitionerId = practitionerId;

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitRequestDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitRequestDTO.java
@@ -29,7 +29,7 @@ public class VisitRequestDTO {
     private boolean status;
 
     public VisitRequestDTO(LocalDateTime now, String description, String petId, String practitionerId) {
-        this.visitDate = LocalDateTime.parse(now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
+        this.visitDate = now;
         this.description = description;
         this.petId =  petId;
         this.practitionerId = practitionerId;

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitRequestDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitRequestDTO.java
@@ -1,6 +1,7 @@
 package com.petclinic.bffapigateway.dtos.Visits;
 
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @Builder
 public class VisitRequestDTO {
 
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime visitDate;
 /*   private int year;
     private int month;

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitRequestDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitRequestDTO.java
@@ -22,7 +22,7 @@ public class VisitRequestDTO {
     private int month;
     private int day;*/
     private String description;
-    private String petId = "1";
+    private String petId;
     private String practitionerId;
 /*    private int petId;
     private int practitionerId;*/

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitResponseDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitResponseDTO.java
@@ -1,5 +1,6 @@
 package com.petclinic.bffapigateway.dtos.Visits;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,7 +17,8 @@ public class VisitResponseDTO {
 /*    private int year;
     private int month;
     private int day;*/
-    private LocalDateTime visitDate;
+@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+private LocalDateTime visitDate;
     private String description;
     private String petId;
     private String practitionerId;

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.LocalDateTime;
 
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
@@ -70,8 +71,8 @@ class VisitsServiceClientIntegrationTest {
 
     @Test
     void getAllVisits() throws JsonProcessingException {
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25T13:45:00"), "this is a dummy description", "2", "2", true);
-        VisitResponseDTO visitResponseDTO2 = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25T13:45:00"), "this is a dummy description", "2", "2", true);
+        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", true);
+        VisitResponseDTO visitResponseDTO2 = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", true);
         server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .setBody(objectMapper.writeValueAsString(Arrays.asList(visitResponseDTO, visitResponseDTO2))).addHeader("Content-Type", "application/json"));
 
@@ -86,7 +87,7 @@ class VisitsServiceClientIntegrationTest {
     void createVisitForPet_Valid() throws JsonProcessingException {
         // Arrange
         VisitRequestDTO visitRequestDTO = new VisitRequestDTO(
-                LocalDateTime.now(),
+                LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
                 "Test Visit",
                 "1",
                 "2"
@@ -95,7 +96,7 @@ class VisitsServiceClientIntegrationTest {
         // Mock the server response
         VisitResponseDTO visitResponseDTO = new VisitResponseDTO(
                 "73b5c112-5703-4fb7-b7bc-ac8186811ae1",
-                LocalDateTime.now(),
+                LocalDateTime.parse("2024-11-25 14:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
                 "Test Visit",
                 "1",
                 "2",
@@ -149,7 +150,7 @@ class VisitsServiceClientIntegrationTest {
                 .visitId(UUID.randomUUID().toString())
                 .petId("15")
                 .practitionerId(2)
-                .visitDate(LocalDateTime.parse("2021-12-12T13:00:00"))
+                .visitDate(LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("Cat is crazy")
                 .status(false)
                 .build();
@@ -199,7 +200,7 @@ class VisitsServiceClientIntegrationTest {
                 .visitId(UUID.randomUUID().toString())
                 .petId("15")
                 .practitionerId(2)
-                .visitDate(LocalDateTime.parse("2021-12-12T13:00:00"))
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("Cat is crazy")
                 .status(false)
                 .build();
@@ -207,7 +208,7 @@ class VisitsServiceClientIntegrationTest {
                 .visitId(UUID.randomUUID().toString())
                 .petId("201")
                 .practitionerId(22)
-                .visitDate(LocalDateTime.parse("2021-12-12T13:00:00"))
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("Dog is sick")
                 .status(false)
                 .build();
@@ -359,7 +360,7 @@ class VisitsServiceClientIntegrationTest {
 
     @Test
     void getVisitById() throws Exception {
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee", LocalDateTime.parse("2022-11-25T13:45:00"), "this is a dummy description", "2", "2", true);        server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", true);        server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .setBody(objectMapper.writeValueAsString(visitResponseDTO)).addHeader("Content-Type", "application/json"));
 
         Mono<VisitResponseDTO> visitResponseDTOMono = visitsServiceClient.getVisitByVisitId("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee");

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -1546,7 +1546,7 @@ class ApiGatewayControllerTest {
     void shouldUpdateAVisitsById() {
         // Create instances of VisitRequestDTO and VisitResponseDTO for creating a visit
         VisitRequestDTO visitRequestDTO = VisitRequestDTO.builder()
-                .visitDate(LocalDateTime.parse("2021-12-12T14:00:00"))
+                .visitDate(LocalDateTime.parse("2024-11-25 14:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("Charle's Richard cat has a paw infection.")
                 .petId("1")
                 .practitionerId("1")
@@ -1555,7 +1555,7 @@ class ApiGatewayControllerTest {
 
         VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
                 .visitId(UUID.randomUUID().toString())
-                .visitDate(LocalDateTime.parse("2021-12-12T14:00:00"))
+                .visitDate(LocalDateTime.parse("2024-11-25 14:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("Charle's Richard cat has a paw infection.")
                 .petId("1")
                 .practitionerId("1")
@@ -1580,14 +1580,14 @@ class ApiGatewayControllerTest {
                 .expectBody()
                 .jsonPath("$.visitId").isEqualTo(visitResponseDTO.getVisitId())
                 .jsonPath("$.petId").isEqualTo("1")
-                .jsonPath("$.visitDate").isEqualTo("2021-12-12T14:00:00")
+                .jsonPath("$.visitDate").isEqualTo("2024-11-25 14:45")
                 .jsonPath("$.description").isEqualTo("Charle's Richard cat has a paw infection.")
                 .jsonPath("$.status").isEqualTo(false)
                 .jsonPath("$.practitionerId").isEqualTo("1");
 
         // Create an instance of VisitDetails for updating
         VisitDetails visitDetailsToUpdate = VisitDetails.builder()
-                .visitDate(LocalDateTime.parse("2021-12-12T14:00:00"))
+                .visitDate(LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("Charle's Richard dog has a paw infection.")
                 .petId("2")
                 .practitionerId(2)
@@ -1613,8 +1613,8 @@ class ApiGatewayControllerTest {
     }
     @Test
     void shouldGetAllVisits() {
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25T13:45:00"), "this is a dummy description", "2", "2", true);
-        VisitResponseDTO visitResponseDTO2 = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25T13:45:00"), "this is a dummy description", "2", "2", true);
+        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", true);
+        VisitResponseDTO visitResponseDTO2 = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", true);
         when(visitsServiceClient.getAllVisits()).thenReturn(Flux.just(visitResponseDTO,visitResponseDTO2));
 
         client.get()
@@ -1632,7 +1632,7 @@ class ApiGatewayControllerTest {
         VisitDetails visit = new VisitDetails();
         visit.setVisitId(UUID.randomUUID().toString());
         visit.setPetId("1");
-        visit.setVisitDate(LocalDateTime.parse("2021-12-12T14:00:00"));
+        visit.setVisitDate(LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
         visit.setDescription("Charle's Richard cat has a paw infection.");
         visit.setStatus(false);
         visit.setPractitionerId(1);
@@ -1647,7 +1647,7 @@ class ApiGatewayControllerTest {
                 .expectBody()
                 .jsonPath("$[0].visitId").isEqualTo(visit.getVisitId())
                 .jsonPath("$[0].petId").isEqualTo("1")
-                .jsonPath("$[0].visitDate").isEqualTo("2021-12-12T14:00:00")
+                .jsonPath("$[0].visitDate").isEqualTo("2022-11-25 13:45")
                 .jsonPath("$[0].description").isEqualTo("Charle's Richard cat has a paw infection.")
                 .jsonPath("$[0].practitionerId").isEqualTo(1);
     }
@@ -1657,7 +1657,7 @@ class ApiGatewayControllerTest {
         VisitDetails visit = new VisitDetails();
         visit.setVisitId(UUID.randomUUID().toString());
         visit.setPetId("1");
-        visit.setVisitDate(LocalDateTime.parse("2021-12-12T14:00:00"));
+        visit.setVisitDate(LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
         visit.setDescription("Charle's Richard cat has a paw infection.");
         visit.setStatus(false);
         visit.setPractitionerId(1);
@@ -1672,7 +1672,7 @@ class ApiGatewayControllerTest {
                 .expectBody()
                 .jsonPath("$[0].visitId").isEqualTo(visit.getVisitId())
                 .jsonPath("$[0].petId").isEqualTo("1")
-                .jsonPath("$[0].visitDate").isEqualTo("2021-12-12T14:00:00")
+                .jsonPath("$[0].visitDate").isEqualTo("2022-11-25 13:45")
                 .jsonPath("$[0].description").isEqualTo("Charle's Richard cat has a paw infection.")
                 .jsonPath("$[0].practitionerId").isEqualTo(1);
     }
@@ -1705,7 +1705,7 @@ class ApiGatewayControllerTest {
 
     @Test
     void getSingleVisit_Valid() {
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25T13:45:00"), "this is a dummy description", "2", "2", true);
+        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", true);
         when(visitsServiceClient.getVisitByVisitId(anyString())).thenReturn(Mono.just(visitResponseDTO));
 
         client.get()
@@ -1715,7 +1715,7 @@ class ApiGatewayControllerTest {
                 .expectBody()
                 .jsonPath("$.visitId").isEqualTo(visitResponseDTO.getVisitId())
                 .jsonPath("$.petId").isEqualTo(visitResponseDTO.getPetId())
-                .jsonPath("$.visitDate").isEqualTo("2022-11-25T13:45:00")
+                .jsonPath("$.visitDate").isEqualTo("2022-11-25 13:45")
                 .jsonPath("$.description").isEqualTo(visitResponseDTO.getDescription())
                 .jsonPath("$.practitionerId").isEqualTo(visitResponseDTO.getPractitionerId());
     }
@@ -1745,13 +1745,13 @@ class ApiGatewayControllerTest {
         VisitDetails visit2 = new VisitDetails();
         visit1.setVisitId(UUID.randomUUID().toString());
         visit1.setPetId("21");
-        visit1.setVisitDate(LocalDateTime.parse("2021-12-07T14:00:00"));
+        visit1.setVisitDate(LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
         visit1.setDescription("John Smith's cat has a paw infection.");
         visit1.setStatus(false);
         visit1.setPractitionerId(2);
         visit2.setVisitId(UUID.randomUUID().toString());
         visit2.setPetId("21");
-        visit2.setVisitDate(LocalDateTime.parse("2021-12-08T15:00:00"));
+        visit2.setVisitDate(LocalDateTime.parse("2022-11-25 14:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
         visit2.setDescription("John Smith's dog has a paw infection.");
         visit2.setStatus(false);
         visit2.setPractitionerId(2);
@@ -1772,13 +1772,13 @@ class ApiGatewayControllerTest {
                 .expectBody()
                 .jsonPath("$[0].visitId").isEqualTo(visit1.getVisitId())
                 .jsonPath("$[0].petId").isEqualTo("21")
-                .jsonPath("$[0].visitDate").isEqualTo("2021-12-07T14:00:00")
+                .jsonPath("$[0].visitDate").isEqualTo("2022-11-25 13:45")
                 .jsonPath("$[0].description").isEqualTo("John Smith's cat has a paw infection.")
                 .jsonPath("$[0].status").isEqualTo(false)
                 .jsonPath("$[0].practitionerId").isEqualTo(2)
                 .jsonPath("$[1].visitId").isEqualTo(visit2.getVisitId())
                 .jsonPath("$[1].petId").isEqualTo("21")
-                .jsonPath("$[1].visitDate").isEqualTo("2021-12-08T15:00:00")
+                .jsonPath("$[1].visitDate").isEqualTo("2022-11-25 14:45")
                 .jsonPath("$[1].description").isEqualTo("John Smith's dog has a paw infection.")
                 .jsonPath("$[1].status").isEqualTo(false)
                 .jsonPath("$[1].practitionerId").isEqualTo(2);
@@ -1810,13 +1810,13 @@ class ApiGatewayControllerTest {
         VisitDetails visit2 = new VisitDetails();
         visit1.setVisitId(UUID.randomUUID().toString());
         visit1.setPetId("21");
-        visit1.setVisitDate(LocalDateTime.parse("2021-12-07T14:00:00"));
+        visit1.setVisitDate(LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
         visit1.setDescription("John Smith's cat has a paw infection.");
         visit1.setStatus(true);
         visit1.setPractitionerId(2);
         visit2.setVisitId(UUID.randomUUID().toString());
         visit2.setPetId("21");
-        visit2.setVisitDate(LocalDateTime.parse("2021-12-08T15:00"));
+        visit2.setVisitDate(LocalDateTime.parse("2022-11-25 14:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
         visit2.setDescription("John Smith's dog has a paw infection.");
         visit2.setStatus(true);
         visit2.setPractitionerId(2);
@@ -1837,13 +1837,13 @@ class ApiGatewayControllerTest {
                 .expectBody()
                 .jsonPath("$[0].visitId").isEqualTo(visit1.getVisitId())
                 .jsonPath("$[0].petId").isEqualTo(21)
-                .jsonPath("$[0].visitDate").isEqualTo("2021-12-07T14:00:00")
+                .jsonPath("$[0].visitDate").isEqualTo("2022-11-25 13:45")
                 .jsonPath("$[0].description").isEqualTo("John Smith's cat has a paw infection.")
                 .jsonPath("$[0].status").isEqualTo(true)
                 .jsonPath("$[0].practitionerId").isEqualTo(2)
                 .jsonPath("$[1].visitId").isEqualTo(visit2.getVisitId())
                 .jsonPath("$[1].petId").isEqualTo(21)
-                .jsonPath("$[1].visitDate").isEqualTo("2021-12-08T15:00:00")
+                .jsonPath("$[1].visitDate").isEqualTo("2022-11-25 14:45")
                 .jsonPath("$[1].description").isEqualTo("John Smith's dog has a paw infection.")
                 .jsonPath("$[1].status").isEqualTo(true)
                 .jsonPath("$[1].practitionerId").isEqualTo(2);
@@ -1933,6 +1933,21 @@ class ApiGatewayControllerTest {
         Mockito.verify(visitsServiceClient, times(1))
                 .deleteVisitByVisitId(invalidId);
     }
+
+    private VisitResponseDTO buildVisitResponseDTO(){
+        return VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .practitionerId(UUID.randomUUID().toString())
+                .status(true)
+                .build();
+    }
+    /**
+     * End of Visits Methods
+     * **/
+
 
 
 
@@ -2364,19 +2379,6 @@ void deleteAllInventory_shouldSucceed() {
                 .rateScore(4.0)
                 .build();
     }
-
-    private VisitResponseDTO buildVisitResponseDTO(){
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-        String visitId = UUID.randomUUID().toString();
-        return VisitResponseDTO.builder()
-                .visitId(visitId)
-                .visitDate(LocalDateTime.parse("2023-01-21T21:00:00", dtf))
-                .description("delete this desc")
-                .petId("2")
-                .practitionerId("2")
-                .status(true)
-                .build();
-        }
 
     @Test
     void sendForgottenEmail_ShouldSucceed(){

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
@@ -17,6 +17,8 @@ public interface VisitService {
     Mono<VisitResponseDTO> updateVisit(String visitId, Mono<VisitRequestDTO> visitRequestDTOMono);
     Mono<Void> deleteVisit(String visitId);
 
+    //test
+
 
 //    Mono<VetDTO> testingGetVetDTO(String vetId);
 //    Mono<PetResponseDTO> testingGetPetDTO(int petId);

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
@@ -7,6 +7,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
@@ -15,24 +16,26 @@ public class DataSetupService implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        Visit visit1 = buildVisit("visitId1", LocalDateTime.parse("2022-11-24T13:00:00"), "this is a dummy description", "2", "2200332", true);
-        Visit visit2 = buildVisit("visitId2", LocalDateTime.parse("2022-03-01T13:00:00"), "Dog Needs Meds", "1", "2200332", true);
-        Visit visit3 = buildVisit("visitId3", LocalDateTime.parse("2020-07-19T13:00:00"),"Dog Needs Surgery After Meds", "1", "2200332", false);
-        Visit visit4 = buildVisit("visitId4", LocalDateTime.parse("2022-12-24T13:00:00"), "Dog Needs Physio-Therapy", "1", "2200332", true);
+        Visit visit1 = buildVisit("visitId1", "2022-11-24 13:00", "this is a dummy description", "2", "2200332", true);
+        Visit visit2 = buildVisit("visitId2", "2022-03-01 13:00", "Dog Needs Meds", "1", "2200332", true);
+        Visit visit3 = buildVisit("visitId3", "2020-07-19 13:00","Dog Needs Surgery After Meds", "1", "2200332", false);
+        Visit visit4 = buildVisit("visitId4", "2022-12-24 13:00", "Dog Needs Physio-Therapy", "1", "2200332", true);
 
         Flux.just(visit1, visit2, visit3, visit4).flatMap(x -> visitRepo.insert(Mono.just(x)).log(x.toString())).subscribe();
     }
 
-
-    private Visit buildVisit(String visitId, LocalDateTime visitDate, String description, String petId, String practitionerId, boolean status){
+    private Visit buildVisit(String visitId, String visitDate, String description, String petId, String practitionerId, boolean status){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        LocalDateTime parsedVisitDate = LocalDateTime.parse(visitDate, formatter);
 
         return Visit.builder()
                 .visitId(visitId)
-                .visitDate(visitDate)
+                .visitDate(parsedVisitDate)
                 .description(description)
                 .petId(petId)
                 .practitionerId(practitionerId)
                 .status(status)
                 .build();
     }
+
 }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/Visit.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/Visit.java
@@ -1,5 +1,6 @@
 package com.petclinic.visits.visitsservicenew.DataLayer;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import java.time.LocalDateTime;
@@ -16,6 +17,7 @@ public class Visit {
 
     private String visitId;
 
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     LocalDateTime visitDate;
 
     private String description;

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitRequestDTO.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitRequestDTO.java
@@ -1,6 +1,7 @@
 package com.petclinic.visits.visitsservicenew.PresentationLayer;
 
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,6 +13,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 public class VisitRequestDTO {
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime visitDate;
 /*    private int year;
     private int month;

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitResponseDTO.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitResponseDTO.java
@@ -1,5 +1,6 @@
 package com.petclinic.visits.visitsservicenew.PresentationLayer;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,6 +14,8 @@ import java.time.LocalDateTime;
 @Builder
 public class VisitResponseDTO {
     private String visitId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime visitDate;
 /*   private int year;
     private int month;

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
@@ -7,17 +7,12 @@ import com.petclinic.visits.visitsservicenew.Exceptions.BadRequestException;
 import com.petclinic.visits.visitsservicenew.Exceptions.NotFoundException;
 import com.petclinic.visits.visitsservicenew.PresentationLayer.VisitRequestDTO;
 import com.petclinic.visits.visitsservicenew.PresentationLayer.VisitResponseDTO;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -28,7 +23,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -62,18 +56,18 @@ class VisitServiceImplTest {
     private final String PET_ID = visitResponseDTO.getPetId();
     private final String VISIT_ID = visitResponseDTO.getVisitId();
 
-    String uuid1 = UUID.randomUUID().toString();
-    String uuid2 = UUID.randomUUID().toString();
-    String uuid3 = UUID.randomUUID().toString();
-    String uuid4 = UUID.randomUUID().toString();
-    String uuid5 = UUID.randomUUID().toString();
-    String uuid6 = UUID.randomUUID().toString();
+    String uuidVisit1 = UUID.randomUUID().toString();
+    String uuidVisit2 = UUID.randomUUID().toString();
+    String uuidVet = UUID.randomUUID().toString();
+    String uuidPet = UUID.randomUUID().toString();
+    String uuidPhoto = UUID.randomUUID().toString();
+    String uuidOwner = UUID.randomUUID().toString();
 
     Set<SpecialtyDTO> set= new HashSet<>();
 
 
     VetDTO vet = VetDTO.builder()
-            .vetId(uuid3)
+            .vetId(uuidVet)
             .vetBillId("1")
             .firstName("James")
             .lastName("Carter")
@@ -88,18 +82,18 @@ class VisitServiceImplTest {
 
     Date currentDate =new Date();
     PetResponseDTO petResponseDTO = PetResponseDTO.builder()
-            .petTypeId(uuid4)
+            .petTypeId(uuidPet)
             .name("Billy")
             .birthDate(currentDate)
-            .photoId(uuid5)
-            .ownerId(uuid6)
+            .photoId(uuidPhoto)
+            .ownerId(uuidOwner)
             .build();
 
 
 
 
-    Visit visit1 = buildVisit(uuid1,"this is a dummy description",vet.getVetId());
-    Visit visit2 = buildVisit(uuid2,"this is a dummy description",vet.getVetId());
+    Visit visit1 = buildVisit(uuidVisit1,"this is a dummy description",vet.getVetId());
+    Visit visit2 = buildVisit(uuidVisit2,"this is a dummy description",vet.getVetId());
 
     @Test
     void getVisitByVisitId(){
@@ -182,7 +176,6 @@ class VisitServiceImplTest {
 
         StepVerifier.create(visitService.addVisit(Mono.just(visitRequestDTO)))
                 .consumeNextWith(visitDTO1 -> {
-                    assertEquals(visit1.getVisitId(), visitDTO1.getVisitId());
                     assertEquals(visit1.getDescription(), visitDTO1.getDescription());
                     assertEquals(visit1.getPetId(), visitDTO1.getPetId());
                     assertEquals(visit1.getVisitDate(), visitDTO1.getVisitDate());
@@ -193,7 +186,7 @@ class VisitServiceImplTest {
     @Test
     void deleteVisitById_visitId_shouldSucceed(){
         //arrange
-        String visitId = uuid1.toString();
+        String visitId = uuidVisit1.toString();
 
         Mockito.when(visitRepo.existsByVisitId(visitId)).thenReturn(Mono.just(true));
         Mockito.when(visitRepo.deleteByVisitId(visitId)).thenReturn(Mono.empty());
@@ -212,7 +205,7 @@ class VisitServiceImplTest {
     @Test
     void deleteVisitById_visitDoesNotExist_shouldThrowNotFoundException() {
         // Arrange
-        String visitId = uuid1.toString();
+        String visitId = UUID.randomUUID().toString();
 
         // Mock the existsByVisitId method to return false, indicating that the visit does not exist
         Mockito.when(visitRepo.existsByVisitId(visitId)).thenReturn(Mono.just(false));
@@ -249,33 +242,33 @@ class VisitServiceImplTest {
 
 
     private Visit buildVisit(String uuid,String description, String vetId){
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
         return Visit.builder()
                 .visitId(uuid)
-                .visitDate(LocalDateTime.parse("2023-11-25T13:45", dtf))
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description(description)
                 .petId("2")
                 .practitionerId(vetId)
-                .status(true).build();
+                .status(true)
+                .build();
     }
     private VisitResponseDTO buildVisitResponseDTO(){
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
         return VisitResponseDTO.builder()
                 .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
-                .visitDate(LocalDateTime.parse("2023-11-25T13:45:00", dtf))
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("this is a dummy description")
                 .petId("2")
                 .practitionerId(UUID.randomUUID().toString())
-                .status(true).build();
+                .status(true)
+                .build();
     }
     private VisitRequestDTO buildVisitRequestDTO() {
-            DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
             return VisitRequestDTO.builder()
-                    .visitDate(LocalDateTime.parse("2023-11-25T13:45:00", dtf))
+                    .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                     .description("this is a dummy description")
                     .petId("2")
                     .practitionerId(UUID.randomUUID().toString())
-                    .status(true).build();
+                    .status(true)
+                    .build();
         }
 
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/DataLayer/VisitRepoTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/DataLayer/VisitRepoTest.java
@@ -17,16 +17,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class VisitRepoTest {
     @Autowired
     private VisitRepo visitRepo;
-    private final Visit visit1 = buildVisit("73b5c112-5703-4fb7-b7bc-ac8186811ae1", "2");
-    private final Visit visit2 = buildVisit("visitId2", "2");
-    private final Visit visit3 = buildVisit("visitId3", "3");
+    String uuidVisit1 = UUID.randomUUID().toString();
+    String uuidVisit2 = UUID.randomUUID().toString();
+    Visit visit1 = buildVisit(uuidVisit1, "testing 1", "2200332");
+    Visit visit2 = buildVisit(uuidVisit2, "testing 1", "2200333");
+
+
 
     @BeforeEach
     void setupDb(){
         Publisher<Visit> visitPublisher = visitRepo.deleteAll()
                 .thenMany(visitRepo.save(visit1))
-                .thenMany(visitRepo.save(visit2))
-                .thenMany(visitRepo.save(visit3));
+                .thenMany(visitRepo.save(visit2));
         StepVerifier.create(visitPublisher)
                 .expectNextCount(1)
                 .verifyComplete();
@@ -80,15 +82,13 @@ class VisitRepoTest {
 
 
 
-
-    private Visit buildVisit(String visitId, String petId){
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private Visit buildVisit(String uuid,String description, String vetId){
         return Visit.builder()
-                .visitId(visitId)
-                .visitDate(LocalDateTime.parse("2022-11-25T13:45:00"))
-                .description("this is a dummy description")
-                .petId(petId)
-                .practitionerId(UUID.randomUUID().toString())
+                .visitId(uuid)
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description(description)
+                .petId("2")
+                .practitionerId(vetId)
                 .status(true).build();
     }
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -39,17 +39,18 @@ class VisitControllerUnitTest {
     @MockBean
     private PetsClient petsClient;
 
-    String uuid1 = UUID.randomUUID().toString();
-    String uuid2 = UUID.randomUUID().toString();
-    String uuid3 = UUID.randomUUID().toString();
-    String uuid4 = UUID.randomUUID().toString();
+    String uuidVisit1 = UUID.randomUUID().toString();
+    String uuidVet = UUID.randomUUID().toString();
+    String uuidPet = UUID.randomUUID().toString();
+    String uuidPhoto = UUID.randomUUID().toString();
+    String uuidOwner = UUID.randomUUID().toString();
 
 
     Set<SpecialtyDTO> set= new HashSet<>();
 
 
     VetDTO vet = VetDTO.builder()
-            .vetId(uuid1)
+            .vetId(uuidVet)
             .vetBillId("1")
             .firstName("James")
             .lastName("Carter")
@@ -64,14 +65,14 @@ class VisitControllerUnitTest {
 
     Date currentDate =new Date();
     PetResponseDTO petResponseDTO = PetResponseDTO.builder()
-            .petTypeId(uuid2)
+            .petTypeId(uuidPet)
             .name("Billy")
             .birthDate(currentDate)
-            .photoId(uuid3)
-            .ownerId(uuid4)
+            .photoId(uuidPhoto)
+            .ownerId(uuidOwner)
             .build();
 
-    Visit visit1 = buildVisit(uuid1,"this is a dummy description",vet.getVetId());
+    Visit visit1 = buildVisit(uuidVisit1,"this is a dummy description",vet.getVetId());
     private final VisitResponseDTO visitResponseDTO = buildVisitResponseDto();
     private final VisitRequestDTO visitRequestDTO = buildVisitRequestDTO(vet.getVetId());
     private final String Visit_UUID_OK = visitResponseDTO.getVisitId();
@@ -105,7 +106,7 @@ class VisitControllerUnitTest {
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
                 .jsonPath("$.visitId").isEqualTo(visitResponseDTO.getVisitId())
-                .jsonPath("$.visitDate").isEqualTo("2022-11-25T13:45:00")
+                .jsonPath("$.visitDate").isEqualTo("2024-11-25 13:45")
                 .jsonPath("$.description").isEqualTo(visitResponseDTO.getDescription())
                 .jsonPath("$.petId").isEqualTo(visitResponseDTO.getPetId())
                 .jsonPath("$.practitionerId").isEqualTo(visitResponseDTO.getPractitionerId())
@@ -242,36 +243,36 @@ class VisitControllerUnitTest {
                 .jsonPath("$.message", "No visit was found with visitId: " + invalidVisitId);
     }
 
-
-
-    private VisitResponseDTO buildVisitResponseDto(){
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-        return VisitResponseDTO.builder()
-                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
-                .visitDate(LocalDateTime.parse("2022-11-25T13:45:00", dtf))
-                .description("this is a dummy description")
-                .petId("2")
-                .practitionerId(UUID.randomUUID().toString())
-                .status(true).build();
-    }
-    private VisitRequestDTO buildVisitRequestDTO(String vetId){
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-        return VisitRequestDTO.builder()
-                .visitDate(LocalDateTime.parse("2022-11-25T13:45:00", dtf))
-                .description("this is a dummy description")
-                .petId("2")
-                .practitionerId(UUID.randomUUID().toString())
-                .status(true).build();
-    }
-
-    private Visit buildVisit(String uuid, String description, String vetId){
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+    private Visit buildVisit(String uuid,String description, String vetId){
         return Visit.builder()
                 .visitId(uuid)
-                .visitDate(LocalDateTime.parse("2022-11-25T13:45", dtf))
+                .visitDate(LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description(description)
                 .petId("2")
                 .practitionerId(vetId)
-                .status(true).build();
+                .status(true)
+                .build();
     }
+
+
+    private VisitResponseDTO buildVisitResponseDto(){
+        return VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .practitionerId(UUID.randomUUID().toString())
+                .status(true)
+                .build();
+    }
+    private VisitRequestDTO buildVisitRequestDTO(String vetId){
+        return VisitRequestDTO.builder()
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .practitionerId(vetId)
+                .status(true)
+                .build();
+    }
+
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -41,17 +41,17 @@ class VisitsControllerIntegrationTest {
     @MockBean
     private PetsClient petsClient;
 
-    String uuid1 = UUID.randomUUID().toString();
-    String uuid2 = UUID.randomUUID().toString();
-    String uuid3 = UUID.randomUUID().toString();
-    String uuid4 = UUID.randomUUID().toString();
-    String uuid5 = UUID.randomUUID().toString();
-    String uuid6 = UUID.randomUUID().toString();
+    String uuidVisit1 = UUID.randomUUID().toString();
+    String uuidVisit2 = UUID.randomUUID().toString();
+    String uuidVet = UUID.randomUUID().toString();
+    String uuidPet = UUID.randomUUID().toString();
+    String uuidPhoto = UUID.randomUUID().toString();
+    String uuidOwner = UUID.randomUUID().toString();
 
     Set<SpecialtyDTO> set= new HashSet<>();
 
     VetDTO vet = VetDTO.builder()
-            .vetId(uuid3)
+            .vetId(uuidVet)
             .vetBillId("1")
             .firstName("James")
             .lastName("Carter")
@@ -66,15 +66,15 @@ class VisitsControllerIntegrationTest {
 
     Date currentDate =new Date();
     PetResponseDTO petResponseDTO = PetResponseDTO.builder()
-            .petTypeId(uuid4)
+            .petTypeId(uuidPet)
             .name("Billy")
             .birthDate(currentDate)
-            .photoId(uuid5)
-            .ownerId(uuid6)
+            .photoId(uuidPhoto)
+            .ownerId(uuidOwner)
             .build();
 
-    Visit visit1 = buildVisit(uuid1,"this is a dummy description",vet.getVetId());
-    Visit visit2 = buildVisit(uuid2,"this is a dummy description",vet.getVetId());
+    Visit visit1 = buildVisit(uuidVisit1,"this is a dummy description",vet.getVetId());
+    Visit visit2 = buildVisit(uuidVisit2,"this is a dummy description",vet.getVetId());
     private final VisitResponseDTO visitResponseDTO = buildVisitResponseDto(visit1.getVisitId(),vet.getVetId());
     private final VisitRequestDTO visitRequestDTO = buildVisitRequestDto(vet.getVetId());
 
@@ -120,7 +120,7 @@ class VisitsControllerIntegrationTest {
                 .jsonPath("$.practitionerId").isEqualTo(visit1.getPractitionerId())
                 .jsonPath("$.petId").isEqualTo(visit1.getPetId())
                 .jsonPath("$.description").isEqualTo(visit1.getDescription())
-                .jsonPath("$.visitDate").isEqualTo("2023-11-25T13:45:00")
+                .jsonPath("$.visitDate").isEqualTo("2024-11-25 13:45")
                 .jsonPath("$.status").isEqualTo(visit1.isStatus());
     }
     @Test
@@ -214,7 +214,7 @@ class VisitsControllerIntegrationTest {
                 .value((visitDTO1) -> {
                     assertEquals(visitDTO1.getDescription(), visit1.getDescription());
                     assertEquals(visitDTO1.getPetId(), visit1.getPetId());
-                    assertEquals(visitDTO1.getVisitDate(), LocalDateTime.parse("2023-11-25T13:45"));
+                    assertEquals(visitDTO1.getVisitDate(), LocalDateTime.parse("2024-11-25 13:45",DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
                     assertEquals(visitDTO1.getPractitionerId(), visit1.getPractitionerId());
                 });
     }
@@ -245,38 +245,39 @@ class VisitsControllerIntegrationTest {
                 .jsonPath("$.practitionerId").isEqualTo(visit1.getPractitionerId())
                 .jsonPath("$.petId").isEqualTo(visit1.getPetId())
                 .jsonPath("$.description").isEqualTo(visit1.getDescription())
-                .jsonPath("$.visitDate").isEqualTo("2023-11-25T13:45:00")
+                .jsonPath("$.visitDate").isEqualTo("2024-11-25 13:45")
                 .jsonPath("$.status").isEqualTo(visit1.isStatus());
     }
 
     private Visit buildVisit(String uuid,String description, String vetId){
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
         return Visit.builder()
                 .visitId(uuid)
-                .visitDate(LocalDateTime.parse("2023-11-25T13:45", dtf))
+
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description(description)
                 .petId("2")
                 .practitionerId(vetId)
-                .status(true).build();
+                .status(true)
+                .build();
     }
 
     private VisitResponseDTO buildVisitResponseDto(String visitId,String vetId){
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
         return VisitResponseDTO.builder()
                 .visitId(visitId)
-                .visitDate(LocalDateTime.parse("2023-11-25T13:45:00", dtf))
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("this is a dummy description")
                 .petId("2")
                 .practitionerId(vetId)
-                .status(true).build();
+                .status(true)
+                .build();
     }
     private VisitRequestDTO buildVisitRequestDto(String vetId){
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
         return VisitRequestDTO.builder()
-                .visitDate(LocalDateTime.parse("2023-11-25T13:45:00", dtf))
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("this is a dummy description")
                 .petId("2")
                 .practitionerId(vetId)
-                .status(true).build();
+                .status(true)
+                .build();
     }
 }


### PR DESCRIPTION
JIRA: link to jira ticket
https://champlainsaintlambert.atlassian.net/browse/CPC-949

## Context:
This ticket was to modify the visitDate variable's LocalDateTime format to disregard seconds and milliseconds through the use of @JsonFormat(pattern = "yyyy-MM-dd HH:mm") as well as an updated DateTimeFormatter.

## Changes
- modified all date logic in visits-serivce-new 
- modified all visits tests in api-gateway

## Before and After UI (Required for UI-impacting PRs)
Before changes
![image](https://github.com/cgerard321/champlain_petclinic/assets/77695020/c6402b85-b636-49ab-91c9-38e0ca242eac)


After changes
![image](https://github.com/cgerard321/champlain_petclinic/assets/77695020/ae1182b5-6b9f-4bb6-91a8-9c20b23c2cd2)


## Linked pull requests (Optional)
- [pull request link](https://github.com/cgerard321/champlain_petclinic/pull/408)
