### PR TITLE
Bug/cpc 881 cstm   fix pet is active status and patch related tests on api gateway

### DIFF
--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/CustomerServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/CustomerServiceClientIntegrationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerRequestDTO;
 import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerResponseDTO;
+import com.petclinic.bffapigateway.dtos.Pets.PetRequestDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetResponseDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetType;
 import com.petclinic.bffapigateway.dtos.Vets.PhotoDetails;
@@ -22,6 +23,7 @@ import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static reactor.core.publisher.Mono.just;
 
 public class CustomerServiceClientIntegrationTest {
 
@@ -59,6 +61,7 @@ public class CustomerServiceClientIntegrationTest {
             .birthDate("2015-03-03")
             .type(type)
             .imageId(2)
+            .isActive("true")
             .build();
 
 
@@ -168,6 +171,33 @@ public class CustomerServiceClientIntegrationTest {
         assertEquals(updatedPetResponse.getPetId(), responseDTO.getPetId());
         assertEquals(updatedPetResponse.getName(), responseDTO.getName());
     }
+
+
+    @Test
+    void testPatchPet() throws Exception {
+        PetRequestDTO petRequestDTO = new PetRequestDTO(); // Create a request DTO
+        petRequestDTO.setPetId("petId-123");
+        petRequestDTO.setIsActive("true"); // Set the isActive status
+
+        PetResponseDTO updatedPetResponse = new PetResponseDTO(); // Create an expected response DTO
+        updatedPetResponse.setPetId("petId-123");
+        updatedPetResponse.setIsActive("true"); // Set the isActive status in the expected response
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(mapper.writeValueAsString(updatedPetResponse))); // Use the expected response DTO
+
+        Mono<PetResponseDTO> responseMono = customersServiceClient.patchPet(petRequestDTO, "petId-123");
+
+        PetResponseDTO responseDTO = responseMono.block(); // Blocking for simplicity
+
+        // Verify the response
+        assertEquals(updatedPetResponse.getPetId(), responseDTO.getPetId());
+        assertEquals(updatedPetResponse.getIsActive(), responseDTO.getIsActive()); // Check the isActive status
+    }
+
+
 
 
     @Test

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -12,6 +12,7 @@ import com.petclinic.bffapigateway.dtos.Inventory.*;
 import com.petclinic.bffapigateway.dtos.Inventory.InventoryRequestDTO;
 import com.petclinic.bffapigateway.dtos.Inventory.InventoryResponseDTO;
 import com.petclinic.bffapigateway.dtos.Inventory.ProductResponseDTO;
+import com.petclinic.bffapigateway.dtos.Pets.PetRequestDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetResponseDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetType;
 import com.petclinic.bffapigateway.dtos.Vets.*;
@@ -779,6 +780,7 @@ class ApiGatewayControllerTest {
         pet.setName("Fluffy");
         pet.setBirthDate("2000-01-01");
         pet.setType(type);
+        pet.setIsActive("true");
 
         when(customersServiceClient.createPet(pet,od.getOwnerId()))
 
@@ -797,7 +799,8 @@ class ApiGatewayControllerTest {
                 .jsonPath("$.petId").isEqualTo(pet.getPetId())
                 .jsonPath("$.name").isEqualTo(pet.getName())
                 .jsonPath("$.birthDate").isEqualTo(pet.getBirthDate())
-                .jsonPath("$.type").isEqualTo(pet.getType());
+                .jsonPath("$.type").isEqualTo(pet.getType())
+                .jsonPath("$.isActive").isEqualTo(pet.getIsActive());
 
     }
 
@@ -812,6 +815,7 @@ class ApiGatewayControllerTest {
         pet.setName("Fluffy");
         pet.setBirthDate("2000-01-01");
         pet.setType(type);
+        pet.setIsActive("true");
 
         when(customersServiceClient.updatePet(any(PetResponseDTO.class), any(String.class)))
                 .thenReturn(Mono.just(pet));
@@ -827,8 +831,35 @@ class ApiGatewayControllerTest {
                 .jsonPath("$.petId").isEqualTo(pet.getPetId())
                 .jsonPath("$.name").isEqualTo(pet.getName())
                 .jsonPath("$.birthDate").isEqualTo(pet.getBirthDate())
-                .jsonPath("$.type").isEqualTo(pet.getType());
+                .jsonPath("$.type").isEqualTo(pet.getType())
+                .jsonPath("$.isActive").isEqualTo(pet.getIsActive());
     }
+
+    @Test
+    void shouldPatchPet() {
+        PetRequestDTO petRequest = new PetRequestDTO();
+        petRequest.setIsActive("false");
+
+        PetResponseDTO petResponse = new PetResponseDTO();
+        petResponse.setPetId("30");
+        petResponse.setIsActive("false");
+
+        when(customersServiceClient.patchPet(any(PetRequestDTO.class), any(String.class)))
+                .thenReturn(Mono.just(petResponse));
+
+        client.patch()
+                .uri("/api/gateway/pet/{petId}", petResponse.getPetId())
+                .body(fromValue(petRequest))
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.petId").isEqualTo(petResponse.getPetId())
+                .jsonPath("$.isActive").isEqualTo(petResponse.getIsActive());
+    }
+
+
 
 
     //
@@ -1017,6 +1048,7 @@ class ApiGatewayControllerTest {
         pet.setName("Fluffy");
         pet.setBirthDate("2000-01-01");
         pet.setType(type);
+        pet.setIsActive("true");
 
         when(customersServiceClient.createPet(pet,od.getOwnerId()))
                 .thenReturn(Mono.just(pet));
@@ -1082,6 +1114,7 @@ class ApiGatewayControllerTest {
         pet.setName("Fluffy");
         pet.setBirthDate("2000-01-01");
         pet.setType(type);
+        pet.setIsActive("true");
 
         when(customersServiceClient.createPet(pet,od.getOwnerId()))
 
@@ -1116,6 +1149,7 @@ class ApiGatewayControllerTest {
         pet.setName("Fluffy");
         pet.setBirthDate("2000-01-01");
         pet.setType(type);
+        pet.setIsActive("true");
 
         when(customersServiceClient.createPet(pet,od.getOwnerId()))
                 .thenReturn(Mono.just(pet));

--- a/customers-service-reactive/src/test/java/com/petclinic/customersservice/presentationlayer/PetControllerIntegrationTest.java
+++ b/customers-service-reactive/src/test/java/com/petclinic/customersservice/presentationlayer/PetControllerIntegrationTest.java
@@ -101,7 +101,8 @@ class PetControllerIntegrationTest {
                 .jsonPath("$.name").isEqualTo(petEntity.getName())
                 .jsonPath("$.petTypeId").isEqualTo(petEntity.getPetTypeId())
                 .jsonPath("$.ownerId").isEqualTo(petEntity.getOwnerId())
-                .jsonPath("$.photoId").isEqualTo(petEntity.getPhotoId());
+                .jsonPath("$.photoId").isEqualTo(petEntity.getPhotoId())
+                .jsonPath("$.isActive").isEqualTo(petEntity.getIsActive());
     }
 
     @Test
@@ -118,8 +119,23 @@ class PetControllerIntegrationTest {
                 .jsonPath("$.name").isEqualTo(petEntity.getName())
                 .jsonPath("$.petTypeId").isEqualTo(petEntity.getPetTypeId())
                 .jsonPath("$.ownerId").isEqualTo(petEntity.getOwnerId())
-                .jsonPath("$.photoId").isEqualTo(petEntity.getPhotoId());
+                .jsonPath("$.photoId").isEqualTo(petEntity.getPhotoId())
+                .jsonPath("$.isActive").isEqualTo(petEntity.getIsActive());
 
+
+    }
+
+    @Test
+    void updatePetIsActive() {
+        Publisher<Pet> setup = repo.deleteAll().thenMany(repo.save(petEntity));
+        StepVerifier.create(setup).expectNextCount(1).verifyComplete();
+        client.patch().uri("/pet/" + PET_ID)
+                .body(Mono.just(petEntity), Pet.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange().expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.isActive").isEqualTo(petEntity.getIsActive());
     }
 
     private Pet buildPet() {
@@ -130,6 +146,7 @@ class PetControllerIntegrationTest {
                 .ownerId("111")
                 .petTypeId("111")
                 .photoId("111")
+                .isActive("true")
                 .build();
     }
 


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-881
## Context:
Increase jacoco coverage on the api-gateway and customer-service
## Changes:
Added isActive status patch testing on api-gateway and customer-service-reactive, fixed up some tests that require isActive as a variable.
## Test Coverage:
![image](https://github.com/cgerard321/champlain_petclinic/assets/15218772/00da2a7c-3092-46b9-8128-5ce0e873197f)
Up from 94%

**Gateway Tests**

![image](https://github.com/cgerard321/champlain_petclinic/assets/15218772/054720ec-6332-4e00-a8cb-f33b95f2320a)
 
![image](https://github.com/cgerard321/champlain_petclinic/assets/15218772/b427e56d-6d94-4809-b494-fcc18764bea0)



