### PR TITLE
feat/(VETS-CPC-941): Delete vets education implemented

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -234,4 +234,14 @@ public class VetsServiceClient {
         return educationResponseDTOFlux;
     }
 
+    public Mono<Void> deleteEducation(String vetId, String educationId) {
+        Mono<Void> result = webClientBuilder
+                .build()
+                .delete()
+                .uri(vetsServiceUrl + "/" + vetId + "/educations" + "/" + educationId)
+                .retrieve()
+                .bodyToMono(Void.class);
+        return result;
+    }
+
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -242,6 +242,10 @@ public class BFFApiGatewayController {
      * End of Visit Methods
      **/
 
+    /**
+     * Start of Vet Methods
+     **/
+
     @GetMapping(value = "vets")
     public Flux<VetDTO> getAllVets() {
         return vetsServiceClient.getVets();
@@ -290,6 +294,17 @@ public class BFFApiGatewayController {
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
+    @GetMapping(value = "vets/{vetId}/educations")
+    public Flux<EducationResponseDTO> getEducationsByVetId(@PathVariable String vetId) {
+        return vetsServiceClient.getEducationsByVetId(VetsEntityDtoUtil.verifyId(vetId));
+    }
+
+    @DeleteMapping(value = "vets/{vetId}/educations/{educationId}")
+    public Mono<Void> deleteEducationByEducationId(@PathVariable String vetId,
+                                                   @PathVariable String educationId){
+        return vetsServiceClient.deleteEducation(vetId,educationId);
+    }
+
 
     @GetMapping("/vets/{vetId}")
     public Mono<ResponseEntity<VetDTO>> getVetByVetId(@PathVariable String vetId) {
@@ -330,7 +345,9 @@ public class BFFApiGatewayController {
         return vetsServiceClient.deleteVet(VetsEntityDtoUtil.verifyId(vetId));
     }
 
-
+    /**
+     * End of Vet Methods
+     **/
 //
 //    @DeleteMapping(value = "users/{userId}")
 //    public Mono<UserDetails> deleteUser(@RequestHeader(AUTHORIZATION) String auth, final @PathVariable long userId) {
@@ -567,8 +584,5 @@ public class BFFApiGatewayController {
         return inventoryServiceClient.deleteAllInventories();
     }
 
-    @GetMapping(value = "vets/{vetId}/educations")
-    public Flux<EducationResponseDTO> getEducationsByVetId(@PathVariable String vetId) {
-        return vetsServiceClient.getEducationsByVetId(VetsEntityDtoUtil.verifyId(vetId));
-    }
+
 }

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
@@ -24,6 +24,31 @@ angular.module('vetDetails')
             self.educations = resp.data;
         });
 
+        $scope.deleteVetEducation = function (educationId) {
+            let varIsConf = confirm('Are you sure you want to delete this educationId: ' + educationId + '?');
+            if (varIsConf) {
+
+                $http.delete('api/gateway/vets/' + $stateParams.vetId + '/educations/' + educationId)
+                    .then(successCallback, errorCallback)
+
+                function successCallback(response) {
+                    $scope.errors = [];
+                    alert(educationId + " Deleted Successfully!");
+                    console.log(response, 'res');
+                    //refresh list
+                    $http.get('api/gateway/vets/' + $stateParams.vetId + '/educations').then(function (resp) {
+                        self.educations = resp.data;
+                        arr = resp.data;
+                    });
+                }
+
+                function errorCallback(error) {
+                    alert(data.errors);
+                    console.log(error, 'cannot get data.');
+                }
+            }
+        };
+
         $http.get('api/gateway/vets/' + $stateParams.vetId + '/ratings/percentages')
             .then(function (resp) {
                 const ratingsData = resp.data;
@@ -62,7 +87,7 @@ angular.module('vetDetails')
 
                 function errorCallback(error) {
                     alert(data.errors);
-                    console.log(error, 'can not get data.');
+                    console.log(error, 'cannot get data.');
                 }
             }
         };

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
@@ -99,15 +99,20 @@
                             <th>Field Of Study</th>
                             <th>Start Year</th>
                             <th>End Year</th>
+                            <th>Delete</th>
                         </tr>
                         </thead>
                         <tbody>
-                            <tr ng-repeat="educations in $ctrl.educations track by educations.educatonId">
+
+                        <tr ng-repeat="educations in $ctrl.educations track by educations.educationId">
                                 <td>{{ educations.degree }}</td>
                                 <td>{{ educations.schoolName }}</td>
                                 <td>{{ educations.fieldOfStudy }}</td>
                                 <td>{{ educations.startDate }}</td>
                                 <td>{{ educations.endDate }}</td>
+                                <td>
+                                    <a class="btn btn-danger educationButton" href="javascript:void(0)" ng-click="deleteVetEducation(educations.educationId)">Delete Education</a>
+                                    </td>
                             </tr>
                         </tbody>
                     </table>

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
@@ -373,6 +373,27 @@ class VetsServiceClientIntegrationTest {
         assertEquals("2015", education.getStartDate());
         assertEquals("2019", education.getEndDate());
     }
+    @Test
+    void deleteEducationsByEducationId() throws JsonProcessingException{
+        final String educationId = "794ac37f-1e07-43c2-93bc-61839e61d989";
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setBody("    {\n" +
+                        "    \"educationId\": \"123456\",\n" +
+                        "    \"vetId\": \"678910\",\n" +
+                        "    \"schoolName\": \"University of Toronto\",\n" +
+                        "    \"degree\": \"Doctor of Veterinary Medicine\",\n" +
+                        "    \"fieldOfStudy\": \"Veterinary Medicine\",\n" +
+                        "    \"startDate\": \"2015\",\n" +
+                        "    \"endDate\": \"2019\"\n" +
+                        "    }"));
+
+
+        final Mono<Void> empty = vetsServiceClient.deleteEducation(vetDTO.getVetId(), educationId);
+
+        assertEquals(empty.block(), null);
+    }
 
     private void prepareResponse(Consumer<MockResponse> consumer) {
         MockResponse response = new MockResponse();

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -273,6 +273,46 @@ class ApiGatewayControllerTest {
                     assertThat(responseDTO.getRateDate()).isEqualTo(updatedRating.getRateDate());
                 });
     }
