### PR TITLE
feat(VIST-CPC-947): implement delete all canceled visits functionality

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
@@ -146,10 +146,6 @@ public class VisitsServiceClient {
                 newStatus = Status.CONFIRMED;
                 break;
 
-            case "IN_PROGRESS":
-                newStatus = Status.IN_PROGRESS;
-                break;
-
             case "COMPLETED":
                 newStatus = Status.COMPLETED;
                 break;
@@ -213,6 +209,17 @@ public Mono<VisitResponseDTO> createVisitForPet(VisitRequestDTO visit) {
                 .retrieve()
                 .bodyToMono(Void.class);
     }
+
+    public Mono<Void> deleteAllCancelledVisits(){
+        return webClient
+                .delete()
+                .uri("/visits/cancelled")
+                .retrieve()
+                .bodyToMono(Void.class);
+    }
+
+
+
     private String joinIds(List<Integer> petIds) {
         return petIds.stream().map(Object::toString).collect(joining(","));
     }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/Status.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/Status.java
@@ -3,10 +3,8 @@ package com.petclinic.bffapigateway.dtos.Visits;
 public enum Status {
 
     UPCOMING,
-    REQUESTED,
+    COMPLETED,
     CONFIRMED,
-    CANCELLED,
-    IN_PROGRESS,
-    COMPLETED
+    CANCELLED
 
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -272,6 +272,15 @@ public class BFFApiGatewayController {
         return visitsServiceClient.deleteVisitByVisitId(visitId).then(Mono.just(ResponseEntity.noContent().<Void>build()))
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
+
+    @DeleteMapping(value = "visits/cancelled")
+    public Mono<ResponseEntity<Void>> deleteAllCancelledVisits(){
+        return visitsServiceClient.deleteAllCancelledVisits().then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+
+    }
+
+
     /**
      * End of Visit Methods
      **/

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.controller.js
@@ -22,6 +22,14 @@ angular.module('visitList')
             }
         }
 
+        function delayedReload() {
+            var loadingIndicator = document.getElementById('loadingIndicator');
+            loadingIndicator.style.display = 'block';
+            setTimeout(function() {
+                location.reload();
+            }, 1000); //delay by 1 second
+        }
+
         $scope.cancelVisit = function (visitId, status){
             console.log("Called Function")
             console.log(status)
@@ -30,8 +38,6 @@ angular.module('visitList')
                 status = "CANCELLED"
             }else if(status === "CONFIRMED"){
                 status = "CONFIRMED"
-            }else if(status === "IN_PROGRESS"){
-                status = "IN_PROGRESS"
             }else if(status === "COMPLETED"){
                 status = "COMPLETED"
             }else{
@@ -59,6 +65,7 @@ angular.module('visitList')
             }
         }
 
+
         $scope.deleteVisit = function (visitId) {
             let varIsConf = confirm('You are about to delete visit ' + visitId + '. Is this what you want to do ? ');
             if (varIsConf) {
@@ -78,15 +85,28 @@ angular.module('visitList')
                     console.log(error, 'Could not receive data');
                 }
             }
+        };
 
-            function delayedReload() {
-                var loadingIndicator = document.getElementById('loadingIndicator');
-                loadingIndicator.style.display = 'block';
-                setTimeout(function() {
-                    location.reload();
-                }, 1000); //delay by 1 second
+        $scope.deleteAllCancelledVisits = function () {
+            let varIsConf = confirm('You are about to delete all canceled visits. Is this what you want to do ? ');
+            if (varIsConf) {
+                $http.delete('api/gateway/visits/cancelled')
+                    .then(successCallback, errorCallback);
+
+                function successCallback(response) {
+                    $scope.errors = [];
+                    alert("All canceled visits were deleted successfully");
+                    console.log(response, 'res');
+                    delayedReload();
+                }
+
+                function errorCallback(error) {
+                    alert(data.errors);
+                    console.log(error, 'Could not receive data');
+                }
             }
         };
+
     }]);
 
 //     // self.sortFetchedVisits = function() {

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.controller.js
@@ -27,7 +27,7 @@ angular.module('visitList')
             loadingIndicator.style.display = 'block';
             setTimeout(function() {
                 location.reload();
-            }, 1000); //delay by 1 second
+            }, 500); //delay by 1 second
         }
 
         $scope.cancelVisit = function (visitId, status){

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.js
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.js
@@ -20,4 +20,10 @@ angular.module('visitList', ['ui.router'])
                 url: '/visits/:visitId/deleteVisit',
                 template: '<visit-list></visit-list>'
             })
+
+            .state('deleteCancelledVisit', {
+                parent: 'app',
+                url: '/visits/cancelled',
+                template: '<visit-list></visit-list>'
+            })
     }]);

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
@@ -36,6 +36,8 @@
     <h3 style="margin: 0;">Upcoming Visits</h3>
     <a ui-sref="visitsNew">
         <button class="original-button" id="addBtn">Create Visit</button>
