### PR TITLE
feat(INVT-CPC-895): Get all custom inventory types

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/InventoryServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/InventoryServiceClient.java
@@ -197,6 +197,14 @@ public class InventoryServiceClient {
                 .retrieve().bodyToMono(InventoryTypeResponseDTO.class);
     }
 
+    public Flux<InventoryTypeResponseDTO> getAllInventoryTypes(){
+        return webClient.get()
+                .uri(inventoryServiceUrl + "/type")
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToFlux(InventoryTypeResponseDTO.class);
+    }
+
     public Mono<Void> deleteInventoryByInventoryId(final String inventoryId){
         return webClient.delete()
                 .uri(inventoryServiceUrl + "/{inventoryId}", inventoryId)

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -827,6 +827,12 @@ public class BFFApiGatewayController {
     }
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN,Roles.INVENTORY_MANAGER})
+
+    @GetMapping(value = "inventory/type")
+    public Flux<InventoryTypeResponseDTO> getAllInventoryTypes(){
+        return inventoryServiceClient.getAllInventoryTypes();
+    }
+
     @DeleteMapping(value = "inventory/{inventoryId}")
     public Mono<Void> deleteInventoryByInventoryId(@PathVariable String inventoryId) {
         return inventoryServiceClient.deleteInventoryByInventoryId(inventoryId);

--- a/api-gateway/src/main/resources/static/scripts/Inventory-form/inventory-form.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/Inventory-form/inventory-form.controller.js
@@ -5,7 +5,12 @@ angular.module('inventoryForm')
         var self = this;
         console.log("State params: " + $stateParams)
         $scope.inventoryTypeFormSearch = "";
-        $scope.inventoryTypeOptions = ["New Type", "Internal", "Sales"] //get all form the inventory type repository but dont remove the New Type
+        $scope.inventoryTypeOptions = ["New Type"] //get all form the inventory type repository but dont remove the New Type
+        $http.get("api/gateway/inventory/type").then(function (resp) {
+            //Includes all types inside the array
+            resp.data.forEach(function (type) {
+                $scope.inventoryTypeOptions.push(type.type);
+            })});
         $scope.selectedOption = $scope.inventoryTypeOptions[0]
 
         self.submitInventoryForm = function () {

--- a/api-gateway/src/main/resources/static/scripts/inventory-list/inventory-list.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/inventory-list/inventory-list.controller.js
@@ -20,6 +20,20 @@ angular.module('inventoryList')
             console.log("inventory list: " + self.inventoryList)
         });
 
+                $http.get('api/gateway/inventory').then(function (resp) {
+                    self.inventoryList = resp.data;
+                    console.log("Resp data: " + resp.data)
+                    console.log("inventory list: " + self.inventoryList)
+                });
+        //custom types handler
+        $scope.inventoryTypeOptions = ['',]
+        $http.get("api/gateway/inventory/type").then(function (resp) {
+            //Includes all types inside the array
+            resp.data.forEach(function (type) {
+                $scope.inventoryTypeOptions.push(type.type);
+            })});
+
+//search by inventory field
         $scope.searchInventory = function (inventoryName, inventoryType, inventoryDescription){
             getInventoryList(inventoryName, inventoryType, inventoryDescription)
         }

--- a/api-gateway/src/main/resources/static/scripts/inventory-list/inventory-list.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/inventory-list/inventory-list.controller.js
@@ -25,8 +25,8 @@ angular.module('inventoryList')
                     console.log("Resp data: " + resp.data)
                     console.log("inventory list: " + self.inventoryList)
                 });
+        $scope.inventoryTypeOptions = []
         //custom types handler