+    @Test
+    void getAllEducationsByVetId_WithValidId_ShouldSucceed(){
+        EducationResponseDTO educationResponseDTO = buildEducation();
+        when(vetsServiceClient.getEducationsByVetId(anyString()))
+                .thenReturn(Flux.just(educationResponseDTO));
+
+        client
+                .get()
+                .uri("/api/gateway/vets/" + VET_ID + "/educations")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$[0].educationId").isEqualTo(educationResponseDTO.getEducationId())
+                .jsonPath("$[0].vetId").isEqualTo(educationResponseDTO.getVetId())
+                .jsonPath("$[0].degree").isEqualTo(educationResponseDTO.getDegree())
+                .jsonPath("$[0].fieldOfStudy").isEqualTo(educationResponseDTO.getFieldOfStudy())
+                .jsonPath("$[0].schoolName").isEqualTo(educationResponseDTO.getSchoolName())
+                .jsonPath("$[0].startDate").isEqualTo(educationResponseDTO.getStartDate())
+                .jsonPath("$[0].endDate").isEqualTo(educationResponseDTO.getEndDate());
+
+    }
+
+    @Test
+    void deleteVetEducation() {
+        EducationResponseDTO educationResponseDTO = buildEducation();
+        when(vetsServiceClient.deleteEducation(VET_ID, educationResponseDTO.getEducationId()))
+                .thenReturn((Mono.empty()));
+
+        client
+                .delete()
+                .uri("/api/gateway/vets/" + VET_ID + "/educations/{educationId}", educationResponseDTO.getEducationId())
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk();
+
+        Mockito.verify(vetsServiceClient, times(1))
+                .deleteEducation(VET_ID, educationResponseDTO.getEducationId());
+    }
 
     @Test
     void getAllVets() {
@@ -2508,29 +2548,7 @@ void deleteAllInventory_shouldSucceed() {
                 .hasSize(2);
     }
 
-    @Test
-    void getAllEducationsByVetId_WithValidId_ShouldSucceed(){
-        EducationResponseDTO educationResponseDTO = buildEducation();
-        when(vetsServiceClient.getEducationsByVetId(anyString()))
-                .thenReturn(Flux.just(educationResponseDTO));
 
-        client
-                .get()
-                .uri("/api/gateway/vets/" + VET_ID + "/educations")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBody()
-                .jsonPath("$[0].educationId").isEqualTo(educationResponseDTO.getEducationId())
-                .jsonPath("$[0].vetId").isEqualTo(educationResponseDTO.getVetId())
-                .jsonPath("$[0].degree").isEqualTo(educationResponseDTO.getDegree())
-                .jsonPath("$[0].fieldOfStudy").isEqualTo(educationResponseDTO.getFieldOfStudy())
-                .jsonPath("$[0].schoolName").isEqualTo(educationResponseDTO.getSchoolName())
-                .jsonPath("$[0].startDate").isEqualTo(educationResponseDTO.getStartDate())
-                .jsonPath("$[0].endDate").isEqualTo(educationResponseDTO.getEndDate());
-
-    }
 
     private EducationResponseDTO buildEducation(){
         return EducationResponseDTO.builder()

--- a/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/Education.java
+++ b/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/Education.java
@@ -1,6 +1,7 @@
 package com.petclinic.vet.dataaccesslayer;
 
 import lombok.*;
+import org.springframework.data.annotation.Id;
 
 @Setter
 @Getter
@@ -8,6 +9,8 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 public class Education {
+    @Id //very important
+    private String id;
     private String educationId;
     private String vetId;
     private String schoolName;

--- a/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/EducationRepository.java
+++ b/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/EducationRepository.java
@@ -3,9 +3,11 @@ package com.petclinic.vet.dataaccesslayer;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @Repository
 public interface EducationRepository extends ReactiveMongoRepository<Education, String> {
 
     Flux<Education> findAllByVetId(String vetId);
+    Mono<Education> findByVetIdAndEducationId(String vetId, String educationId);
 }

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -130,9 +130,17 @@ public class VetController {
         return vetService.deleteVetByVetId(EntityDtoUtil.verifyId(vetId));
     }
 
+    //education
     @GetMapping("{vetId}/educations")
     public Flux<EducationResponseDTO> getAllEducationsByVetId(@PathVariable String vetId) {
         return educationService.getAllEducationsByVetId(EntityDtoUtil.verifyId(vetId));
+    }
+
+    @DeleteMapping("{vetId}/educations/{educationId}")
+    public Mono<Void> deleteEducationByEducationId(@PathVariable String vetId,
+                                                   @PathVariable String educationId){
+        return educationService.deleteEducationByEducationId(vetId, educationId);
+
     }
 
 

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationService.java
@@ -3,8 +3,11 @@ package com.petclinic.vet.servicelayer;
 
 import com.petclinic.vet.dataaccesslayer.EducationRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface EducationService {
     Flux<EducationResponseDTO> getAllEducationsByVetId(String vetId);
+    Mono<Void> deleteEducationByEducationId(String vetId, String educationId);
+
 
 }

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationServiceImpl.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/EducationServiceImpl.java
@@ -5,6 +5,7 @@ import com.petclinic.vet.dataaccesslayer.EducationRepository;
 import com.petclinic.vet.util.EntityDtoUtil;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @Service
 public class EducationServiceImpl implements EducationService {
@@ -23,4 +24,12 @@ public class EducationServiceImpl implements EducationService {
                 .map(EntityDtoUtil::toDTO);
     }
 
-}
+    @Override
+    public Mono<Void> deleteEducationByEducationId(String vetId, String educationId) {
+        return educationRepository.findByVetIdAndEducationId(vetId, educationId)
+                .switchIfEmpty(Mono.error(new Exception("Education with id " + educationId + " not found.")))
+                    .flatMap(educationRepository::delete);
+        }
+    }
+
+

--- a/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/EducationRepositoryTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/EducationRepositoryTest.java
@@ -71,4 +71,11 @@ class EducationRepositoryTest {
                 })
                 .verifyComplete();
     }