+        <button class="btn btn-danger" ng-click="deleteAllCancelledVisits()">Delete All Canceled Visits</button>
+
     </a>
 </div>
 <p>Type something in the input field to search throughout the table:</p>

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
@@ -1,29 +1,32 @@
 <style>
-
     .container {
         display: flex;
-        justify-content: space-between;
-        align-items: center;             /* This aligns items vertically */
+        justify-content: flex-end;
+        align-items: center;
         width: 100%;
         margin-bottom: 20px;
     }
 
-    .original-button {
+    .delete-all-button{
         display: flex;
+        justify-content: flex-end;
         align-items: center;
-        justify-content: center;
-        line-height: 1;
-        text-decoration: none;
-        color: #ffffff;
+        width: 100%;
+        margin-bottom: 20px;
+    }
+
+    
+    .original-button {
+        color: #fff;
+        background-color: #19d256;
+        border-color: #dc3545;
         font-size: 18px;
         border-radius: 5px;
         width: 200px;
         height: 40px;
         font-weight: bold;
-        border-bottom: 4px solid #179e43;
-        transition: 0.3s;
-        box-shadow: 0px 3px 5px 0px rgba(0, 0, 0, 0.4);
-        background-color: #19d256;
+
+
     }
 
     .original-button:hover {
@@ -31,15 +34,17 @@
         border-bottom-width: 2px;
         transform: translateY(2px);
     }
+
 </style>
+
 <div class="container">
-    <h3 style="margin: 0;">Upcoming Visits</h3>
     <a ui-sref="visitsNew">
         <button class="original-button" id="addBtn">Create Visit</button>
-        <button class="btn btn-danger" ng-click="deleteAllCancelledVisits()">Delete All Canceled Visits</button>
-
     </a>
 </div>
+
+<h3 style="margin: 0;">Upcoming Visits</h3>
+
 <p>Type something in the input field to search throughout the table:</p>
 <input ng-model="search.visitId" placeholder="Filter by VisitID">
 <input ng-model="search.date" placeholder="Filter by Date">
@@ -48,6 +53,11 @@
 <input ng-model="search.petId" placeholder="Filter by PetId">
 <input ng-model="search.status" placeholder="Filter by Status">
 <input ng-model="search.billId" placeholder="Filter by Bill">
+
+<div class="delete-all-button">
+<button class="btn btn-danger" ng-click="deleteAllCancelledVisits()">Delete All Canceled Visits</button>
+</div>
+
 <table class="table">
     <thead>
     <tr>
@@ -105,7 +115,7 @@
         <td class="col-sm-2">{{v.visitId}}</td>
         <td class="col-sm-2">{{visitsCtrl.visit.visitDate}}</td>
         <td style="white-space: pre-line">{{v.description}}</td>
-        <!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
+        <!-- <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
         <td style="white-space: pre-line">{{v.practitionerId}}</td>
         <td style="white-space: pre-line">{{v.petId}}</td>
         <td class="status-text" style="white-space: pre-line">{{v.status}}</td>

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
@@ -76,7 +76,8 @@ class VisitsServiceClientIntegrationTest {
 
     @Test
     void getVisitsForStatus() throws JsonProcessingException{
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.REQUESTED);        server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
+        server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .setBody(objectMapper.writeValueAsString(visitResponseDTO)).addHeader("Content-Type", "application/json"));
 
         Flux<VisitResponseDTO> visitResponseDTOFlux = visitsServiceClient.getVisitsForStatus(STATUS);
@@ -102,7 +103,7 @@ class VisitsServiceClientIntegrationTest {
                 "Test Visit",
                 "1",
                 "2",
-                Status.REQUESTED
+                Status.UPCOMING
         );
         server.enqueue(new MockResponse()
                 .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -204,7 +205,7 @@ class VisitsServiceClientIntegrationTest {
                 .practitionerId(2)
                 .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("Cat is crazy")
-                .status(Status.REQUESTED)
+                .status(Status.UPCOMING)
                 .build();
         final VisitDetails visit2 = VisitDetails.builder()
                 .visitId(UUID.randomUUID().toString())
@@ -212,7 +213,7 @@ class VisitsServiceClientIntegrationTest {
                 .practitionerId(22)
                 .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .description("Dog is sick")
-                .status(Status.REQUESTED)
+                .status(Status.UPCOMING)
                 .build();
 
 //        final String body = objectMapper.writeValueAsString(objectMapper.convertValue(visit, VisitDetails.class));
@@ -392,7 +393,8 @@ class VisitsServiceClientIntegrationTest {
 
     @Test
     void getVisitById() throws Exception {
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.REQUESTED);        server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
+        server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .setBody(objectMapper.writeValueAsString(visitResponseDTO)).addHeader("Content-Type", "application/json"));
 
         Mono<VisitResponseDTO> visitResponseDTOMono = visitsServiceClient.getVisitByVisitId("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee");
@@ -400,4 +402,18 @@ class VisitsServiceClientIntegrationTest {
                 .expectNextMatches(returnedVisitResponseDTO1 -> returnedVisitResponseDTO1.getVisitId().equals("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee"))
                 .verifyComplete();
     }
+
+    @Test
+    void deleteAllCancelledVisits_shouldSucceed() {
+        server.enqueue(new MockResponse()
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setResponseCode(204));
+
+        Mono<Void> result = visitsServiceClient.deleteAllCancelledVisits();
+
+        StepVerifier.create(result)
+                .verifyComplete();
+    }
+
+
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
@@ -407,13 +407,12 @@ class VisitsServiceClientIntegrationTest {
     void deleteAllCancelledVisits_shouldSucceed() {
         server.enqueue(new MockResponse()
                 .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .setResponseCode(204));
+                .setResponseCode(204)); //no content
 
         Mono<Void> result = visitsServiceClient.deleteAllCancelledVisits();
 
         StepVerifier.create(result)
                 .verifyComplete();
     }
-
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -2216,7 +2216,7 @@ class ApiGatewayControllerTest {
         when(visitsServiceClient.deleteVisitByVisitId(VISIT_ID)).thenReturn(Mono.empty());
         client.delete()
                 .uri("/api/gateway/visits/" + VISIT_ID)
-                .accept(APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isNoContent();
 
@@ -2233,12 +2233,43 @@ class ApiGatewayControllerTest {
 
         client.delete()
                 .uri("/api/gateway/visits/" + invalidId)
-                .accept(APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isNotFound(); // Expecting a 404 status code
 
         Mockito.verify(visitsServiceClient, times(1))
                 .deleteVisitByVisitId(invalidId);
+    }
+
+    @Test
+    void deleteAllCancelledVisits_shouldSucceed(){
+
+        when(visitsServiceClient.deleteAllCancelledVisits()).thenReturn(Mono.empty());
+
+        client.delete()
+                .uri("/api/gateway/visits/cancelled")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNoContent();
+        Mockito.verify(visitsServiceClient, times(1))
+                .deleteAllCancelledVisits();
+
+    }
+
+    @Test
+    void deleteAllCancelledVisits_shouldThrowRuntimeException(){
+
+        when(visitsServiceClient.deleteAllCancelledVisits())
+                .thenReturn(Mono.error(new RuntimeException("Failed to delete cancelled visits")));
+
+        client.delete()
+                .uri("/api/gateway/visits/cancelled")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().is5xxServerError();
+
+        Mockito.verify(visitsServiceClient, times(1)).deleteAllCancelledVisits();
+
     }
 
     private VisitResponseDTO buildVisitResponseDTO(){

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
@@ -16,9 +16,7 @@ public interface VisitService {
     Mono<VisitResponseDTO> updateVisit(String visitId, Mono<VisitRequestDTO> visitRequestDTOMono);
     Mono<VisitResponseDTO> updateStatusForVisitByVisitId(String visitId, String status);
     Mono<Void> deleteVisit(String visitId);
-
-    //test
-
+    Mono<Void> deleteAllCancelledVisits();
 
 //    Mono<VetDTO> testingGetVetDTO(String vetId);
 //    Mono<PetResponseDTO> testingGetPetDTO(int petId);

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
@@ -47,23 +47,14 @@ public class VisitServiceImpl implements VisitService {
             case("UPCOMING"):
                 status = Status.UPCOMING;
 
-            case("REQUESTED"):
-                status = Status.REQUESTED;
-
             case("CONFIRMED"):
                 status = Status.CONFIRMED;
 
             case("CANCELLED"):
                 status = Status.CANCELLED;
 
-            case("IN_PROGRESS"):
-                status = Status.IN_PROGRESS;
-
-            case("COMPLETED"):
-                status = Status.COMPLETED;
-
             default:
-                status = Status.CONFIRMED;
+                status = Status.COMPLETED;
         }
         return repo.findAllByStatus(statusString)
                 .map(EntityDtoUtil::toVisitResponseDTO);
@@ -110,6 +101,19 @@ public class VisitServiceImpl implements VisitService {
                 });
     }
 
+    @Override
+    public Mono<Void> deleteAllCancelledVisits() {
+        return repo.findAllByStatus("CANCELLED")
+                .collectList()
+                .flatMap(canceledVisits ->{
+                    if(canceledVisits.isEmpty()){
+                        return Mono.empty();
+                    } else{
+                        return repo.deleteAll(canceledVisits);
+                    }
+                });
+    }
+
 
 //    @Override
 //    public Mono<VetDTO> testingGetVetDTO(String vetId) {
@@ -143,12 +147,13 @@ public class VisitServiceImpl implements VisitService {
         Status newStatus;
         Status newStatus1;
         switch (status){
-            case "CONFIRMED":
-                newStatus1 = Status.CONFIRMED;
+
+            case "UPCOMING":
+                newStatus1 = Status.UPCOMING;
                 break;
 
-            case "IN_PROGRESS":
-                newStatus1 = Status.IN_PROGRESS;
+            case "CONFIRMED":
+                newStatus1 = Status.CONFIRMED;
                 break;
 
             case "COMPLETED":
@@ -190,7 +195,7 @@ public class VisitServiceImpl implements VisitService {
         } else if ( dto.getPractitionerId() == null || dto.getPractitionerId().isBlank()) {
             return Mono.error(new BadRequestException("VetId cannot be null or blank"));
         }
-        else if (dto.getStatus() != Status.REQUESTED){
+        else if (dto.getStatus() != Status.UPCOMING){
             return Mono.error(new BadRequestException("Status is being set wrong!"));
         }
         else {

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
@@ -8,6 +8,7 @@ import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -19,7 +20,7 @@ public class DataSetupService implements CommandLineRunner {
         Visit visit1 = buildVisit("visitId1", "2022-11-24 13:00", "this is a dummy description", "2", "2200332", Status.COMPLETED);
         Visit visit2 = buildVisit("visitId2", "2022-03-01 13:00", "Dog Needs Meds", "1", "2200332", Status.COMPLETED);
         Visit visit3 = buildVisit("visitId3", "2020-07-19 13:00","Dog Needs Surgery After Meds", "1", "2200332", Status.COMPLETED);
-        Visit visit4 = buildVisit("visitId4", "2022-12-24 13:00", "Dog Needs Physio-Therapy", "1", "2200332", Status.CONFIRMED);
+        Visit visit4 = buildVisit("visitId4", "2022-12-24 13:00", "Dog Needs Physio-Therapy", "1", "2200332", Status.UPCOMING);
         Visit visit5 = buildVisit("visitId5", "2023-12-24 13:00", "Cat Needs Check-Up", "4", "2200332", Status.UPCOMING);
 
         Flux.just(visit1, visit2, visit3, visit4, visit5).flatMap(x -> visitRepo.insert(Mono.just(x)).log(x.toString())).subscribe();

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
@@ -19,8 +19,8 @@ public class DataSetupService implements CommandLineRunner {
         Visit visit1 = buildVisit("visitId1", "2022-11-24 13:00", "this is a dummy description", "2", "2200332", Status.COMPLETED);
         Visit visit2 = buildVisit("visitId2", "2022-03-01 13:00", "Dog Needs Meds", "1", "2200332", Status.COMPLETED);
         Visit visit3 = buildVisit("visitId3", "2020-07-19 13:00","Dog Needs Surgery After Meds", "1", "2200332", Status.COMPLETED);
-        Visit visit4 = buildVisit("visitId4", "2022-12-24 13:00", "Dog Needs Physio-Therapy", "1", "2200332", Status.COMPLETED);
-        Visit visit5 = buildVisit("visitId5", "2023-12-24 13:00", "Cat Needs Check-Up", "4", "2200332", Status.REQUESTED);
+        Visit visit4 = buildVisit("visitId4", "2022-12-24 13:00", "Dog Needs Physio-Therapy", "1", "2200332", Status.CONFIRMED);
+        Visit visit5 = buildVisit("visitId5", "2023-12-24 13:00", "Cat Needs Check-Up", "4", "2200332", Status.UPCOMING);
 
         Flux.just(visit1, visit2, visit3, visit4, visit5).flatMap(x -> visitRepo.insert(Mono.just(x)).log(x.toString())).subscribe();
     }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/Status.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/Status.java
@@ -3,10 +3,7 @@ package com.petclinic.visits.visitsservicenew.DataLayer;
 public enum Status {
 
     UPCOMING,
-    REQUESTED,
     CONFIRMED,
-    CANCELLED,
-    IN_PROGRESS,
-    COMPLETED
-
+    COMPLETED,
+    CANCELLED
 }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -69,6 +69,8 @@ public class VisitController {
                 .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)));
     }
 
+    //test
+
 
 //    @GetMapping("/pets/{petId}")
 //    public Mono<PetResponseDTO> getPetByIdTest(@PathVariable int petId){

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -69,7 +69,11 @@ public class VisitController {
                 .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)));
     }
 
-    //test
+    @DeleteMapping("/cancelled")
+    public Mono<ResponseEntity<Void>> deleteAllCancelLedVisits(){
+        return visitService.deleteAllCancelledVisits()
+                .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)));
+    }
 
 
 //    @GetMapping("/pets/{petId}")

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
@@ -279,7 +279,7 @@ class VisitServiceImplTest {
         List<Visit> cancelledVisits = new ArrayList<>();
         cancelledVisits.add(buildVisit(uuidVisit1, "Cat is sick", vet.getVetId()));
         cancelledVisits.add(buildVisit(uuidVisit2, "Cat is sick", vet.getVetId()));
-        cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set visit statuses to cancelled
+        cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set statuses to CANCELLED
 
         Mockito.when(visitRepo.findAllByStatus("CANCELLED")).thenReturn(Flux.fromIterable(cancelledVisits));
         Mockito.when(visitRepo.deleteAll(cancelledVisits)).thenReturn(Mono.empty());
@@ -298,11 +298,10 @@ class VisitServiceImplTest {
     @Test
     void deleteAllCanceledVisits_shouldThrowRuntimeException() {
         // Arrange
-
         List<Visit> cancelledVisits = new ArrayList<>();
         cancelledVisits.add(buildVisit(uuidVisit1, "Cat is sick", vet.getVetId()));
         cancelledVisits.add(buildVisit(uuidVisit2, "Cat is sick", vet.getVetId()));
-        cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set visit statuses to cancelled
+        cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set statuses to CANCELLED
 
         Mockito.when(visitRepo.findAllByStatus("CANCELLED")).thenReturn(Flux.fromIterable(cancelledVisits));
         Mockito.when(visitRepo.deleteAll(cancelledVisits)).thenReturn(Mono.error(new RuntimeException("Failed to delete visits")));

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
@@ -23,10 +23,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"spring.data.mongodb.port: 0"})
@@ -217,11 +214,28 @@ class VisitServiceImplTest {
                     assertEquals(visit1.getStatus(), Status.CANCELLED);
                 }).verifyComplete();
     }
+    @Test
+    void updateVisit(){
+        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+
+        StepVerifier.create(visitService.updateVisit(VISIT_ID, Mono.just(visitRequestDTO)))
+                .consumeNextWith(visitDTO1 -> {
+                    assertEquals(visit1.getVisitId(), visitDTO1.getVisitId());
+                    assertEquals(visit1.getDescription(), visitDTO1.getDescription());
+                    assertEquals(visit1.getPetId(), visitDTO1.getPetId());
+                    assertEquals(visit1.getVisitDate(), visitDTO1.getVisitDate());
+                    assertEquals(visit1.getPractitionerId(), visitDTO1.getPractitionerId());
+                }).verifyComplete();
+    }
+
 
     @Test
     void deleteVisitById_visitId_shouldSucceed(){
         //arrange
-        String visitId = uuidVisit1.toString();
+        String visitId = uuidVisit1;
 
         Mockito.when(visitRepo.existsByVisitId(visitId)).thenReturn(Mono.just(true));
         Mockito.when(visitRepo.deleteByVisitId(visitId)).thenReturn(Mono.empty());
@@ -250,31 +264,60 @@ class VisitServiceImplTest {
 
         // Assert
         StepVerifier.create(result)
-                .expectError(NotFoundException.class) // Expecting a NotFoundException
+                .expectError(NotFoundException.class) // Expecting NotFoundException
                 .verify();
 
-        // Verify that deleteByVisitId was not called
+        // Verify that deleteByVisitId was not called since is does not exist
         Mockito.verify(visitRepo, Mockito.never()).deleteByVisitId(visitId);
     }
 
-
     @Test
-    void updateVisit(){
-        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
-        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
-        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+    void deleteAllCancelledVisits(){
 
-        StepVerifier.create(visitService.updateVisit(VISIT_ID, Mono.just(visitRequestDTO)))
-                .consumeNextWith(visitDTO1 -> {
-                    assertEquals(visit1.getVisitId(), visitDTO1.getVisitId());
-                    assertEquals(visit1.getDescription(), visitDTO1.getDescription());
-                    assertEquals(visit1.getPetId(), visitDTO1.getPetId());
-                    assertEquals(visit1.getVisitDate(), visitDTO1.getVisitDate());
-                    assertEquals(visit1.getPractitionerId(), visitDTO1.getPractitionerId());
-                }).verifyComplete();
+        // Arrange
+
+        List<Visit> cancelledVisits = new ArrayList<>();
+        cancelledVisits.add(buildVisit(uuidVisit1, "Cat is sick", vet.getVetId()));
+        cancelledVisits.add(buildVisit(uuidVisit2, "Cat is sick", vet.getVetId()));
+        cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set visit statuses to cancelled
+
+        Mockito.when(visitRepo.findAllByStatus("CANCELLED")).thenReturn(Flux.fromIterable(cancelledVisits));
+        Mockito.when(visitRepo.deleteAll(cancelledVisits)).thenReturn(Mono.empty());
+
+        // Act
+        Mono<Void> result = visitService.deleteAllCancelledVisits();
+
+        // Assert
+        StepVerifier.create(result)
+                .verifyComplete();
+
+        Mockito.verify(visitRepo, Mockito.times(1)).findAllByStatus("CANCELLED");
+        Mockito.verify(visitRepo, Mockito.times(1)).deleteAll(cancelledVisits);
     }
 
+    @Test
+    void deleteAllCanceledVisits_shouldThrowRuntimeException() {
+        // Arrange
+
+        List<Visit> cancelledVisits = new ArrayList<>();
+        cancelledVisits.add(buildVisit(uuidVisit1, "Cat is sick", vet.getVetId()));
+        cancelledVisits.add(buildVisit(uuidVisit2, "Cat is sick", vet.getVetId()));
+        cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set visit statuses to cancelled
+
+        Mockito.when(visitRepo.findAllByStatus("CANCELLED")).thenReturn(Flux.fromIterable(cancelledVisits));
+        Mockito.when(visitRepo.deleteAll(cancelledVisits)).thenReturn(Mono.error(new RuntimeException("Failed to delete visits")));
+
+        // Act
+        Mono<Void> result = visitService.deleteAllCancelledVisits();
+
+        // Assert
+        StepVerifier.create(result)
+                .expectError(RuntimeException.class)
+                .verify();
+
+        Mockito.verify(visitRepo, Mockito.times(1)).findAllByStatus("CANCELLED");
+        Mockito.verify(visitRepo, Mockito.times(1)).deleteAll(cancelledVisits);
+    }
 
     private Visit buildVisit(String uuid,String description, String vetId){
         return Visit.builder()
@@ -293,7 +336,7 @@ class VisitServiceImplTest {
                 .description("this is a dummy description")
                 .petId("2")
                 .practitionerId(UUID.randomUUID().toString())
-                .status(Status.REQUESTED)
+                .status(Status.UPCOMING)
                 .build();
     }
     private VisitRequestDTO buildVisitRequestDTO() {
@@ -302,7 +345,7 @@ class VisitServiceImplTest {
                     .description("this is a dummy description")
                     .petId("2")
                     .practitionerId(UUID.randomUUID().toString())
-                    .status(Status.REQUESTED)
+                    .status(Status.UPCOMING)
                     .build();
         }
 

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -272,7 +272,7 @@ class VisitControllerUnitTest {
                 .delete()
                 .uri("/visits/cancelled")
                 .exchange()
-                .expectStatus().is5xxServerError();  // Expecting a 5xx Server Error status.
+                .expectStatus().is5xxServerError();
 
         Mockito.verify(visitService, times(1)).deleteAllCancelledVisits();
     }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -246,6 +246,38 @@ class VisitControllerUnitTest {
                 .jsonPath("$.message", "No visit was found with visitId: " + invalidVisitId);
     }
 
+    @Test
+    void deleteAllCancelledVisits_shouldSucceed(){
+        // Arrange
+        Mockito.when(visitService.deleteAllCancelledVisits()).thenReturn(Mono.empty());
+
+        // Act & Assert
+       webTestClient
+               .delete()
+               .uri("/visits/cancelled")
+               .exchange()
+               .expectStatus().isNoContent();
+
+       Mockito.verify(visitService, times(1)).deleteAllCancelledVisits();
+    }
+
+    @Test
+    void deleteAllCancelledVisits_shouldThrowRuntimeException() {
+        // Arrange
+        Mockito.when(visitService.deleteAllCancelledVisits())
+                .thenReturn(Mono.error(new RuntimeException("Failed to delete cancelled visits")));
+
+        // Act & Assert
+        webTestClient
+                .delete()
+                .uri("/visits/cancelled")
+                .exchange()
+                .expectStatus().is5xxServerError();  // Expecting a 5xx Server Error status.
+
+        Mockito.verify(visitService, times(1)).deleteAllCancelledVisits();
+    }
+
+
     private Visit buildVisit(String uuid,String description, String vetId){
         return Visit.builder()
                 .visitId(uuid)

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -1,12 +1,10 @@
 package com.petclinic.visits.visitsservicenew.PresentationLayer;
-import com.petclinic.visits.visitsservicenew.BusinessLayer.VisitService;
 import com.petclinic.visits.visitsservicenew.DataLayer.Status;
 import com.petclinic.visits.visitsservicenew.DataLayer.Visit;
 import com.petclinic.visits.visitsservicenew.DataLayer.VisitRepo;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
@@ -19,7 +17,6 @@ import reactor.test.StepVerifier;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
@@ -40,24 +37,23 @@ class VisitsControllerIntegrationTest {
     private VisitRepo visitRepo;
 
     @MockBean
-    private VisitService visitService;
-
-
-    @MockBean
     private VetsClient vetsClient;
 
     @MockBean
     private PetsClient petsClient;
 
-
     String uuidVisit1 = UUID.randomUUID().toString();
     String uuidVisit2 = UUID.randomUUID().toString();
+
+    String uuidCancelledVisit1 = UUID.randomUUID().toString();
+    String uuidCancelledVisit2 = UUID.randomUUID().toString();
+
     String uuidVet = UUID.randomUUID().toString();
     String uuidPet = UUID.randomUUID().toString();
     String uuidPhoto = UUID.randomUUID().toString();
     String uuidOwner = UUID.randomUUID().toString();
 
-    private final String STATUS = "UPCOMING";
+    private final String STATUS = "CONFIRMED";
 
     Set<SpecialtyDTO> set= new HashSet<>();
 
@@ -84,10 +80,11 @@ class VisitsControllerIntegrationTest {
             .ownerId(uuidOwner)
             .build();
 
-
     Visit visit1 = buildVisit(uuidVisit1,"this is a dummy description",vet.getVetId());
     Visit visit2 = buildVisit(uuidVisit2,"this is a dummy description",vet.getVetId());
 
+    Visit cancelledVisit1 = buildCancelledVisit(uuidCancelledVisit1, "this is a dummy description", vet.getVetId());
+    Visit cancelledVisit2 = buildCancelledVisit(uuidCancelledVisit2, "this is a dummy description", vet.getVetId());
 
     private final VisitResponseDTO visitResponseDTO = buildVisitResponseDto(visit1.getVisitId(),vet.getVetId());
     private final VisitRequestDTO visitRequestDTO = buildVisitRequestDto(vet.getVetId());
@@ -95,7 +92,7 @@ class VisitsControllerIntegrationTest {
     private final String PRAC_ID = visitResponseDTO.getPractitionerId();
     private final String PET_ID = visitResponseDTO.getPetId();
     private final String VISIT_ID = visitResponseDTO.getVisitId();
-    private final int dbSize = 2;
+    private final int dbSize = 4;
     //private final LocalDateTime visitDate = visitResponseDTO.getVisitDate().withSecond(0);
 
 
@@ -103,7 +100,9 @@ class VisitsControllerIntegrationTest {
     void dbSetUp(){
         Publisher<Visit> visitPublisher = visitRepo.deleteAll()
                 .thenMany(visitRepo.save(visit1)
-                        .thenMany(visitRepo.save(visit2)));
+                        .thenMany(visitRepo.save(visit2)
+                                .thenMany(visitRepo.save(cancelledVisit1)
+                                        .thenMany(visitRepo.save(cancelledVisit2)))));
 
         StepVerifier.create(visitPublisher).expectNextCount(1).verifyComplete();
     }
@@ -120,7 +119,6 @@ class VisitsControllerIntegrationTest {
                 .expectBodyList(VisitResponseDTO.class)
                 .value((list)-> assertEquals(list.size(), dbSize));
     }
-
     @Test
     void getVisitByVisitId(){
         webTestClient
@@ -190,6 +188,10 @@ class VisitsControllerIntegrationTest {
     @Test
     void getVisitsForStatus(){
 
+        visit1.setStatus(Status.CONFIRMED);
+
+        visitRepo.save(visit1).block(); //block is telling the test to wait for the response to complete
+
         webTestClient
                 .get()
                 .uri("/visits/status/"+STATUS)
@@ -200,13 +202,13 @@ class VisitsControllerIntegrationTest {
                 .expectBodyList(VisitResponseDTO.class)
                 .value((list)->{
                     assertNotNull(list);
-                    assertEquals(dbSize, list.size());
+                    assertEquals(1, list.size());
                     assertEquals(list.get(0).getVisitId(), visit1.getVisitId());
                     assertEquals(list.get(0).getPractitionerId(), visit1.getPractitionerId());
                     assertEquals(list.get(0).getPetId(), visit1.getPetId());
                     assertEquals(list.get(0).getDescription(), visit1.getDescription());
                     assertEquals(list.get(0).getVisitDate(), visit1.getVisitDate());
-                    assertEquals(list.get(0).getStatus().toString(), "UPCOMING");
+                    assertEquals(list.get(0).getStatus().toString(), "CONFIRMED");
                 });
     }
 
@@ -215,6 +217,13 @@ class VisitsControllerIntegrationTest {
     void addVisit(){
         when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
         when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+
+        VisitRequestDTO visitRequestDTO = new VisitRequestDTO();
+        visitRequestDTO.setPractitionerId(visit1.getPractitionerId());
+        visitRequestDTO.setPetId(visit1.getPetId());
+        visitRequestDTO.setDescription(visit1.getDescription());
+        visitRequestDTO.setVisitDate(LocalDateTime.parse("2024-11-25 13:45",DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
+        visitRequestDTO.setStatus(Status.UPCOMING);
 
         webTestClient
                 .post()
@@ -226,36 +235,22 @@ class VisitsControllerIntegrationTest {
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody(VisitResponseDTO.class)
                 .value((visitDTO1) -> {
+                    assertEquals(visitDTO1.getVisitDate(), LocalDateTime.parse("2024-11-25 13:45",DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
                     assertEquals(visitDTO1.getDescription(), visit1.getDescription());
                     assertEquals(visitDTO1.getPetId(), visit1.getPetId());
-                    assertEquals(visitDTO1.getVisitDate(), LocalDateTime.parse("2024-11-25 13:45",DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
                     assertEquals(visitDTO1.getPractitionerId(), visit1.getPractitionerId());
+                    assertEquals(visitDTO1.getStatus(), visit1.getStatus());
                 });
     }
 
 
 
     @Test
-    void updateStatusForVisitByVisitId(){
-        String status = "CANCELLED";
-        webTestClient
-                .put()
-                .uri("/visits/"+VISIT_ID+"/status/"+status)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody()
-                .jsonPath("$.visitId").isEqualTo(visit1.getVisitId())
-                .jsonPath("$.practitionerId").isEqualTo(visit1.getPractitionerId())
-                .jsonPath("$.petId").isEqualTo(visit1.getPetId())
-                .jsonPath("$.description").isEqualTo(visit1.getDescription())
-                .jsonPath("$.visitDate").isEqualTo("2024-11-25 13:45")
-                .jsonPath("$.status").isEqualTo("CANCELLED");
-    }
-
-    @Test
     void updateVisit(){
+
         when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
         when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+
 
         webTestClient
                 .put()
@@ -275,50 +270,47 @@ class VisitsControllerIntegrationTest {
     }
 
     @Test
+    void updateStatusForVisitByVisitId(){
+        String status = "CANCELLED";
+        webTestClient
+                .put()
+                .uri("/visits/"+VISIT_ID+"/status/"+status)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.visitId").isEqualTo(visit1.getVisitId())
+                .jsonPath("$.practitionerId").isEqualTo(visit1.getPractitionerId())
+                .jsonPath("$.petId").isEqualTo(visit1.getPetId())
+                .jsonPath("$.description").isEqualTo(visit1.getDescription())
+                .jsonPath("$.visitDate").isEqualTo("2024-11-25 13:45")
+                .jsonPath("$.status").isEqualTo("CANCELLED");
+    }
+
+    @Test
     void deleteVisit(){
-        // Arrange
-        String visitId = UUID.randomUUID().toString();
-        when(visitService.deleteVisit(visitId)).thenReturn(Mono.empty());
-
-        // Act & Assert
         webTestClient
                 .delete()
-                .uri("/visits/{visitId}", visitId)
+                .uri("/visits/"+visit1.getVisitId())
+                .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isNoContent();
     }
 
     @Test
-    void deleteAllCancelledVisits_shouldSucceed() {
-        // Arrange
-        Mockito.when(visitService.deleteAllCancelledVisits()).thenReturn(Mono.empty());
+    void deleteAllCanceledVisits() {
 
-        // Act & Assert
-        webTestClient
-                .delete()
-                .uri("/visits/cancelled")
-                .exchange()
-                .expectStatus().isNoContent();
-
-        Mockito.verify(visitService, times(1)).deleteAllCancelledVisits();
-    }
-
-
-    @Test
-    void deleteAllCancelledVisits_shouldThrowRuntimeException() {
-        // Arrange
-        Mockito.when(visitService.deleteAllCancelledVisits())
-                .thenReturn(Mono.error(new RuntimeException("Failed to delete cancelled visits")));
-
-        // Act & Assert
         webTestClient
                 .delete()
                 .uri("/visits/cancelled")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().is5xxServerError()  // Simulating a failure, expecting a server error status.
-                .expectBody()
-                .jsonPath("$.message").isEqualTo("Failed to delete cancelled visits");
+                .expectStatus().isNoContent();
+
+        // Verify that canceled visits were deleted
+        String cancelledStatus = "CANCELLED";
+        StepVerifier.create(visitRepo.findAllByStatus(cancelledStatus))
+                .expectNextCount(0)
+                .verifyComplete();
     }
 
 
@@ -331,6 +323,18 @@ class VisitsControllerIntegrationTest {
                 .petId("2")
                 .practitionerId(vetId)
                 .status(Status.UPCOMING)
+                .build();
+    }
+
+    private Visit buildCancelledVisit(String uuid,String description, String vetId){
+        return Visit.builder()
+                .visitId(uuid)
+
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description(description)
+                .petId("2")
+                .practitionerId(vetId)
+                .status(Status.CANCELLED)
                 .build();
     }
 


### PR DESCRIPTION
JIRA: link to jira ticket
https://champlainsaintlambert.atlassian.net/browse/CPC-947
## Context:
This ticket pertains to implementing a new functionality in the frontend that allows for the user to delete all cancelled visits from the database. This functionality compliments our teams newly incorporated Cancel Visit functionality.
## Changes
- deleteAllCancelledVisits method logic implemented in the backend
- successful and exception test cases implemented in the frontend and backend test classes
- UI styling touchups

## Before and After UI (Required for UI-impacting PRs)
Before changes:
![image](https://github.com/cgerard321/champlain_petclinic/assets/100872287/60cb6827-47a7-4c69-9ae4-3372d06c58d9)

After changes:
![AfterChanges](https://github.com/cgerard321/champlain_petclinic/assets/77695020/4b2c17ae-daa7-4731-8993-dcd621e2ee66)

![AfterBtnPress1](https://github.com/cgerard321/champlain_petclinic/assets/77695020/23f9ece2-8443-4def-933a-abe543bd338a)


![Results](https://github.com/cgerard321/champlain_petclinic/assets/77695020/ce1e11bf-89d7-43e3-90c1-57fcf4698b2c)

## Dev notes
- Our team has decided that we will be making some minor changes to the separation logic regarding the Upcoming and Previous visits. Will be introduced in upcoming pull requests.

## Linked pull requests 

[- pull request link](https://github.com/cgerard321/champlain_petclinic/pull/489)