-        $scope.inventoryTypeOptions = ['',]
         $http.get("api/gateway/inventory/type").then(function (resp) {
             //Includes all types inside the array
             resp.data.forEach(function (type) {

--- a/api-gateway/src/main/resources/static/scripts/inventory-list/inventory-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/inventory-list/inventory-list.template.html
@@ -18,8 +18,7 @@
         </td>
         <td>
         <span>
-            <select class="form-control col-sm-4" id="inventoryType" ng-model="inventoryType" name="inventoryType"
-                    ng-options="type for type in inventoryTypeOptions" placeholder="None" required title="Please select the inventory type." ng-keyup="$event.keyCode == 13 && searchInventory(inventoryName, inventoryType, inventoryDescription)">
+            <select class="form-control col-sm-4" id="inventoryType" ng-model="inventoryType" name="inventoryType" ng-options="type for type in inventoryTypeOptions" placeholder="None" required title="Please select the inventory type." ng-keyup="$event.keyCode == 13 && searchInventory(inventoryName, inventoryType, inventoryDescription)">
             </select>
         </span>
         </td>

--- a/api-gateway/src/main/resources/static/scripts/inventory-list/inventory-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/inventory-list/inventory-list.template.html
@@ -18,9 +18,8 @@
         </td>
         <td>
         <span>
-            <select class="form-control col-sm-4" id="inventoryType" ng-model="inventoryType" name="inventoryType" required title="Please select the inventory type." ng-keyup="$event.keyCode == 13 && searchInventory(inventoryName, inventoryType, inventoryDescription)">
-                <option value="internal">internal</option>
-                <option value="sales">sales</option>
+            <select class="form-control col-sm-4" id="inventoryType" ng-model="inventoryType" name="inventoryType"
+                    ng-options="type for type in inventoryTypeOptions" placeholder="None" required title="Please select the inventory type." ng-keyup="$event.keyCode == 13 && searchInventory(inventoryName, inventoryType, inventoryDescription)">
             </select>
         </span>
         </td>

--- a/api-gateway/src/main/resources/static/scripts/inventory-update-form/inventory-update-form.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/inventory-update-form/inventory-update-form.controller.js
@@ -8,18 +8,14 @@ angular.module('inventoryUpdateForm')
         $scope.inventoryTypeFormUpdateSearch = "";
         $scope.inventoryTypeUpdateOptions = ["New Type"];
         $http.get("api/gateway/inventory/type").then(function (resp) {
-            //add transparent none for search query
-            //fill the inv type when updating
+            //Includes all types inside the array
             resp.data.forEach(function (type) {
                 $scope.inventoryTypeUpdateOptions.push(type.type);
             })});
         $scope.selectedUpdateOption = $scope.inventoryTypeUpdateOptions[0]
-
         $http.get('api/gateway/inventory/' + inventoryId).then(function (resp) {
             self.inventory = resp.data;
-
         });
-
         self.submitUpdateInventoryForm = function () {
             var data;
 

--- a/api-gateway/src/main/resources/static/scripts/inventory-update-form/inventory-update-form.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/inventory-update-form/inventory-update-form.controller.js
@@ -7,15 +7,24 @@ angular.module('inventoryUpdateForm')
         var method = $stateParams.method;
         $scope.inventoryTypeFormUpdateSearch = "";
         $scope.inventoryTypeUpdateOptions = ["New Type"];
-        $http.get("api/gateway/inventory/type").then(function (resp) {
-            //Includes all types inside the array
-            resp.data.forEach(function (type) {
-                $scope.inventoryTypeUpdateOptions.push(type.type);
-            })});
-        $scope.selectedUpdateOption = $scope.inventoryTypeUpdateOptions[0]
         $http.get('api/gateway/inventory/' + inventoryId).then(function (resp) {
             self.inventory = resp.data;
+
+            $http.get("api/gateway/inventory/type").then(function (typesResp) {
+
+                // Includes all types inside the array
+                typesResp.data.forEach(function (type) {
+                    $scope.inventoryTypeUpdateOptions.push(type.type);
+                });
+                var inventoryType = self.inventory.inventoryType;
+                if ($scope.inventoryTypeUpdateOptions.includes(inventoryType)) {
+                    $scope.selectedUpdateOption = inventoryType;
+                } else {
+                    $scope.inventoryTypeFormUpdateSearch = $scope.inventoryTypeUpdateOptions[0];
+                }
+            });
         });
+
         self.submitUpdateInventoryForm = function () {
             var data;
 

--- a/api-gateway/src/main/resources/static/scripts/inventory-update-form/inventory-update-form.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/inventory-update-form/inventory-update-form.controller.js
@@ -6,7 +6,13 @@ angular.module('inventoryUpdateForm')
         var inventoryId = $stateParams.inventoryId || "";
         var method = $stateParams.method;
         $scope.inventoryTypeFormUpdateSearch = "";
-        $scope.inventoryTypeUpdateOptions = ["New Type", "Internal", "Sales"] //get all form the inventory type repository but dont remove the New Type
+        $scope.inventoryTypeUpdateOptions = ["New Type"];
+        $http.get("api/gateway/inventory/type").then(function (resp) {
+            //add transparent none for search query
+            //fill the inv type when updating
+            resp.data.forEach(function (type) {
+                $scope.inventoryTypeUpdateOptions.push(type.type);
+            })});
         $scope.selectedUpdateOption = $scope.inventoryTypeUpdateOptions[0]
 
         $http.get('api/gateway/inventory/' + inventoryId).then(function (resp) {

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/InventoryServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/InventoryServiceClientIntegrationTest.java
@@ -113,4 +113,23 @@ class InventoryServiceClientIntegrationTest {
                 .verifyComplete();
     }
 
+    @Test
+    void getInventoryTypes() throws JsonProcessingException{
+        InventoryTypeResponseDTO inventoryTypeResponseDTO = new InventoryTypeResponseDTO(
+                "142f383f-9fbf-479b-95e3-6c928f6a290b",
+                "Internal"
+        );
+
+        mockWebServer.enqueue(new MockResponse()
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .setBody(objectMapper.writeValueAsString(inventoryTypeResponseDTO))
+                .addHeader("Content-Type", "application/json"));
+
+        Flux<InventoryTypeResponseDTO> inventoryTypeResponseDTOFlux = inventoryServiceClient
+                .getAllInventoryTypes();
+        StepVerifier.create(inventoryTypeResponseDTOFlux)
+                .expectNextCount(1)
+                .verifyComplete();
+    }
+
 }

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryService.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryService.java
@@ -24,6 +24,7 @@ public interface ProductInventoryService {
     Mono<InventoryTypeResponseDTO> addInventoryType(Mono<InventoryTypeRequestDTO> inventoryTypeRequestDTO);
 
     Flux<InventoryResponseDTO> searchInventories(Pageable page, String inventoryName, String inventoryType, String inventoryDescription);
+    Flux<InventoryTypeResponseDTO> getAllInventoryTypes();
 
     Mono<ProductResponseDTO> getProductByProductIdInInventory(String inventoryId, String productId);
 

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryServiceImpl.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryServiceImpl.java
@@ -315,5 +315,11 @@ public class ProductInventoryServiceImpl implements ProductInventoryService {
                 .flatMap(inventoryTypeRepository::insert)
                 .map(EntityDTOUtil::toInventoryTypeResponseDTO);
     }
+
+    @Override
+    public Flux<InventoryTypeResponseDTO> getAllInventoryTypes() {
+        return inventoryTypeRepository.findAll()
+                .map(EntityDTOUtil::toInventoryTypeResponseDTO);
+    }
 }
 

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/presentationlayer/InventoryController.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/presentationlayer/InventoryController.java
@@ -128,5 +128,10 @@ public Flux<InventoryResponseDTO> searchInventories(
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
+    @GetMapping("/type")
+    public Flux<InventoryTypeResponseDTO> getAllInventoryTypes(){
+    return productInventoryService.getAllInventoryTypes();
+    }
+
 }
 

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/utils/DataBaseLoaderService.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/utils/DataBaseLoaderService.java
@@ -125,5 +125,13 @@ public class DataBaseLoaderService  implements CommandLineRunner {
                 .flatMap(inventoryRepository::insert)
                 .log()
                 .subscribe();
+        Mono.just(inventoryType1)
+                .flatMap(inventoryTypeRepository::insert)
+                .log()
+                .subscribe();
+        Mono.just(inventoryType2)
+                .flatMap(inventoryTypeRepository::insert)
+                .log()
+                .subscribe();
     }
 }

--- a/inventory-service/src/test/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryServiceUnitTest.java
+++ b/inventory-service/src/test/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryServiceUnitTest.java
@@ -815,6 +815,18 @@ class ProductInventoryServiceUnitTest {
                 })
                 .verifyComplete();
     }
+    @Test
+    public void getAllInventoryTypes_ShouldSucceed(){
+        when(inventoryTypeRepository.findAll())
+                .thenReturn(Flux.just(inventoryType));
+        Flux<InventoryTypeResponseDTO> inventoryTypeResponseDTOFlux = productInventoryService.getAllInventoryTypes();
+
+        StepVerifier
+                .create(inventoryTypeResponseDTOFlux)
+                .expectNextCount(1)
+                .verifyComplete();
+
+    }
 
 
 

--- a/inventory-service/src/test/java/com/petclinic/inventoryservice/presentationlayer/InventoryControllerIntegrationTest.java
+++ b/inventory-service/src/test/java/com/petclinic/inventoryservice/presentationlayer/InventoryControllerIntegrationTest.java
@@ -737,6 +737,16 @@ class InventoryControllerIntegrationTest {
                 });
     }
 
+    @Test
+    public void getAllInventoryTypes_shouldSucceed(){
+        webTestClient.get()
+                .uri("/inventory/type")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON);
+    }
+
     /*
     @Test
     public void deleteInventoryByInventoryId_withNotFoundInventoryId_shouldNotFound() {

--- a/inventory-service/src/test/java/com/petclinic/inventoryservice/presentationlayer/InventoryControllerUnitTest.java
+++ b/inventory-service/src/test/java/com/petclinic/inventoryservice/presentationlayer/InventoryControllerUnitTest.java
@@ -14,6 +14,8 @@ import reactor.core.publisher.Mono;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -55,6 +57,16 @@ class InventoryControllerUnitTest {
                     .productDescription("Sedative Medication")
                     .productPrice(100.00)
                     .productQuantity(10)
+                    .build()
+    );
+    List<InventoryTypeResponseDTO> typesDTOS = Arrays.asList(
+            InventoryTypeResponseDTO.builder()
+                    .type("Internal")
+                    .typeId(UUID.randomUUID().toString())
+                    .build(),
+            InventoryTypeResponseDTO.builder()
+                    .type("External")
+                    .typeId(UUID.randomUUID().toString())
                     .build()
     );
 
@@ -716,6 +728,23 @@ class InventoryControllerUnitTest {
 
         verify(productInventoryService, times(1))
                 .addInventoryType(any());
+    }
+    @Test
+    public void getAllInventoryTypes_shouldSucceed(){
+        when(productInventoryService.getAllInventoryTypes())
+                .thenReturn(Flux.fromIterable(typesDTOS));
+
+        webTestClient.get()
+                .uri("/inventory/type")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBodyList(ProductResponseDTO.class)
+                .value(responseDTOs -> {
+                    assertNotNull(responseDTOs);
+                    assertEquals(typesDTOS.size(), responseDTOs.size());
+                });
     }
 
 


### PR DESCRIPTION
JIRA: link to jira ticket
https://champlainsaintlambert.atlassian.net/browse/CPC-895
## Context:
This ticket is about adding the rendering of all created inventory types after creating them.
## Changes

- This affects the inventory
- This affects the addition and editing of inventories
- Added get all inventory type request
- Displays all the default + custom inventory types in the dropdown bar
- Search queries now support the custom inventory types as well + displayed when clicked on
- All testing required is completed

## Before and After UI (Required for UI-impacting PRs)
Before
![image](https://github.com/cgerard321/champlain_petclinic/assets/119442915/a922a82e-10ff-44ea-92f6-33c853039a13)
After
![image](https://github.com/cgerard321/champlain_petclinic/assets/119442915/17128ebb-5339-4471-9634-e8d8c4413c4b)
Add Form
![image](https://github.com/cgerard321/champlain_petclinic/assets/119442915/1dc904c4-7555-48ba-9e5e-5b23fac6a7d3)
Update Form
![image](https://github.com/cgerard321/champlain_petclinic/assets/119442915/d137cbf4-1ce9-430a-8b44-f2ad7460fd95)

## Linked pull requests (Optional)
https://github.com/cgerard321/champlain_petclinic/pull/505
