### PR TITLE
Feat(VETS-CPC 964 ): Change vetId to use UUID

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -47,6 +47,15 @@ public class VetsServiceClient {
                 .get()
                 .uri(vetsServiceUrl + "/" + vetId + "/photo")
                 .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, error->{
+                    HttpStatusCode statusCode = error.statusCode();
+                    if(statusCode.equals(NOT_FOUND))
+                        return Mono.error(new ExistingVetNotFoundException("Photo for vet "+vetId + " not found", NOT_FOUND));
+                    return Mono.error(new IllegalArgumentException("Something went wrong"));
+                })
+                .onStatus(HttpStatusCode::is5xxServerError,error->
+                        Mono.error(new IllegalArgumentException("Something went wrong"))
+                )
                 .bodyToMono(Resource.class);
         return photo;
     }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -289,7 +289,7 @@ public class BFFApiGatewayController {
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
-    //Ratinngs
+    //Ratings
     @GetMapping(value = "vets/{vetId}/ratings")//, produces= MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<RatingResponseDTO> getRatingsByVetId(@PathVariable String vetId) {
         return vetsServiceClient.getRatingsByVetId(VetsEntityDtoUtil.verifyId(vetId));

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/utils/VetsEntityDtoUtil.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/utils/VetsEntityDtoUtil.java
@@ -9,12 +9,8 @@ public class VetsEntityDtoUtil {
     public VetsEntityDtoUtil(){}
 
     public static String verifyId(String id) {
-        try {
-            Integer.parseInt(id);
-        }
-        catch(NumberFormatException e) {
+        if(id.length() != 36)
             throw new InvalidInputException("This id is not valid");
-        }
         return id;
     }
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
@@ -72,13 +72,13 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
                         "        \"ratingId\": \"123456\",\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"rateScore\": 4.5\n" +
                         "    }"));
 
-        final RatingResponseDTO rating = vetsServiceClient.getRatingsByVetId("678910").blockFirst();
+        final RatingResponseDTO rating = vetsServiceClient.getRatingsByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").blockFirst();
         assertEquals("123456", rating.getRatingId());
-        assertEquals("678910", rating.getVetId());
+        assertEquals("deb1950c-3c56-45dc-874b-89e352695eb7", rating.getVetId());
         //Had to make it optional so it could diferentiate between double and object
         assertEquals(Optional.of(4.5), Optional.ofNullable(rating.getRateScore()));
     }
@@ -110,7 +110,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(400)
                 .setBody("Something went wrong"));
 