+    @Test
+    public void deleteEducationOfVet_ShouldSucceed () {
+        StepVerifier
+                .create(educationRepository.delete(e1))
+                .expectNextCount(0)
+                .verifyComplete();
+    }
 }

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -559,7 +559,24 @@ class VetControllerIntegrationTest {
                     assertEquals(education1.getEndDate(), list.get(0).getEndDate());
                 });
     }
+    @Test
+    void deleteAnEducationForVet_WithValidId_ShouldSucceed() {
+        Publisher<Education> setup = educationRepository.deleteAll().
+                thenMany(educationRepository.save(education1));
 
+        StepVerifier
+                .create(setup)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        client
+                .delete()
+                .uri("/vets/" + vet.getVetId() + "/educations/{educationId}", education1.getEducationId())
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody();
+    }
 
     @Test
     void toStringBuilders() {

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -494,6 +494,25 @@ class VetControllerUnitTest {
         Mockito.verify(educationService, times(1)).getAllEducationsByVetId(VET_ID);
     }
 
+    @Test
+    void deleteEducationForVetByEducationId_ShouldSucceed() {
+        String educationId = "794ac37f-1e07-43c2-93bc-61839e61d989";
+        String vetId = "694ac37f-1e07-43c2-93bc-61839e61d989";
+
+        when(educationService.deleteEducationByEducationId(vetId,educationId))
+                .thenReturn((Mono.empty()));
+
+        client
+                .delete()
+                .uri("/vets/" + vetId + "/educations/{educationId}", educationId)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk();
+
+        Mockito.verify(educationService, times(1))
+                .deleteEducationByEducationId(vetId,educationId);
+    }
+
     private Vet buildVet() {
         return Vet.builder()
                 .vetId("678910")

--- a/vet-service/src/test/java/com/petclinic/vet/servicelayer/EducationServiceImplTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/servicelayer/EducationServiceImplTest.java
@@ -9,9 +9,11 @@ import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWeb
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -43,6 +45,17 @@ class EducationServiceImplTest {
                     assertEquals(education.getEducationId(), found.getEducationId());
                     assertEquals(education.getVetId(), found.getVetId());
                 })
+                .verifyComplete();
+    }
+    @Test
+    void deleteEducationByEducationId() {
+        when(educationRepository.findByVetIdAndEducationId(anyString(), anyString())).thenReturn(Mono.just(education));
+        when(educationRepository.delete(any())).thenReturn(Mono.empty());
+
+        Mono<Void> deletedEducation = educationService.deleteEducationByEducationId(education.getVetId(), education.getEducationId());
+
+        StepVerifier
+                .create(deletedEducation)
                 .verifyComplete();
     }
 


### PR DESCRIPTION
JIRA: [link to jira ticket](https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/13?selectedIssue=CPC-941)
## Context:
This ticket is about implementing the function of deleting an education of a vet via a delete button
## Changes
- Education entity
- Implemented delete education in vet-service and Api gateway
- Completed testing for deleteEducationByVetId in both vet service and API gateway
- Implemented a working front-end that deleted a specific education of a vet

## Before and After UI (Required for UI-impacting PRs)
Before
<img width="899" alt="image" src="https://github.com/cgerard321/champlain_petclinic/assets/102537024/398208da-9db1-4d23-a1d5-71ab948c4dca">
After
<img width="844" alt="image" src="https://github.com/cgerard321/champlain_petclinic/assets/102537024/69d902d0-9474-4616-a8b5-57b752bdbf2f">

Result of delete
<img width="767" alt="image" src="https://github.com/cgerard321/champlain_petclinic/assets/102537024/fa10e3d5-6dae-46f4-8c64-1ca37f2965fe">

## Dev notes (Optional)
- Specific technical changes that should be noted
## Linked pull requests (Optional)
- pull request link