-        final RatingResponseDTO rating = vetsServiceClient.getRatingsByVetId("678910").onErrorResume(throwable -> {
+        final RatingResponseDTO rating = vetsServiceClient.getRatingsByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").onErrorResume(throwable -> {
             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                 return Mono.empty();
             } else {
@@ -128,7 +128,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final RatingResponseDTO rating = vetsServiceClient.getRatingsByVetId("678910").onErrorResume(throwable -> {
+        final RatingResponseDTO rating = vetsServiceClient.getRatingsByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").onErrorResume(throwable -> {
             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                 return Mono.empty();
             } else {
@@ -146,7 +146,7 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("5"));
 
-        final Integer numberOfRatings = vetsServiceClient.getNumberOfRatingsByVetId("678910").block();
+        final Integer numberOfRatings = vetsServiceClient.getNumberOfRatingsByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").block();
         //Had to make it optional so it could diferentiate between double and object
         assertEquals(Optional.of(5), Optional.ofNullable(numberOfRatings));
     }
@@ -193,7 +193,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(400)
                 .setBody("Something went wrong"));
 
-        final Integer ratingNumber = vetsServiceClient.getNumberOfRatingsByVetId("678910").onErrorResume(throwable -> {
+        final Integer ratingNumber = vetsServiceClient.getNumberOfRatingsByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").onErrorResume(throwable -> {
             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                 return Mono.empty();
             } else {
@@ -211,7 +211,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final Integer ratingNumber = vetsServiceClient.getNumberOfRatingsByVetId("678910").onErrorResume(throwable -> {
+        final Integer ratingNumber = vetsServiceClient.getNumberOfRatingsByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").onErrorResume(throwable -> {
             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                 return Mono.empty();
             } else {
@@ -312,7 +312,7 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("{\"1.0\":0.0,\"2.0\":0.0,\"4.0\":0.0,\"5.0\":1.0,\"3.0\":0.0}"));
 
-        final String ratingPercentages = vetsServiceClient.getPercentageOfRatingsByVetId("678910").block();
+        final String ratingPercentages = vetsServiceClient.getPercentageOfRatingsByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").block();
         assertEquals("{\"1.0\":0.0,\"2.0\":0.0,\"4.0\":0.0,\"5.0\":1.0,\"3.0\":0.0}", ratingPercentages);
     }
 
@@ -346,7 +346,7 @@ class VetsServiceClientIntegrationTest {
                 .setBody("Something went wrong"));
 
         final String ratingPercentages =
-                vetsServiceClient.getPercentageOfRatingsByVetId("678910")
+                vetsServiceClient.getPercentageOfRatingsByVetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                         .onErrorResume(throwable -> {
                             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                                 return Mono.empty();
@@ -367,7 +367,7 @@ class VetsServiceClientIntegrationTest {
                 .setBody("Something went wrong"));
 
         final String ratingPercentages =
-                vetsServiceClient.getPercentageOfRatingsByVetId("678910")
+                vetsServiceClient.getPercentageOfRatingsByVetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                         .onErrorResume(throwable -> {
                             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                                 return Mono.empty();
@@ -388,7 +388,7 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("   {\n" +
                         "        \"ratingId\":\"" + ratingId + "\",\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"rateScore\": 4.5\n" +
                         "    }"));
 
@@ -469,7 +469,7 @@ class VetsServiceClientIntegrationTest {
     @Test
     void addRatingToVet_WithRateDescriptionOnly_ShouldSetRateDescriptionToItsValue() throws JsonProcessingException {
         RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateScore(3.5)
                 .rateDescription("The vet was decent but lacked table manners.")
                 .predefinedDescription(null)
@@ -479,14 +479,14 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
                         "        \"ratingId\": \"123456\",\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"rateScore\": 3.5,\n" +
                         "        \"rateDescription\": \"The vet was decent but lacked table manners.\",\n" +
                         "        \"predefinedDescription\": null,\n" +
                         "        \"rateDate\": \"16/09/2023\"\n" +
                         "    }"));
 
-        final RatingResponseDTO rating = vetsServiceClient.addRatingToVet("678910", Mono.just(ratingRequestDTO)).block();
+        final RatingResponseDTO rating = vetsServiceClient.addRatingToVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(ratingRequestDTO)).block();
         assertNotNull(rating.getRatingId());
         assertEquals(ratingRequestDTO.getVetId(), rating.getVetId());
         assertEquals(ratingRequestDTO.getRateScore(), rating.getRateScore());
@@ -498,7 +498,7 @@ class VetsServiceClientIntegrationTest {
     @Test
     void addRatingToVet_withPredefinedDescOnly_ShouldSetRateDescriptionToPredefDescription() throws JsonProcessingException {
         RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateScore(3.0)
                 .rateDescription(null)
                 .predefinedDescription(PredefinedDescription.GOOD)
@@ -508,14 +508,14 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
                         "        \"ratingId\": \"123456\",\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"rateScore\": 3.0,\n" +
                         "        \"rateDescription\": \"GOOD\",\n" +
                         "        \"predefinedDescription\": \"GOOD\",\n" +
                         "        \"rateDate\": \"16/09/2023\"\n" +
                         "    }"));
 
-        final RatingResponseDTO rating = vetsServiceClient.addRatingToVet("678910", Mono.just(ratingRequestDTO)).block();
+        final RatingResponseDTO rating = vetsServiceClient.addRatingToVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(ratingRequestDTO)).block();
 
         assertNotNull(rating.getRatingId());
         assertEquals(ratingRequestDTO.getVetId(), rating.getVetId());
@@ -529,7 +529,7 @@ class VetsServiceClientIntegrationTest {
     @Test
     void addRatingToVet_withPredefinedDescAndRateDesc_ShouldSetRateDescriptionToPredefDescription() throws JsonProcessingException {
         RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateScore(3.0)
                 .rateDescription("The vet was decent but lacked table manners.")
                 .predefinedDescription(PredefinedDescription.GOOD)
@@ -539,14 +539,14 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
                         "        \"ratingId\": \"123456\",\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"rateScore\": 3.0,\n" +
                         "        \"rateDescription\": \"GOOD\",\n" +
                         "        \"predefinedDescription\": \"GOOD\",\n" +
                         "        \"rateDate\": \"16/09/2023\"\n" +
                         "    }"));
 
-        final RatingResponseDTO rating = vetsServiceClient.addRatingToVet("678910", Mono.just(ratingRequestDTO)).block();
+        final RatingResponseDTO rating = vetsServiceClient.addRatingToVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(ratingRequestDTO)).block();
         assertNotNull(rating.getRatingId());
         assertEquals(ratingRequestDTO.getVetId(), rating.getVetId());
         assertEquals(ratingRequestDTO.getRateScore(), rating.getRateScore());
@@ -559,7 +559,7 @@ class VetsServiceClientIntegrationTest {
         String invalidVetId="123";
 
         RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateScore(3.5)
                 .rateDescription("The vet was decent but lacked table manners.")
                 .rateDate("16/09/2023")
@@ -586,13 +586,13 @@ class VetsServiceClientIntegrationTest {
     @Test
     void addRatingToVet_IllegalArgumentException400() throws IllegalArgumentException {
         RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateScore(3.5)
                 .rateDescription("The vet was decent but lacked table manners.")
                 .rateDate("16/09/2023")
                 .build();
 
-        String validVetId="678910";
+        String validVetId="deb1950c-3c56-45dc-874b-89e352695eb7";
         String validRatingId="12345";
 
         prepareResponse(response -> response
@@ -616,13 +616,13 @@ class VetsServiceClientIntegrationTest {
     @Test
     void addRatingToVet_IllegalArgumentException500() throws IllegalArgumentException {
         RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateScore(3.5)
                 .rateDescription("The vet was decent but lacked table manners.")
                 .rateDate("16/09/2023")
                 .build();
 
-        String validVetId="678910";
+        String validVetId="deb1950c-3c56-45dc-874b-89e352695eb7";
         String validRatingId="12345";
 
         prepareResponse(response -> response
@@ -647,7 +647,7 @@ class VetsServiceClientIntegrationTest {
     void updateRatingByVetIdAndRatingId_withRateDescriptionOnly_ShouldSetRateDescriptionToItsValue() throws JsonProcessingException {
         RatingRequestDTO updatedRating = RatingRequestDTO.builder()
                 .rateScore(2.0)
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateDescription("Vet cancelled last minute.")
                 .predefinedDescription(null)
                 .rateDate("20/09/2023")
@@ -657,7 +657,7 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
                         "        \"ratingId\": \"123456\",\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"rateScore\": 2.0,\n" +
                         "        \"rateDescription\": \"Vet cancelled last minute.\",\n" +
                         "        \"predefinedDescription\": null,\n" +
@@ -665,7 +665,7 @@ class VetsServiceClientIntegrationTest {
                         "    }"));
 
         final RatingResponseDTO ratingResponseDTO =
-                vetsServiceClient.updateRatingByVetIdAndByRatingId("678910","123456", Mono.just(updatedRating)).block();
+                vetsServiceClient.updateRatingByVetIdAndByRatingId("deb1950c-3c56-45dc-874b-89e352695eb7","123456", Mono.just(updatedRating)).block();
         assertNotNull(ratingResponseDTO);
         assertNotNull(ratingResponseDTO.getRatingId());
         assertEquals(updatedRating.getVetId(), ratingResponseDTO.getVetId());
@@ -679,7 +679,7 @@ class VetsServiceClientIntegrationTest {
     void updateRatingByVetIdAndRatingId_withPredefinedDescOnly_ShouldSetRateDescriptionToPredefDescription() throws JsonProcessingException {
         RatingRequestDTO updatedRating = RatingRequestDTO.builder()
                 .rateScore(2.0)
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateDescription(null)
                 .predefinedDescription(PredefinedDescription.POOR)
                 .rateDate("20/09/2023")
@@ -689,7 +689,7 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
                         "        \"ratingId\": \"123456\",\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"rateScore\": 2.0,\n" +
                         "        \"rateDescription\": \"POOR\",\n" +
                         "        \"predefinedDescription\": \"POOR\",\n" +
@@ -697,7 +697,7 @@ class VetsServiceClientIntegrationTest {
                         "    }"));
 
         final RatingResponseDTO ratingResponseDTO =
-                vetsServiceClient.updateRatingByVetIdAndByRatingId("678910","123456", Mono.just(updatedRating)).block();
+                vetsServiceClient.updateRatingByVetIdAndByRatingId("deb1950c-3c56-45dc-874b-89e352695eb7","123456", Mono.just(updatedRating)).block();
         assertNotNull(ratingResponseDTO);
         assertNotNull(ratingResponseDTO.getRatingId());
         assertEquals(updatedRating.getVetId(), ratingResponseDTO.getVetId());
@@ -712,7 +712,7 @@ class VetsServiceClientIntegrationTest {
     void updateRatingByVetIdAndRatingId_withPredefinedDescAndRateDesc_ShouldSetRateDescriptionToPredefDescription() throws JsonProcessingException {
         RatingRequestDTO updatedRating = RatingRequestDTO.builder()
                 .rateScore(2.0)
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateDescription("Vet cancelled last minute.")
                 .predefinedDescription(PredefinedDescription.POOR)
                 .rateDate("20/09/2023")
@@ -722,7 +722,7 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
                         "        \"ratingId\": \"123456\",\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"rateScore\": 2.0,\n" +
                         "        \"rateDescription\": \"POOR\",\n" +
                         "        \"predefinedDescription\": \"POOR\",\n" +
@@ -730,7 +730,7 @@ class VetsServiceClientIntegrationTest {
                         "    }"));
 
         final RatingResponseDTO ratingResponseDTO =
-                vetsServiceClient.updateRatingByVetIdAndByRatingId("678910","123456", Mono.just(updatedRating)).block();
+                vetsServiceClient.updateRatingByVetIdAndByRatingId("deb1950c-3c56-45dc-874b-89e352695eb7","123456", Mono.just(updatedRating)).block();
         assertNotNull(ratingResponseDTO);
         assertNotNull(ratingResponseDTO.getRatingId());
         assertEquals(updatedRating.getVetId(), ratingResponseDTO.getVetId());
@@ -748,7 +748,7 @@ class VetsServiceClientIntegrationTest {
 
         RatingRequestDTO updatedRating = RatingRequestDTO.builder()
                 .rateScore(2.0)
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateDescription("Vet cancelled last minute.")
                 .rateDate("20/09/2023")
                 .build();
@@ -776,7 +776,7 @@ class VetsServiceClientIntegrationTest {
     void updateRatingByVetIdOrRatingId_IllegalArgumentException400() throws IllegalArgumentException {
         RatingRequestDTO updatedRating = RatingRequestDTO.builder()
                 .rateScore(2.0)
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateDescription("Vet cancelled last minute.")
                 .rateDate("20/09/2023")
                 .build();
@@ -787,7 +787,7 @@ class VetsServiceClientIntegrationTest {
                 .setBody("Something went wrong"));
 
         final RatingResponseDTO ratingResponseDTO =
-                vetsServiceClient.updateRatingByVetIdAndByRatingId("678910","123456", Mono.just(updatedRating))
+                vetsServiceClient.updateRatingByVetIdAndByRatingId("deb1950c-3c56-45dc-874b-89e352695eb7","123456", Mono.just(updatedRating))
                         .onErrorResume(throwable -> {
                             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                                 return Mono.empty();
@@ -804,7 +804,7 @@ class VetsServiceClientIntegrationTest {
     void updateRatingByVetIdOrRatingId_IllegalArgumentException500() throws IllegalArgumentException {
         RatingRequestDTO updatedRating = RatingRequestDTO.builder()
                 .rateScore(2.0)
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .rateDescription("Vet cancelled last minute.")
                 .rateDate("20/09/2023")
                 .build();
@@ -815,7 +815,7 @@ class VetsServiceClientIntegrationTest {
                 .setBody("Something went wrong"));
 
         final RatingResponseDTO ratingResponseDTO =
-                vetsServiceClient.updateRatingByVetIdAndByRatingId("678910","123456", Mono.just(updatedRating))
+                vetsServiceClient.updateRatingByVetIdAndByRatingId("deb1950c-3c56-45dc-874b-89e352695eb7","123456", Mono.just(updatedRating))
                         .onErrorResume(throwable -> {
                             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                                 return Mono.empty();
@@ -836,7 +836,7 @@ class VetsServiceClientIntegrationTest {
                         "        {12, 24, 52, 87}" +
                         "    }"));
 
-        final Resource photo = vetsServiceClient.getPhotoByVetId("678910").block();
+        final Resource photo = vetsServiceClient.getPhotoByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").block();
         byte[] photoBytes = FileCopyUtils.copyToByteArray(photo.getInputStream());
 
         assertNotNull(photoBytes);
@@ -847,7 +847,7 @@ class VetsServiceClientIntegrationTest {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"firstName\": \"Clementine\",\n" +
                         "        \"lastName\": \"LeBlanc\",\n" +
                         "        \"email\": \"skjfhf@gmail.com\",\n" +
@@ -892,7 +892,7 @@ class VetsServiceClientIntegrationTest {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"firstName\": \"Clementine\",\n" +
                         "        \"lastName\": \"LeBlanc\",\n" +
                         "        \"email\": \"skjfhf@gmail.com\",\n" +
@@ -937,7 +937,7 @@ class VetsServiceClientIntegrationTest {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"firstName\": \"Clementine\",\n" +
                         "        \"lastName\": \"LeBlanc\",\n" +
                         "        \"email\": \"skjfhf@gmail.com\",\n" +
@@ -982,7 +982,7 @@ class VetsServiceClientIntegrationTest {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"firstName\": \"Clementine\",\n" +
                         "        \"lastName\": \"LeBlanc\",\n" +
                         "        \"email\": \"skjfhf@gmail.com\",\n" +
@@ -992,7 +992,7 @@ class VetsServiceClientIntegrationTest {
                         "        \"active\": false\n" +
                         "    }"));
 
-        final VetDTO vet = vetsServiceClient.getVetByVetId("678910").block();
+        final VetDTO vet = vetsServiceClient.getVetByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").block();
         assertFalse(vet.isActive());
         assertEquals(vetDTO.getFirstName(), vet.getFirstName());
         assertEquals(vetDTO.getLastName(), vet.getLastName());
@@ -1031,7 +1031,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(400)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.getVetByVetId("678910")
+        final VetDTO vet = vetsServiceClient.getVetByVetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1051,7 +1051,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.getVetByVetId("678910")
+        final VetDTO vet = vetsServiceClient.getVetByVetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1069,7 +1069,7 @@ class VetsServiceClientIntegrationTest {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"firstName\": \"Clementine\",\n" +
                         "        \"lastName\": \"LeBlanc\",\n" +
                         "        \"email\": \"skjfhf@gmail.com\",\n" +
@@ -1114,7 +1114,7 @@ class VetsServiceClientIntegrationTest {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"firstName\": \"Clementine\",\n" +
                         "        \"lastName\": \"LeBlanc\",\n" +
                         "        \"email\": \"skjfhf@gmail.com\",\n" +
@@ -1124,7 +1124,7 @@ class VetsServiceClientIntegrationTest {
                         "        \"active\": false\n" +
                         "    }"));
 
-        final VetDTO vet = vetsServiceClient.updateVet("678910", Mono.just(vetDTO)).block();
+        final VetDTO vet = vetsServiceClient.updateVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(vetDTO)).block();
         assertFalse(vet.isActive());
         assertEquals(vetDTO.getFirstName(), vet.getFirstName());
         assertEquals(vetDTO.getLastName(), vet.getLastName());
@@ -1163,7 +1163,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(400)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.updateVet("678910", Mono.just(vetDTO))
+        final VetDTO vet = vetsServiceClient.updateVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(vetDTO))
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1183,7 +1183,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.updateVet("678910", Mono.just(vetDTO))
+        final VetDTO vet = vetsServiceClient.updateVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(vetDTO))
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1201,7 +1201,7 @@ class VetsServiceClientIntegrationTest {
         prepareResponse(response -> response
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
-                        "        \"vetId\": \"678910\",\n" +
+                        "        \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "        \"firstName\": \"Clementine\",\n" +
                         "        \"lastName\": \"LeBlanc\",\n" +
                         "        \"email\": \"skjfhf@gmail.com\",\n" +
@@ -1285,7 +1285,7 @@ class VetsServiceClientIntegrationTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody("    {\n" +
                         "    \"educationId\": \"123456\",\n" +
-                        "    \"vetId\": \"678910\",\n" +
+                        "    \"vetId\": \"deb1950c-3c56-45dc-874b-89e352695eb7\",\n" +
                         "    \"schoolName\": \"University of Toronto\",\n" +
                         "    \"degree\": \"Doctor of Veterinary Medicine\",\n" +
                         "    \"fieldOfStudy\": \"Veterinary Medicine\",\n" +
@@ -1340,7 +1340,7 @@ class VetsServiceClientIntegrationTest {
 
     private VetDTO buildVetDTO() {
         return VetDTO.builder()
-                .vetId("678910")
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -2687,7 +2687,7 @@ void deleteAllInventory_shouldSucceed() {
 
     private VetDTO buildVetDTO() {
         return VetDTO.builder()
-                .vetId("678910")
+                .vetId("181faeb5-c024-425c-9f08-663600008f06")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")
@@ -2701,7 +2701,7 @@ void deleteAllInventory_shouldSucceed() {
     }
     private VetDTO buildVetDTO2() {
         return VetDTO.builder()
-                .vetId("678910")
+                .vetId("181faeb5-c024-425c-9f08-663600008f06")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")
@@ -2717,7 +2717,7 @@ void deleteAllInventory_shouldSucceed() {
     private RatingResponseDTO buildRatingResponseDTO() {
         return RatingResponseDTO.builder()
                 .ratingId("123456")
-                .vetId("678910")
+                .vetId("181faeb5-c024-425c-9f08-663600008f06")
                 .rateScore(4.0)
                 .build();
     }

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/VetServiceImpl.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/VetServiceImpl.java
@@ -15,20 +15,17 @@ import com.petclinic.vet.dataaccesslayer.VetRepository;
 import com.petclinic.vet.exceptions.InvalidInputException;
 import com.petclinic.vet.exceptions.NotFoundException;
 import com.petclinic.vet.util.EntityDtoUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 
 @Service
+@RequiredArgsConstructor
 public class VetServiceImpl implements VetService {
 
-
     private final VetRepository vetRepository;
-
-    public VetServiceImpl(VetRepository vetRepository) {
-        this.vetRepository = vetRepository;
-    }
 
     @Override
     public Flux<VetDTO> getAll() {

--- a/vet-service/src/main/java/com/petclinic/vet/util/EntityDtoUtil.java
+++ b/vet-service/src/main/java/com/petclinic/vet/util/EntityDtoUtil.java
@@ -27,6 +27,7 @@ import org.springframework.beans.BeanUtils;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 
 public class EntityDtoUtil {
     @Generated
@@ -65,9 +66,7 @@ public class EntityDtoUtil {
     }
 
     public static String generateVetId() {
-        Random random = new Random();
-        int number = random.nextInt(99999);
-        return "22" + (String.format("%05d", number));
+        return UUID.randomUUID().toString();
     }
 
     public static SpecialtyDTO toDTO(Specialty specialty) {
@@ -129,12 +128,8 @@ public class EntityDtoUtil {
     }
 
     public static String verifyId(String id) {
-        try {
-            Integer.parseInt(id);
-        }
-        catch(NumberFormatException e) {
-            throw new InvalidInputException ("This id is not valid");
-        }
+        if(id.length() != 36)
+            throw new InvalidInputException("This id is not valid");
         return id;
     }
 

--- a/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/VetRepositoryTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/dataaccesslayer/VetRepositoryTest.java
@@ -222,7 +222,7 @@ class VetRepositoryTest {
 
     private Vet buildVet() {
         return Vet.builder()
-                .vetId("678910")
+                .vetId("b3bf6ec1-62bb-4297-9b5e-070a00d4e08f")
                 .vetBillId("1")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
@@ -236,7 +236,7 @@ class VetRepositoryTest {
     }
     private Vet buildVet2() {
         return Vet.builder()
-                .vetId("678910")
+                .vetId("b3bf6ec1-62bb-4297-9b5e-070a00d4e08f")
                 .vetBillId("2")
                 .firstName("Pauline")
                 .lastName("LeBlanc")

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -57,17 +57,18 @@ class VetControllerIntegrationTest {
     Education education2 = buildEducation2();
     Vet vet = buildVet("1234");
     Vet vet2 = buildVet2("2345");
-    Rating rating1 = buildRating("12345", "678910", 5.0);
-    Rating rating2 = buildRating("12346", "678910", 4.0);
-    Rating rating3 = buildRating("12347", "678910", 3.0);
+
+    Rating rating1 = buildRating("12345", "db0c8f13-89d2-4ef7-bcd5-3776a3734150", 5.0);
+    Rating rating2 = buildRating("12346", "db0c8f13-89d2-4ef7-bcd5-3776a3734150", 4.0);
+    Rating rating3 = buildRating("12347", "db0c8f13-89d2-4ef7-bcd5-3776a3734150", 3.0);
 
     VetDTO vetDTO = buildVetDTO("3456");
-    String VET_ID = "678910";
+    String VET_ID = "db0c8f13-89d2-4ef7-bcd5-3776a3734150";
     String VET_BILL_ID = vet.getVetBillId();
     String INVALID_VET_ID = "mjbedf";
     RatingRequestDTO updatedRating = RatingRequestDTO.builder()
             .rateScore(2.0)
-            .vetId("678910")
+            .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
             .rateDescription("Vet cancelled last minute.")
             .rateDate("20/09/2023")
             .build();
@@ -104,10 +105,10 @@ class VetControllerIntegrationTest {
 
     @Test
     void getAllRatingsForAVet_WithInvalidVetId_ShouldNotSucceed() {
-        String invalidVetId="123";
+        String invalidVetId="ac90fcca-a79c-411d-93f2-b70a80da0c3a";
         client
                 .get()
-                .uri("/vets/" + 123 + "/ratings")
+                .uri("/vets/" + invalidVetId + "/ratings")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isNotFound()
@@ -653,7 +654,7 @@ class VetControllerIntegrationTest {
 
     @Test
     void getPercentageOfRatingsByInvalidVetId_ShouldNotSucceed(){
-        String invalidVetId="123";
+        String invalidVetId="ac90fcca-a79c-411d-93f2-b70a80da0c3a";
 
         client.get()
                 .uri("/vets/" + invalidVetId + "/ratings" + "/percentages")
@@ -724,7 +725,6 @@ class VetControllerIntegrationTest {
     @Test
     void getVetByVetBillId() {
         Publisher<Vet> setup = vetRepository.deleteAll().thenMany(vetRepository.save(vet));
-        String uri = "/vets/vetBillId/{vetBillId}";
 
         StepVerifier
                 .create(setup)
@@ -789,7 +789,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         VetDTO updatedVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementineeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
                 .lastName("LeBlanc")
@@ -824,7 +824,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         VetDTO updatedVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
                 .lastName("LeBlanccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
@@ -859,7 +859,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         VetDTO updatedVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
@@ -895,7 +895,7 @@ class VetControllerIntegrationTest {
 
         String extensionNum="7654";
         VetDTO updatedVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
@@ -938,7 +938,7 @@ class VetControllerIntegrationTest {
 
         String extensionNum="7920";
         VetDTO updatedVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
@@ -974,7 +974,7 @@ class VetControllerIntegrationTest {
 
         String extensionNum="7920";
         VetDTO updatedVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
@@ -1095,7 +1095,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         VetDTO newVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
@@ -1131,7 +1131,7 @@ class VetControllerIntegrationTest {
 
         String extensionNum="4527";
         VetDTO newVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
@@ -1174,7 +1174,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         VetDTO newVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementineeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
                 .lastName("LeBlanc")
@@ -1210,7 +1210,7 @@ class VetControllerIntegrationTest {
 
         String extensionNum="0987";
         VetDTO newVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
                 .lastName("LeBlanccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
@@ -1246,7 +1246,7 @@ class VetControllerIntegrationTest {
 
         String extensionNum="4527";
         VetDTO newVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
@@ -1283,7 +1283,7 @@ class VetControllerIntegrationTest {
 
         String extensionNum="4527";
         VetDTO newVet=VetDTO.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
@@ -1514,8 +1514,8 @@ class VetControllerIntegrationTest {
     //the extension number can only be 4 digits
     private Vet buildVet(String extensionNum) {
         return Vet.builder()
-                .vetId("678910")
-                .vetBillId("1")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
+                .vetBillId("ac90fcca-a79c-411d-93f2-b70a80da0c3a")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")
@@ -1531,7 +1531,7 @@ class VetControllerIntegrationTest {
     //the extension number can only be 4 digits
     private Vet buildVet2(String extensionNum) {
         return Vet.builder()
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("2")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
@@ -1556,7 +1556,7 @@ class VetControllerIntegrationTest {
     private Education buildEducation(){
         return Education.builder()
                 .educationId("1")
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .degree("Doctor of Veterinary Medicine")
                 .fieldOfStudy("Veterinary Medicine")
                 .schoolName("University of Montreal")
@@ -1568,7 +1568,7 @@ class VetControllerIntegrationTest {
     private Education buildEducation2(){
         return  Education.builder()
                 .educationId("2")
-                .vetId("678910")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .degree("Doctor of Veterinary Medicine")
                 .fieldOfStudy("Veterinary Medicine")
                 .schoolName("University of Veterinary Sciences")
@@ -1580,8 +1580,8 @@ class VetControllerIntegrationTest {
     //the extension number can only be 4 digits
     private VetDTO buildVetDTO(String extensionNum) {
         return VetDTO.builder()
-                .vetId("678910")
-                .vetBillId("1")
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
+                .vetBillId("ac90fcca-a79c-411d-93f2-b70a80da0c3a")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -207,7 +207,7 @@ class VetControllerUnitTest {
     @Test
     void getAverageRatingForEachVetByVetId_ShouldSucceed(){
 
-        String vetId = "678910";
+        String vetId = "cf25e779-548b-4788-aefa-6d58621c2feb";
         Double averageRating = 5.0;
 
         when(vetService.getVetByVetId(vetId))
@@ -623,8 +623,8 @@ class VetControllerUnitTest {
 
     private Vet buildVet() {
         return Vet.builder()
-                .vetId("678910")
-                .vetBillId("1")
+                .vetId("cf25e779-548b-4788-aefa-6d58621c2feb")
+                .vetBillId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")
@@ -639,8 +639,8 @@ class VetControllerUnitTest {
 
     private VetDTO buildVetDTO() {
         return VetDTO.builder()
-                .vetId("678910")
-                .vetBillId("1")
+                .vetId("cf25e779-548b-4788-aefa-6d58621c2feb")
+                .vetBillId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")
@@ -654,7 +654,7 @@ class VetControllerUnitTest {
     }
     private VetDTO buildVetDTO2() {
         return VetDTO.builder()
-                .vetId("678910")
+                .vetId("cf25e779-548b-4788-aefa-6d58621c2feb")
                 .vetBillId("2")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
@@ -711,7 +711,7 @@ class VetControllerUnitTest {
     private RatingResponseDTO buildRatingResponseDTO(String description, double score) {
         return RatingResponseDTO.builder()
                 .ratingId("2")
-                .vetId("678910")
+                .vetId("cf25e779-548b-4788-aefa-6d58621c2feb")
                 .rateScore(score)
                 .rateDescription(description)
                 .rateDate("16/09/2023")

--- a/vet-service/src/test/java/com/petclinic/vet/servicelayer/VetServiceImplTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/servicelayer/VetServiceImplTest.java
@@ -218,7 +218,7 @@ class VetServiceImplTest {
 
     private Vet buildVet() {
         return Vet.builder()
-                .vetId("678910")
+                .vetId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
                 .vetBillId("1")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
@@ -233,8 +233,8 @@ class VetServiceImplTest {
     }
     private VetDTO buildVetDTO() {
         return VetDTO.builder()
-                .vetId("678910")
-                .vetBillId("1")
+                .vetId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
+                .vetBillId("53c2d16e-1ba3-4dbc-8e31-6decd2eaa99a")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")
@@ -248,8 +248,8 @@ class VetServiceImplTest {
     }
     private Vet buildVet2() {
         return Vet.builder()
-                .vetId("678910")
-                .vetBillId("2")
+                .vetId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
+                .vetBillId("74cb3b00-2808-499c-9bf6-15e94d9eacc7")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-964?atlOrigin=eyJpIjoiNmQzNmQzODU0OWYyNDM5YmEwNTVhOTk3Zjk0YWM4YmMiLCJwIjoiaiJ9
## Context:
Currently, the vetId is created by a method that generates random numbers, which can lead to conflicts and is inefficient.
## Changes

- VetGeneration method now generates a random UUID instead of numbers
- VetIdVerificator now checks if vetId is appropriate length (36)
- TestClasses now utilize proper vetId

