### PR TITLE
feat(VETS-CPC-838): split vet dto

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/AuthServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/AuthServiceClient.java
@@ -3,7 +3,8 @@ package com.petclinic.bffapigateway.domainclientlayer;
 import com.petclinic.bffapigateway.dtos.Auth.*;
 import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerRequestDTO;
 import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerResponseDTO;
-import com.petclinic.bffapigateway.dtos.Vets.VetDTO;
+import com.petclinic.bffapigateway.dtos.Vets.VetRequestDTO;
+import com.petclinic.bffapigateway.dtos.Vets.VetResponseDTO;
 import com.petclinic.bffapigateway.exceptions.*;
 import com.petclinic.bffapigateway.utils.Rethrower;
 import lombok.extern.slf4j.Slf4j;
@@ -102,45 +103,44 @@ public class AuthServiceClient {
         }
 
 
-        public Mono<VetDTO> createVetUser(Mono<RegisterVet> model){
+    public Mono<VetResponseDTO> createVetUser(Mono<RegisterVet> model){
 
-            String uuid = UUID.randomUUID().toString();
-            log.info("UUID: " + uuid);
+        String uuid = UUID.randomUUID().toString();
+        log.info("UUID: " + uuid);
 
-            return model.flatMap(registerVet -> {
-                registerVet.setUserId(uuid);
-                return webClientBuilder.build().post()
-                        .uri(authServiceUrl + "/users")
-                        .body(Mono.just(registerVet), RegisterVet.class)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .retrieve()
-                        .onStatus(HttpStatusCode::is4xxClientError,
-                                n -> rethrower.rethrow(n,
-                                        x -> new GenericHttpException(x.get("message").toString(),(HttpStatus) n.statusCode()))
-                        )
-                        .bodyToMono(UserPasswordLessDTO.class)
-                        .flatMap(userDetails -> {
-                                    VetDTO vetDTO = VetDTO.builder()
-                                            .specialties(registerVet.getVet().getSpecialties())
-                                            .active(registerVet.getVet().isActive())
-                                            .email(registerVet.getEmail())
-                                            .image(registerVet.getVet().getImage())
-                                            .resume(registerVet.getVet().getResume())
-                                            .workday(registerVet.getVet().getWorkday())
-                                            .phoneNumber(registerVet.getVet().getPhoneNumber())
-                                            .vetBillId(registerVet.getVet().getVetBillId())
-                                            .firstName(registerVet.getVet().getFirstName())
-                                            .lastName(registerVet.getVet().getLastName())
-                                            .vetId(uuid)
-                                            .build();
-                                    return vetsServiceClient.createVet((Mono.just(vetDTO)));
-                                }
-                        );
-            }).doOnError(throwable -> {
-                log.error("Error creating user: " + throwable.getMessage());
-                vetsServiceClient.deleteVet(uuid);
-            });
-        }
+        return model.flatMap(registerVet -> {
+            registerVet.setUserId(uuid);
+            return webClientBuilder.build().post()
+                    .uri(authServiceUrl + "/users")
+                    .body(Mono.just(registerVet), RegisterVet.class)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError,
+                            n -> rethrower.rethrow(n,
+                                    x -> new GenericHttpException(x.get("message").toString(),(HttpStatus) n.statusCode()))
+                    )
+                    .bodyToMono(UserPasswordLessDTO.class)
+                    .flatMap(userDetails -> {
+                                VetRequestDTO vetDTO = VetRequestDTO.builder()
+                                        .specialties(registerVet.getVet().getSpecialties())
+                                        .active(registerVet.getVet().isActive())
+                                        .email(registerVet.getEmail())
+                                        .resume(registerVet.getVet().getResume())
+                                        .workday(registerVet.getVet().getWorkday())
+                                        .phoneNumber(registerVet.getVet().getPhoneNumber())
+                                        .vetBillId(registerVet.getVet().getVetBillId())
+                                        .firstName(registerVet.getVet().getFirstName())
+                                        .lastName(registerVet.getVet().getLastName())
+                                        .vetId(uuid)
+                                        .build();
+                                return vetsServiceClient.createVet((Mono.just(vetDTO)));
+                            }
+                    );
+        }).doOnError(throwable -> {
+            log.error("Error creating user: " + throwable.getMessage());
+            vetsServiceClient.deleteVet(uuid);
+        });
+    }
 
 
 //    public Mono<UserDetails> updateUser (final long userId, final Register model) {

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -234,49 +234,49 @@ public class VetsServiceClient {
 
 
     //Vets
-    public Flux<VetDTO> getVets() {
+    public Flux<VetResponseDTO> getVets() {
 
         return webClientBuilder
-          .build()
-          .get()
-          .uri(vetsServiceUrl)
-          .retrieve()
-          .onStatus(HttpStatusCode::is5xxServerError,error->
-                  Mono.error(new IllegalArgumentException("Something went wrong"))
-          )
-          .bodyToFlux(VetDTO.class);
+                .build()
+                .get()
+                .uri(vetsServiceUrl)
+                .retrieve()
+                .onStatus(HttpStatusCode::is5xxServerError,error->
+                        Mono.error(new IllegalArgumentException("Something went wrong"))
+                )
+                .bodyToFlux(VetResponseDTO.class);
     }
 
-    public Mono<VetDTO> getVetByVetId(String vetId) {
+    public Mono<VetResponseDTO> getVetByVetId(String vetId) {
 
         return webClientBuilder
-          .build()
-          .get()
-          .uri(vetsServiceUrl + "/{vetId}", vetId)
-          .retrieve()
-          .onStatus(HttpStatusCode::is4xxClientError, error->{
-              HttpStatusCode statusCode = error.statusCode();
-              if(statusCode.equals(NOT_FOUND))
-                  return Mono.error(new ExistingVetNotFoundException("vetId not found: "+vetId, NOT_FOUND));
-              return Mono.error(new IllegalArgumentException("Something went wrong"));
-          })
-          .onStatus(HttpStatusCode::is5xxServerError,error->
-                  Mono.error(new IllegalArgumentException("Something went wrong"))
-          )
-          .bodyToMono(VetDTO.class);
+                .build()
+                .get()
+                .uri(vetsServiceUrl + "/{vetId}", vetId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, error->{
+                    HttpStatusCode statusCode = error.statusCode();
+                    if(statusCode.equals(NOT_FOUND))
+                        return Mono.error(new ExistingVetNotFoundException("vetId not found: "+vetId, NOT_FOUND));
+                    return Mono.error(new IllegalArgumentException("Something went wrong"));
+                })
+                .onStatus(HttpStatusCode::is5xxServerError,error->
+                        Mono.error(new IllegalArgumentException("Something went wrong"))
+                )
+                .bodyToMono(VetResponseDTO.class);
     }
 
-    public Mono<VetDTO> getVetByVetBillId(String vetBillId) {
+    public Mono<VetResponseDTO> getVetByVetBillId(String vetBillId) {
 
         return webClientBuilder
                 .build()
                 .get()
                 .uri(vetsServiceUrl + "/vetBillId/{vetBillId}", vetBillId)
                 .retrieve()
-                .bodyToMono(VetDTO.class);
+                .bodyToMono(VetResponseDTO.class);
     }
 
-    public Flux<VetDTO> getInactiveVets() {
+    public Flux<VetResponseDTO> getInactiveVets() {
 
         return webClientBuilder
                 .build()
@@ -286,10 +286,10 @@ public class VetsServiceClient {
                 .onStatus(HttpStatusCode::is5xxServerError,error->
                         Mono.error(new IllegalArgumentException("Something went wrong"))
                 )
-                .bodyToFlux(VetDTO.class);
+                .bodyToFlux(VetResponseDTO.class);
     }
 
-    public Flux<VetDTO> getActiveVets() {
+    public Flux<VetResponseDTO> getActiveVets() {
 
         return webClientBuilder
                 .build()
@@ -299,23 +299,23 @@ public class VetsServiceClient {
                 .onStatus(HttpStatusCode::is5xxServerError,error->
                         Mono.error(new IllegalArgumentException("Something went wrong"))
                 )
-                .bodyToFlux(VetDTO.class);
+                .bodyToFlux(VetResponseDTO.class);
     }
 
 
-    public Mono<VetDTO> createVet(Mono<VetDTO> model) {
+    public Mono<VetResponseDTO> createVet(Mono<VetRequestDTO> model) {
 
         return webClientBuilder
                 .build()
                 .post()
-        .uri(vetsServiceUrl)
-        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-        .body(model, VetDTO.class)
-        .retrieve()
-        .onStatus(HttpStatusCode::is5xxServerError,error->
-                Mono.error(new IllegalArgumentException("Something went wrong"))
-        )
-        .bodyToMono(VetDTO.class);
+                .uri(vetsServiceUrl)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .body(model, VetRequestDTO.class)
+                .retrieve()
+                .onStatus(HttpStatusCode::is5xxServerError,error->
+                        Mono.error(new IllegalArgumentException("Something went wrong"))
+                )
+                .bodyToMono(VetResponseDTO.class);
     }
 
     public Mono<Void> deleteVet(String vetId) {
@@ -337,14 +337,14 @@ public class VetsServiceClient {
                 .bodyToMono(Void.class);
     }
 
-    public Mono<VetDTO> updateVet(String vetId,Mono<VetDTO> model) {
+    public Mono<VetResponseDTO> updateVet(String vetId,Mono<VetRequestDTO> model) {
 
         return webClientBuilder
                 .build()
                 .put()
                 .uri(vetsServiceUrl + "/{vetId}", vetId)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .body(model, VetDTO.class)
+                .body(model, VetRequestDTO.class)
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, error->{
                     HttpStatusCode statusCode = error.statusCode();
@@ -355,7 +355,7 @@ public class VetsServiceClient {
                 .onStatus(HttpStatusCode::is5xxServerError,error->
                         Mono.error(new IllegalArgumentException("Something went wrong"))
                 )
-                .bodyToMono(VetDTO.class);
+                .bodyToMono(VetResponseDTO.class);
     }
 
 

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Auth/RegisterVet.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Auth/RegisterVet.java
@@ -1,8 +1,7 @@
 package com.petclinic.bffapigateway.dtos.Auth;
 
 
-import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerRequestDTO;
-import com.petclinic.bffapigateway.dtos.Vets.VetDTO;
+import com.petclinic.bffapigateway.dtos.Vets.VetRequestDTO;
 import com.petclinic.bffapigateway.utils.Security.Annotations.PasswordStrengthCheck;
 import com.petclinic.bffapigateway.utils.Security.Variables.Roles;
 import lombok.AllArgsConstructor;
@@ -21,5 +20,5 @@ public class RegisterVet {
     private final String defaultRole = Roles.VET.toString();
     @PasswordStrengthCheck
     private String password;
-    private VetDTO vet;
+    private VetRequestDTO vet;
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/VetAverageRatingDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/VetAverageRatingDTO.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class VetAverageRatingDTO {
 
-    private VetDTO vetDTO;
+    private VetResponseDTO vetDTO;
     private String vetId;
     private double averageRating;
 

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/VetRequestDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/VetRequestDTO.java
@@ -7,18 +7,16 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class VetDTO {
+public class VetRequestDTO {
     private String vetId;
     private String vetBillId;
     private String firstName;
     private String lastName;
     private String email;
     private String phoneNumber;
-    private byte[] image;
     private String resume;
     private Set<Workday> workday;
     private boolean active;
     private Set<SpecialtyDTO> specialties;
-
 
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/VetResponseDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/VetResponseDTO.java
@@ -1,0 +1,25 @@
+package com.petclinic.bffapigateway.dtos.Vets;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VetResponseDTO {
+    private String vetId;
+    private String vetBillId;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String phoneNumber;
+    private String resume;
+    private Set<Workday> workday;
+    private boolean active;
+    private Set<SpecialtyDTO> specialties;
+}

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -460,13 +460,13 @@ public class BFFApiGatewayController {
     //Vets
     @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS})
     @GetMapping(value = "vets")
-    public Flux<VetDTO> getAllVets() {
+    public Flux<VetResponseDTO> getAllVets() {
         return vetsServiceClient.getVets();
     }
 
     @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS})
     @GetMapping("/vets/{vetId}")
-    public Mono<ResponseEntity<VetDTO>> getVetByVetId(@PathVariable String vetId) {
+    public Mono<ResponseEntity<VetResponseDTO>> getVetByVetId(@PathVariable String vetId) {
         return vetsServiceClient.getVetByVetId(VetsEntityDtoUtil.verifyId(vetId))
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
@@ -474,24 +474,24 @@ public class BFFApiGatewayController {
 
     @IsUserSpecific(idToMatch = {"vetId"})
     @GetMapping("/vets/vetBillId/{vetId}")
-    public Mono<ResponseEntity<VetDTO>> getVetByVetBillId(@PathVariable String vetBillId) {
+    public Mono<ResponseEntity<VetResponseDTO>> getVetByVetBillId(@PathVariable String vetBillId) {
         return vetsServiceClient.getVetByVetBillId(VetsEntityDtoUtil.verifyId(vetBillId))
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
     @GetMapping(value = "/vets/active")//, produces= MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<VetDTO> getActiveVets() {
+    public Flux<VetResponseDTO> getActiveVets() {
         return vetsServiceClient.getActiveVets();
     }
 
     @GetMapping(value = "/vets/inactive")//, produces= MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<VetDTO> getInactiveVets() {
+    public Flux<VetResponseDTO> getInactiveVets() {
         return vetsServiceClient.getInactiveVets();
     }
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
     @PostMapping(value = "/users/vets",consumes = "application/json",produces = "application/json")
-    public Mono<ResponseEntity<VetDTO>> insertVet(@RequestBody Mono<RegisterVet> vetDTOMono) {
+    public Mono<ResponseEntity<VetResponseDTO>> insertVet(@RequestBody Mono<RegisterVet> vetDTOMono) {
         return authServiceClient.createVetUser(vetDTOMono)
                 .map(v->ResponseEntity.status(HttpStatus.CREATED).body(v))
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
@@ -499,7 +499,7 @@ public class BFFApiGatewayController {
 
     @IsUserSpecific(idToMatch = {"vetId"}, bypassRoles = {Roles.ADMIN})
     @PutMapping(value = "/vets/{vetId}",consumes = "application/json",produces = "application/json")
-    public Mono<ResponseEntity<VetDTO>> updateVetByVetId(@PathVariable String vetId, @RequestBody Mono<VetDTO> vetDTOMono) {
+    public Mono<ResponseEntity<VetResponseDTO>> updateVetByVetId(@PathVariable String vetId, @RequestBody Mono<VetRequestDTO> vetDTOMono) {
         return vetsServiceClient.updateVet(VetsEntityDtoUtil.verifyId(vetId), vetDTOMono)
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
@@ -668,7 +668,7 @@ public class BFFApiGatewayController {
         return customersServiceClient.deleteOwner(ownerId).then(Mono.just(ResponseEntity.noContent().<OwnerResponseDTO>build()))
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
-    
+
     /**
      * End of Owner Methods
      **/

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
@@ -10,13 +10,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.http.MediaType;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -30,14 +28,9 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static io.netty.handler.codec.http.HttpHeaders.setHeader;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.in;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 
@@ -51,8 +44,11 @@ class VetsServiceClientIntegrationTest {
 
     private ObjectMapper mapper;
 
-    VetDTO vetDTO = buildVetDTO();
+    VetRequestDTO vetRequestDTO = buildVetRequestDTO();
+    VetResponseDTO vetResponseDTO = buildVetResponseDTO();
+
     ClassPathResource cpr=new ClassPathResource("static/images/full_food_bowl.png");
+
 
     @BeforeEach
     void setup() {
@@ -166,7 +162,7 @@ class VetsServiceClientIntegrationTest {
                         "    }"));
 
         final VetAverageRatingDTO averageRatingDTO = vetsServiceClient.getTopThreeVetsWithHighestAverageRating().blockFirst();
-        assertEquals("deb1950c-3c56-45dc-874b-89e352695eb7",vetDTO.getVetId());
+        assertEquals("deb1950c-3c56-45dc-874b-89e352695eb7", vetResponseDTO.getVetId());
         assertEquals(4.5, averageRatingDTO.getAverageRating(),0.1);
         //its 0.0 because the vet doesn't have any ratings
     }
@@ -236,7 +232,7 @@ class VetsServiceClientIntegrationTest {
                 .setBody("4.5"));
 
         final Double averageRating =
-                vetsServiceClient.getAverageRatingByVetId(vetDTO.getVetId())
+                vetsServiceClient.getAverageRatingByVetId(vetResponseDTO.getVetId())
                         .onErrorResume(throwable -> {
                             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                                 return Mono.empty();
@@ -280,7 +276,7 @@ class VetsServiceClientIntegrationTest {
                 .setBody("Something went wrong"));
 
         final Double averageRating =
-                vetsServiceClient.getAverageRatingByVetId(vetDTO.getVetId())
+                vetsServiceClient.getAverageRatingByVetId(vetResponseDTO.getVetId())
                         .onErrorResume(throwable -> {
                             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                                 return Mono.empty();
@@ -300,7 +296,7 @@ class VetsServiceClientIntegrationTest {
                 .setBody("Something went wrong"));
 
         final Double averageRating =
-                vetsServiceClient.getAverageRatingByVetId(vetDTO.getVetId())
+                vetsServiceClient.getAverageRatingByVetId(vetResponseDTO.getVetId())
                         .onErrorResume(throwable -> {
                             if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                                 return Mono.empty();
@@ -385,7 +381,7 @@ class VetsServiceClientIntegrationTest {
 
         assertNull(ratingPercentages);
     }
-  
+
     @Test
     void deleteRatingsByRatingId() throws JsonProcessingException{
         final String ratingId = "794ac37f-1e07-43c2-93bc-61839e61d989";
@@ -398,7 +394,7 @@ class VetsServiceClientIntegrationTest {
                         "        \"rateScore\": 4.5\n" +
                         "    }"));
 
-        final Mono<Void> empty = vetsServiceClient.deleteRating(vetDTO.getVetId(), ratingId);
+        final Mono<Void> empty = vetsServiceClient.deleteRating(vetResponseDTO.getVetId(), ratingId);
 
         assertEquals(empty.block(), null);
     }
@@ -967,13 +963,13 @@ class VetsServiceClientIntegrationTest {
                         "        \"active\": false\n" +
                         "    }"));
 
-        final VetDTO vet = vetsServiceClient.getVets().blockFirst();
+        final VetResponseDTO vet = vetsServiceClient.getVets().blockFirst();
         assertFalse(vet.isActive());
-        assertEquals(vetDTO.getFirstName(), vet.getFirstName());
-        assertEquals(vetDTO.getLastName(), vet.getLastName());
-        assertEquals(vetDTO.getEmail(), vet.getEmail());
-        assertEquals(vetDTO.getPhoneNumber(), vet.getPhoneNumber());
-        assertEquals(vetDTO.getResume(), vet.getResume());
+        assertEquals(vetResponseDTO.getFirstName(), vet.getFirstName());
+        assertEquals(vetResponseDTO.getLastName(), vet.getLastName());
+        assertEquals(vetResponseDTO.getEmail(), vet.getEmail());
+        assertEquals(vetResponseDTO.getPhoneNumber(), vet.getPhoneNumber());
+        assertEquals(vetResponseDTO.getResume(), vet.getResume());
     }
 
     @Test
@@ -983,7 +979,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.getVets()
+        final VetResponseDTO vet = vetsServiceClient.getVets()
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1010,13 +1006,13 @@ class VetsServiceClientIntegrationTest {
                         "        \"active\": false\n" +
                         "    }"));
 
-        final VetDTO vet = vetsServiceClient.getActiveVets().blockFirst();
+        final VetResponseDTO vet = vetsServiceClient.getActiveVets().blockFirst();
         assertFalse(vet.isActive());
-        assertEquals(vetDTO.getFirstName(), vet.getFirstName());
-        assertEquals(vetDTO.getLastName(), vet.getLastName());
-        assertEquals(vetDTO.getEmail(), vet.getEmail());
-        assertEquals(vetDTO.getPhoneNumber(), vet.getPhoneNumber());
-        assertEquals(vetDTO.getResume(), vet.getResume());
+        assertEquals(vetResponseDTO.getFirstName(), vet.getFirstName());
+        assertEquals(vetResponseDTO.getLastName(), vet.getLastName());
+        assertEquals(vetResponseDTO.getEmail(), vet.getEmail());
+        assertEquals(vetResponseDTO.getPhoneNumber(), vet.getPhoneNumber());
+        assertEquals(vetResponseDTO.getResume(), vet.getResume());
     }
 
     @Test
@@ -1026,7 +1022,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.getActiveVets()
+        final VetResponseDTO vet = vetsServiceClient.getActiveVets()
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1053,13 +1049,13 @@ class VetsServiceClientIntegrationTest {
                         "        \"active\": false\n" +
                         "    }"));
 
-        final VetDTO vet = vetsServiceClient.getInactiveVets().blockFirst();
+        final VetResponseDTO vet = vetsServiceClient.getInactiveVets().blockFirst();
         assertFalse(vet.isActive());
-        assertEquals(vetDTO.getFirstName(), vet.getFirstName());
-        assertEquals(vetDTO.getLastName(), vet.getLastName());
-        assertEquals(vetDTO.getEmail(), vet.getEmail());
-        assertEquals(vetDTO.getPhoneNumber(), vet.getPhoneNumber());
-        assertEquals(vetDTO.getResume(), vet.getResume());
+        assertEquals(vetResponseDTO.getFirstName(), vet.getFirstName());
+        assertEquals(vetResponseDTO.getLastName(), vet.getLastName());
+        assertEquals(vetResponseDTO.getEmail(), vet.getEmail());
+        assertEquals(vetResponseDTO.getPhoneNumber(), vet.getPhoneNumber());
+        assertEquals(vetResponseDTO.getResume(), vet.getResume());
     }
 
     @Test
@@ -1069,7 +1065,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.getInactiveVets()
+        final VetResponseDTO vet = vetsServiceClient.getInactiveVets()
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1096,13 +1092,13 @@ class VetsServiceClientIntegrationTest {
                         "        \"active\": false\n" +
                         "    }"));
 
-        final VetDTO vet = vetsServiceClient.getVetByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").block();
+        final VetResponseDTO vet = vetsServiceClient.getVetByVetId("deb1950c-3c56-45dc-874b-89e352695eb7").block();
         assertFalse(vet.isActive());
-        assertEquals(vetDTO.getFirstName(), vet.getFirstName());
-        assertEquals(vetDTO.getLastName(), vet.getLastName());
-        assertEquals(vetDTO.getEmail(), vet.getEmail());
-        assertEquals(vetDTO.getPhoneNumber(), vet.getPhoneNumber());
-        assertEquals(vetDTO.getResume(), vet.getResume());
+        assertEquals(vetResponseDTO.getFirstName(), vet.getFirstName());
+        assertEquals(vetResponseDTO.getLastName(), vet.getLastName());
+        assertEquals(vetResponseDTO.getEmail(), vet.getEmail());
+        assertEquals(vetResponseDTO.getPhoneNumber(), vet.getPhoneNumber());
+        assertEquals(vetResponseDTO.getResume(), vet.getResume());
     }
 
     @Test
@@ -1114,7 +1110,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(404)
                 .setBody("vetId not found: "+invalidVetId));
 
-        final VetDTO vet = vetsServiceClient.getVetByVetId(invalidVetId)
+        final VetResponseDTO vet = vetsServiceClient.getVetByVetId(invalidVetId)
                 .onErrorResume(throwable -> {
                     if (throwable instanceof ExistingVetNotFoundException && throwable.getMessage().equals("vetId not found: "+invalidVetId)) {
                         return Mono.empty();
@@ -1134,7 +1130,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(400)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.getVetByVetId("deb1950c-3c56-45dc-874b-89e352695eb7")
+        final VetResponseDTO vet = vetsServiceClient.getVetByVetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1154,7 +1150,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.getVetByVetId("deb1950c-3c56-45dc-874b-89e352695eb7")
+        final VetResponseDTO vet = vetsServiceClient.getVetByVetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1181,13 +1177,13 @@ class VetsServiceClientIntegrationTest {
                         "        \"active\": false\n" +
                         "    }"));
 
-        final VetDTO vet = vetsServiceClient.createVet(Mono.just(vetDTO)).block();
+        final VetResponseDTO vet = vetsServiceClient.createVet(Mono.just(vetRequestDTO)).block();
         assertFalse(vet.isActive());
-        assertEquals(vetDTO.getFirstName(), vet.getFirstName());
-        assertEquals(vetDTO.getLastName(), vet.getLastName());
-        assertEquals(vetDTO.getEmail(), vet.getEmail());
-        assertEquals(vetDTO.getPhoneNumber(), vet.getPhoneNumber());
-        assertEquals(vetDTO.getResume(), vet.getResume());
+        assertEquals(vetResponseDTO.getFirstName(), vet.getFirstName());
+        assertEquals(vetResponseDTO.getLastName(), vet.getLastName());
+        assertEquals(vetResponseDTO.getEmail(), vet.getEmail());
+        assertEquals(vetResponseDTO.getPhoneNumber(), vet.getPhoneNumber());
+        assertEquals(vetResponseDTO.getResume(), vet.getResume());
     }
 
     @Test
@@ -1197,7 +1193,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.createVet(Mono.just(vetDTO))
+        final VetResponseDTO vet = vetsServiceClient.createVet(Mono.just(vetRequestDTO))
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1224,13 +1220,13 @@ class VetsServiceClientIntegrationTest {
                         "        \"active\": false\n" +
                         "    }"));
 
-        final VetDTO vet = vetsServiceClient.updateVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(vetDTO)).block();
+        final VetResponseDTO vet = vetsServiceClient.updateVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(vetRequestDTO)).block();
         assertFalse(vet.isActive());
-        assertEquals(vetDTO.getFirstName(), vet.getFirstName());
-        assertEquals(vetDTO.getLastName(), vet.getLastName());
-        assertEquals(vetDTO.getEmail(), vet.getEmail());
-        assertEquals(vetDTO.getPhoneNumber(), vet.getPhoneNumber());
-        assertEquals(vetDTO.getResume(), vet.getResume());
+        assertEquals(vetResponseDTO.getFirstName(), vet.getFirstName());
+        assertEquals(vetResponseDTO.getLastName(), vet.getLastName());
+        assertEquals(vetResponseDTO.getEmail(), vet.getEmail());
+        assertEquals(vetResponseDTO.getPhoneNumber(), vet.getPhoneNumber());
+        assertEquals(vetResponseDTO.getResume(), vet.getResume());
     }
 
     @Test
@@ -1242,7 +1238,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(404)
                 .setBody("vetId not found: "+invalidVetId));
 
-        final VetDTO vet = vetsServiceClient.updateVet(invalidVetId, Mono.just(vetDTO))
+        final VetResponseDTO vet = vetsServiceClient.updateVet(invalidVetId, Mono.just(vetRequestDTO))
                 .onErrorResume(throwable -> {
                     if (throwable instanceof ExistingVetNotFoundException && throwable.getMessage().equals("vetId not found: "+invalidVetId)) {
                         return Mono.empty();
@@ -1262,7 +1258,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(400)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.updateVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(vetDTO))
+        final VetResponseDTO vet = vetsServiceClient.updateVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(vetRequestDTO))
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1282,7 +1278,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final VetDTO vet = vetsServiceClient.updateVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(vetDTO))
+        final VetResponseDTO vet = vetsServiceClient.updateVet("deb1950c-3c56-45dc-874b-89e352695eb7", Mono.just(vetRequestDTO))
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1310,7 +1306,7 @@ class VetsServiceClientIntegrationTest {
                         "        \"active\": false\n" +
                         "    }"));
 
-        final Mono<Void> empty = vetsServiceClient.deleteVet(vetDTO.getVetId());
+        final Mono<Void> empty = vetsServiceClient.deleteVet(vetResponseDTO.getVetId());
 
         assertEquals(empty.block(), null);
     }
@@ -1344,7 +1340,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(400)
                 .setBody("Something went wrong"));
 
-        final Void empty = vetsServiceClient.deleteVet(vetDTO.getVetId())
+        final Void empty = vetsServiceClient.deleteVet(vetResponseDTO.getVetId())
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1364,7 +1360,7 @@ class VetsServiceClientIntegrationTest {
                 .setResponseCode(500)
                 .setBody("Something went wrong"));
 
-        final Void empty = vetsServiceClient.deleteVet(vetDTO.getVetId())
+        final Void empty = vetsServiceClient.deleteVet(vetResponseDTO.getVetId())
                 .onErrorResume(throwable -> {
                     if (throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong")) {
                         return Mono.empty();
@@ -1399,6 +1395,7 @@ class VetsServiceClientIntegrationTest {
         assertEquals("Veterinary Medicine", education.getFieldOfStudy());
         assertEquals("2015", education.getStartDate());
         assertEquals("2019", education.getEndDate());
+
     }
 
     @Test
@@ -1676,7 +1673,7 @@ class VetsServiceClientIntegrationTest {
                         "    }"));
 
 
-        final Mono<Void> empty = vetsServiceClient.deleteEducation(vetDTO.getVetId(), educationId);
+        final Mono<Void> empty = vetsServiceClient.deleteEducation(vetResponseDTO.getVetId(), educationId);
 
         assertEquals(empty.block(), null);
     }
@@ -1687,20 +1684,32 @@ class VetsServiceClientIntegrationTest {
         this.server.enqueue(response);
     }
 
-    private VetDTO buildVetDTO() {
-        return VetDTO.builder()
+    private VetResponseDTO buildVetResponseDTO() {
+        return VetResponseDTO.builder()
                 .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
                 .firstName("Clementine")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-2847")
                 .resume("Just became a vet")
-                .image("kjd".getBytes())
+                .workday(new HashSet<>())
+                .specialties(new HashSet<>())
+                .active(false)
+                .build();
+    }
+    private VetRequestDTO buildVetRequestDTO() {
+        return VetRequestDTO.builder()
+                .vetId("deb1950c-3c56-45dc-874b-89e352695eb7")
+                .firstName("Clementine")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.com")
+                .phoneNumber("947-238-2847")
+                .resume("Just became a vet")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
                 .build();
     }
 
-
 }
+

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -97,9 +97,11 @@ class ApiGatewayControllerTest {
     @Mock
     private CustomersServiceClient customersServiceClientMock;
 
-    VetDTO vetDTO = buildVetDTO();
-    VetDTO vetDTO2 = buildVetDTO2();
-    String VET_ID = buildVetDTO().getVetId();
+    VetResponseDTO vetResponseDTO = buildVetResponseDTO();
+    VetRequestDTO vetRequestDTO = buildVetRequestDTO();
+    VetResponseDTO vetResponseDTO2 = buildVetResponseDTO2();
+    VetRequestDTO vetRequestDTO2 = buildVetRequestDTO2();
+    String VET_ID = buildVetResponseDTO().getVetId();
     String INVALID_VET_ID = "mjbedf";
 
     ClassPathResource cpr=new ClassPathResource("static/images/full_food_bowl.png");
@@ -543,7 +545,7 @@ class ApiGatewayControllerTest {
     @Test
     void getAllVets() {
         when(vetsServiceClient.getVets())
-                .thenReturn(Flux.just(vetDTO));
+                .thenReturn(Flux.just(vetResponseDTO));
 
         client
                 .get()
@@ -553,18 +555,17 @@ class ApiGatewayControllerTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().valueEquals("Content-Type", "text/event-stream;charset=UTF-8")
-                .expectBodyList(VetDTO.class)
+                .expectBodyList(VetResponseDTO.class)
                 .value(responseDTO -> {
                     Assertions.assertNotNull(responseDTO);
                     Assertions.assertNotNull(responseDTO.get(0).getVetId());
-                    assertThat(responseDTO.get(0).getVetId()).isEqualTo(vetDTO.getVetId());
-                    assertThat(responseDTO.get(0).getResume()).isEqualTo(vetDTO.getResume());
-                    assertThat(responseDTO.get(0).getLastName()).isEqualTo(vetDTO.getLastName());
-                    assertThat(responseDTO.get(0).getFirstName()).isEqualTo(vetDTO.getFirstName());
-                    assertThat(responseDTO.get(0).getEmail()).isEqualTo(vetDTO.getEmail());
-                    assertThat(responseDTO.get(0).getImage()).isNotEmpty();
-                    assertThat(responseDTO.get(0).isActive()).isEqualTo(vetDTO.isActive());
-                    assertThat(responseDTO.get(0).getWorkday()).isEqualTo(vetDTO.getWorkday());
+                    assertThat(responseDTO.get(0).getVetId()).isEqualTo(vetResponseDTO.getVetId());
+                    assertThat(responseDTO.get(0).getResume()).isEqualTo(vetResponseDTO.getResume());
+                    assertThat(responseDTO.get(0).getLastName()).isEqualTo(vetResponseDTO.getLastName());
+                    assertThat(responseDTO.get(0).getFirstName()).isEqualTo(vetResponseDTO.getFirstName());
+                    assertThat(responseDTO.get(0).getEmail()).isEqualTo(vetResponseDTO.getEmail());
+                    assertThat(responseDTO.get(0).isActive()).isEqualTo(vetResponseDTO.isActive());
+                    assertThat(responseDTO.get(0).getWorkday()).isEqualTo(vetResponseDTO.getWorkday());
                 });
         Mockito.verify(vetsServiceClient, times(1))
                 .getVets();
@@ -573,7 +574,7 @@ class ApiGatewayControllerTest {
     @Test
     void getVetByVetId() {
         when(vetsServiceClient.getVetByVetId(anyString()))
-                .thenReturn(Mono.just(vetDTO));
+                .thenReturn(Mono.just(vetResponseDTO));
 
         client
                 .get()
@@ -583,13 +584,12 @@ class ApiGatewayControllerTest {
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
-                .jsonPath("$.vetId").isEqualTo(vetDTO.getVetId())
-                .jsonPath("$.resume").isEqualTo(vetDTO.getResume())
-                .jsonPath("$.lastName").isEqualTo(vetDTO.getLastName())
-                .jsonPath("$.firstName").isEqualTo(vetDTO.getFirstName())
-                .jsonPath("$.email").isEqualTo(vetDTO.getEmail())
-                .jsonPath("$.image").isNotEmpty()
-                .jsonPath("$.active").isEqualTo(vetDTO.isActive());
+                .jsonPath("$.vetId").isEqualTo(vetResponseDTO.getVetId())
+                .jsonPath("$.resume").isEqualTo(vetResponseDTO.getResume())
+                .jsonPath("$.lastName").isEqualTo(vetResponseDTO.getLastName())
+                .jsonPath("$.firstName").isEqualTo(vetResponseDTO.getFirstName())
+                .jsonPath("$.email").isEqualTo(vetResponseDTO.getEmail())
+                .jsonPath("$.active").isEqualTo(vetResponseDTO.isActive());
 
         Mockito.verify(vetsServiceClient, times(1))
                 .getVetByVetId(VET_ID);
@@ -598,7 +598,7 @@ class ApiGatewayControllerTest {
     @Test
     void getActiveVets() {
         when(vetsServiceClient.getActiveVets())
-                .thenReturn(Flux.just(vetDTO2));
+                .thenReturn(Flux.just(vetResponseDTO2));
 
         client
                 .get()
@@ -608,18 +608,17 @@ class ApiGatewayControllerTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().valueEquals("Content-Type", "text/event-stream;charset=UTF-8")
-                .expectBodyList(VetDTO.class)
+                .expectBodyList(VetResponseDTO.class)
                 .value(responseDTO -> {
                     Assertions.assertNotNull(responseDTO);
                     Assertions.assertNotNull(responseDTO.get(0).getVetId());
-                    assertThat(responseDTO.get(0).getVetId()).isEqualTo(vetDTO2.getVetId());
-                    assertThat(responseDTO.get(0).getResume()).isEqualTo(vetDTO2.getResume());
-                    assertThat(responseDTO.get(0).getLastName()).isEqualTo(vetDTO2.getLastName());
-                    assertThat(responseDTO.get(0).getFirstName()).isEqualTo(vetDTO2.getFirstName());
-                    assertThat(responseDTO.get(0).getEmail()).isEqualTo(vetDTO2.getEmail());
-                    assertThat(responseDTO.get(0).getImage()).isNotEmpty();
-                    assertThat(responseDTO.get(0).isActive()).isEqualTo(vetDTO2.isActive());
-                    assertThat(responseDTO.get(0).getWorkday()).isEqualTo(vetDTO2.getWorkday());
+                    assertThat(responseDTO.get(0).getVetId()).isEqualTo(vetResponseDTO2.getVetId());
+                    assertThat(responseDTO.get(0).getResume()).isEqualTo(vetResponseDTO2.getResume());
+                    assertThat(responseDTO.get(0).getLastName()).isEqualTo(vetResponseDTO2.getLastName());
+                    assertThat(responseDTO.get(0).getFirstName()).isEqualTo(vetResponseDTO2.getFirstName());
+                    assertThat(responseDTO.get(0).getEmail()).isEqualTo(vetResponseDTO2.getEmail());
+                    assertThat(responseDTO.get(0).isActive()).isEqualTo(vetResponseDTO2.isActive());
+                    assertThat(responseDTO.get(0).getWorkday()).isEqualTo(vetResponseDTO2.getWorkday());
                 });
         Mockito.verify(vetsServiceClient, times(1))
                 .getActiveVets();
@@ -628,7 +627,7 @@ class ApiGatewayControllerTest {
     @Test
     void getInactiveVets() {
         when(vetsServiceClient.getInactiveVets())
-                .thenReturn(Flux.just(vetDTO));
+                .thenReturn(Flux.just(vetResponseDTO));
 
         client
                 .get()
@@ -638,18 +637,17 @@ class ApiGatewayControllerTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().valueEquals("Content-Type", "text/event-stream;charset=UTF-8")
-                .expectBodyList(VetDTO.class)
+                .expectBodyList(VetResponseDTO.class)
                 .value(responseDTO -> {
                     Assertions.assertNotNull(responseDTO);
                     Assertions.assertNotNull(responseDTO.get(0).getVetId());
-                    assertThat(responseDTO.get(0).getVetId()).isEqualTo(vetDTO.getVetId());
-                    assertThat(responseDTO.get(0).getResume()).isEqualTo(vetDTO.getResume());
-                    assertThat(responseDTO.get(0).getLastName()).isEqualTo(vetDTO.getLastName());
-                    assertThat(responseDTO.get(0).getFirstName()).isEqualTo(vetDTO.getFirstName());
-                    assertThat(responseDTO.get(0).getEmail()).isEqualTo(vetDTO.getEmail());
-                    assertThat(responseDTO.get(0).getImage()).isNotEmpty();
-                    assertThat(responseDTO.get(0).isActive()).isEqualTo(vetDTO.isActive());
-                    assertThat(responseDTO.get(0).getWorkday()).isEqualTo(vetDTO.getWorkday());
+                    assertThat(responseDTO.get(0).getVetId()).isEqualTo(vetResponseDTO.getVetId());
+                    assertThat(responseDTO.get(0).getResume()).isEqualTo(vetResponseDTO.getResume());
+                    assertThat(responseDTO.get(0).getLastName()).isEqualTo(vetResponseDTO.getLastName());
+                    assertThat(responseDTO.get(0).getFirstName()).isEqualTo(vetResponseDTO.getFirstName());
+                    assertThat(responseDTO.get(0).getEmail()).isEqualTo(vetResponseDTO.getEmail());
+                    assertThat(responseDTO.get(0).isActive()).isEqualTo(vetResponseDTO.isActive());
+                    assertThat(responseDTO.get(0).getWorkday()).isEqualTo(vetResponseDTO.getWorkday());
                 });
         Mockito.verify(vetsServiceClient, times(1))
                 .getInactiveVets();
@@ -663,7 +661,7 @@ class ApiGatewayControllerTest {
                 .username("vet")
                 .email("vet@email.com")
                 .password("pwd")
-                .vet(vetDTO).build();
+                .vet(vetRequestDTO).build();
 
 
         Role role = Role.builder()
@@ -681,7 +679,7 @@ class ApiGatewayControllerTest {
         Mono<RegisterVet> dto = Mono.just(registerVet);
 
         when(authServiceClient.createVetUser(any(Mono.class)))
-                .thenReturn((Mono.just(vetDTO)));
+                .thenReturn((Mono.just(vetResponseDTO)));
 
 
 
@@ -701,24 +699,23 @@ class ApiGatewayControllerTest {
     @Test
     void updateVet() {
         when(vetsServiceClient.updateVet(anyString(), any(Mono.class)))
-                .thenReturn(Mono.just(vetDTO2));
+                .thenReturn(Mono.just(vetResponseDTO2));
 
         client
                 .put()
                 .uri("/api/gateway/vets/" + VET_ID)
-                .body(Mono.just(vetDTO2), VetDTO.class)
+                .body(Mono.just(vetResponseDTO2), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
-                .jsonPath("$.vetId").isEqualTo(vetDTO2.getVetId())
-                .jsonPath("$.resume").isEqualTo(vetDTO2.getResume())
-                .jsonPath("$.lastName").isEqualTo(vetDTO2.getLastName())
-                .jsonPath("$.firstName").isEqualTo(vetDTO2.getFirstName())
-                .jsonPath("$.email").isEqualTo(vetDTO2.getEmail())
-                .jsonPath("$.image").isNotEmpty()
-                .jsonPath("$.active").isEqualTo(vetDTO2.isActive());
+                .jsonPath("$.vetId").isEqualTo(vetResponseDTO2.getVetId())
+                .jsonPath("$.resume").isEqualTo(vetResponseDTO2.getResume())
+                .jsonPath("$.lastName").isEqualTo(vetResponseDTO2.getLastName())
+                .jsonPath("$.firstName").isEqualTo(vetResponseDTO2.getFirstName())
+                .jsonPath("$.email").isEqualTo(vetResponseDTO2.getEmail())
+                .jsonPath("$.active").isEqualTo(vetResponseDTO2.isActive());
 
         Mockito.verify(vetsServiceClient, times(1))
                 .updateVet(anyString(), any(Mono.class));
@@ -743,7 +740,7 @@ class ApiGatewayControllerTest {
     @Test
     void getByVetId_Invalid() {
         when(vetsServiceClient.getVetByVetId(anyString()))
-                .thenReturn(Mono.just(vetDTO));
+                .thenReturn(Mono.just(vetResponseDTO));
 
         client
                 .get()
@@ -759,12 +756,12 @@ class ApiGatewayControllerTest {
     @Test
     void updateByVetId_Invalid() {
         when(vetsServiceClient.updateVet(anyString(), any(Mono.class)))
-                .thenReturn(Mono.just(vetDTO));
+                .thenReturn(Mono.just(vetResponseDTO));
 
         client
                 .put()
                 .uri("/api/gateway/vets/" + INVALID_VET_ID)
-                .body(Mono.just(vetDTO), VetDTO.class)
+                .body(Mono.just(vetRequestDTO), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(INTERNAL_SERVER_ERROR)
@@ -867,7 +864,8 @@ class ApiGatewayControllerTest {
 
     @Test
     void toStringBuilderVets() {
-        System.out.println(VetDTO.builder());
+        System.out.println(VetResponseDTO.builder());
+        System.out.println(VetRequestDTO.builder());
     }
 
 
@@ -3002,8 +3000,8 @@ void deleteAllInventory_shouldSucceed() {
                 .build();
     }
 
-    private VetDTO buildVetDTO() {
-        return VetDTO.builder()
+    private VetResponseDTO buildVetResponseDTO() {
+        return VetResponseDTO.builder()
                 .vetId("181faeb5-c024-425c-9f08-663600008f06")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
@@ -3011,19 +3009,43 @@ void deleteAllInventory_shouldSucceed() {
                 .phoneNumber("947-238-2847")
                 .resume("Just became a vet")
                 .workday(new HashSet<>())
-                .image("kjd".getBytes())
                 .specialties(new HashSet<>())
                 .active(false)
                 .build();
     }
-    private VetDTO buildVetDTO2() {
-        return VetDTO.builder()
+    private VetResponseDTO buildVetResponseDTO2() {
+        return VetResponseDTO.builder()
                 .vetId("181faeb5-c024-425c-9f08-663600008f06")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-2847")
-                .image("kjd".getBytes())
+                .resume("Just became a vet")
+                .workday(new HashSet<>())
+                .specialties(new HashSet<>())
+                .active(true)
+                .build();
+    }
+    private VetRequestDTO buildVetRequestDTO() {
+        return VetRequestDTO.builder()
+                .vetId("181faeb5-c024-425c-9f08-663600008f06")
+                .firstName("Pauline")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.com")
+                .phoneNumber("947-238-2847")
+                .resume("Just became a vet")
+                .workday(new HashSet<>())
+                .specialties(new HashSet<>())
+                .active(false)
+                .build();
+    }
+    private VetRequestDTO buildVetRequestDTO2() {
+        return VetRequestDTO.builder()
+                .vetId("181faeb5-c024-425c-9f08-663600008f06")
+                .firstName("Pauline")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.com")
+                .phoneNumber("947-238-2847")
                 .resume("Just became a vet")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/RequestContextAdd.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/RequestContextAdd.java
@@ -3,7 +3,7 @@ package com.petclinic.billing.businesslayer;
 import com.petclinic.billing.datalayer.Bill;
 import com.petclinic.billing.datalayer.BillRequestDTO;
 import com.petclinic.billing.datalayer.OwnerResponseDTO;
-import com.petclinic.billing.datalayer.VetDTO;
+import com.petclinic.billing.datalayer.VetResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -15,7 +15,7 @@ public class RequestContextAdd {
 
     private BillRequestDTO billRequestDTO;
     private Bill bill;
-    private VetDTO vetDTO;
+    private VetResponseDTO vetDTO;
     private OwnerResponseDTO ownerResponseDTO;
 
     public RequestContextAdd(BillRequestDTO billRequestDTO) {

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/VetResponseDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/VetResponseDTO.java
@@ -1,38 +1,23 @@
 package com.petclinic.billing.datalayer;
-/**
- @author Kamilah Hatteea & Brandon Levis : Vet-Service
-  * Worked together with (Code with Friends) on IntelliJ IDEA
-  * <p>
-  * User: @Kamilah Hatteea
-  * Date: 2022-09-22
-  * Ticket: feat(VVS-CPC-554): edit veterinarian
-  * User: Brandon Levis
-  * Date: 2022-09-22
-  * Ticket: feat(VVS-CPC-553): add veterinarian
- */
 
 import lombok.*;
 
 import java.util.Set;
-
 
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class VetDTO {
+public class VetResponseDTO {
     private String vetId;
     private String vetBillId;
     private String firstName;
     private String lastName;
     private String email;
     private String phoneNumber;
-    private String imageId;
     private String resume;
     //private Set<Workday> workday;
     private boolean active;
     private Set<SpecialtyDTO> specialties;
-
-
 }

--- a/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
@@ -262,7 +262,7 @@ public class BillServiceImplTest {
 
     private Bill buildUnpaidBill(){
 
-        VetDTO vetDTO = buildVetDTO();
+        VetResponseDTO vetDTO = buildVetDTO();
         Calendar calendar = Calendar.getInstance();
         calendar.set(2022, Calendar.SEPTEMBER, 25);
         LocalDate date = calendar.getTime().toInstant()
@@ -292,7 +292,7 @@ public class BillServiceImplTest {
 
 
 
-        VetDTO vetDTO = buildVetDTO();
+        VetResponseDTO vetDTO = buildVetDTO();
 
         Calendar calendar = Calendar.getInstance();
         calendar.set(2022, Calendar.SEPTEMBER, 25);
@@ -306,8 +306,8 @@ public class BillServiceImplTest {
 
     }
 
-    private VetDTO buildVetDTO() {
-        return VetDTO.builder()
+    private VetResponseDTO buildVetDTO() {
+        return VetResponseDTO.builder()
                 .vetId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
                 .vetBillId("53c2d16e-1ba3-4dbc-8e31-6decd2eaa99a")
                 .firstName("Pauline")
@@ -315,7 +315,6 @@ public class BillServiceImplTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-2847")
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .specialties(new HashSet<>())
                 .active(false)
                 .build();

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -65,7 +65,7 @@ public class VetController {
 
     @DeleteMapping("{vetId}/ratings/{ratingId}")
     public Mono<ResponseEntity<Void>> deleteRatingByRatingId(@PathVariable String vetId,
-                                             @PathVariable String ratingId){
+                                                             @PathVariable String ratingId){
         return ratingService.deleteRatingByRatingId(vetId, ratingId)
                 .then(Mono.just(ResponseEntity.noContent().<Void>build()))
                 .defaultIfEmpty(ResponseEntity.notFound().build());
@@ -110,46 +110,46 @@ public class VetController {
                .defaultIfEmpty(ResponseEntity.notFound().build());
    }*/
 
-   //Vets
+    //Vets
     @GetMapping()
-    public Flux<VetDTO> getAllVets() {
+    public Flux<VetResponseDTO> getAllVets() {
         return vetService.getAll();
     }
 
     @GetMapping("{vetId}")
-    public Mono<ResponseEntity<VetDTO>> getVetByVetId(@PathVariable String vetId) {
+    public Mono<ResponseEntity<VetResponseDTO>> getVetByVetId(@PathVariable String vetId) {
         return vetService.getVetByVetId(EntityDtoUtil.verifyId(vetId))
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/vetBillId/{vetBillId}")
-    public Mono<ResponseEntity<VetDTO>> getVetByBillId(@PathVariable String vetBillId) {
+    public Mono<ResponseEntity<VetResponseDTO>> getVetByBillId(@PathVariable String vetBillId) {
         return vetService.getVetByVetBillId(EntityDtoUtil.verifyId(vetBillId))
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/active")
-    public Flux<VetDTO> getActiveVets() {
+    public Flux<VetResponseDTO> getActiveVets() {
         return vetService.getVetByIsActive(true);
     }
 
     @GetMapping("/inactive")
-    public Flux<VetDTO> getInactiveVets() {
+    public Flux<VetResponseDTO> getInactiveVets() {
         return vetService.getVetByIsActive(false);
     }
 
     @PostMapping
-    public Mono<ResponseEntity<VetDTO>> insertVet(@RequestBody Mono<VetDTO> vetDTOMono) {
-        return vetService.insertVet(vetDTOMono)
+    public Mono<ResponseEntity<VetResponseDTO>> insertVet(@RequestBody Mono<VetRequestDTO> vetRequestDTOMono) {
+        return vetService.insertVet(vetRequestDTOMono)
                 .map(v->ResponseEntity.status(HttpStatus.CREATED).body(v))
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
     @PutMapping("{vetId}")
-    public Mono<ResponseEntity<VetDTO>> updateVetByVetId(@PathVariable String vetId, @RequestBody Mono<VetDTO> vetDTOMono) {
-        return vetService.updateVet(EntityDtoUtil.verifyId(vetId), vetDTOMono)
+    public Mono<ResponseEntity<VetResponseDTO>> updateVetByVetId(@PathVariable String vetId, @RequestBody Mono<VetRequestDTO> vetRequestDTOMono) {
+        return vetService.updateVet(EntityDtoUtil.verifyId(vetId), vetRequestDTOMono)
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetRequestDTO.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetRequestDTO.java
@@ -1,0 +1,27 @@
+package com.petclinic.vet.presentationlayer;
+
+import com.petclinic.vet.dataaccesslayer.Workday;
+import com.petclinic.vet.servicelayer.SpecialtyDTO;
+import lombok.*;
+
+import java.util.Set;
+
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VetRequestDTO {
+    private String vetId;
+    private String vetBillId;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String phoneNumber;
+    private String resume;
+    private Set<Workday> workday;
+    private boolean active;
+    private Set<SpecialtyDTO> specialties;
+
+}

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetResponseDTO.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetResponseDTO.java
@@ -1,39 +1,25 @@
-package com.petclinic.vet.servicelayer;
-/**
- @author Kamilah Hatteea & Brandon Levis : Vet-Service
-  * Worked together with (Code with Friends) on IntelliJ IDEA
-  * <p>
-  * User: @Kamilah Hatteea
-  * Date: 2022-09-22
-  * Ticket: feat(VVS-CPC-554): edit veterinarian
-  * User: Brandon Levis
-  * Date: 2022-09-22
-  * Ticket: feat(VVS-CPC-553): add veterinarian
- */
+package com.petclinic.vet.presentationlayer;
 
 import com.petclinic.vet.dataaccesslayer.Workday;
+import com.petclinic.vet.servicelayer.SpecialtyDTO;
 import lombok.*;
 
 import java.util.Set;
-
 
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class VetDTO {
+public class VetResponseDTO {
     private String vetId;
     private String vetBillId;
     private String firstName;
     private String lastName;
     private String email;
     private String phoneNumber;
-    private String imageId;
     private String resume;
     private Set<Workday> workday;
     private boolean active;
     private Set<SpecialtyDTO> specialties;
-
-
 }

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/VetAverageRatingDTO.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/VetAverageRatingDTO.java
@@ -1,5 +1,7 @@
 package com.petclinic.vet.servicelayer;
 
+import com.petclinic.vet.presentationlayer.VetRequestDTO;
+import com.petclinic.vet.presentationlayer.VetResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,7 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class VetAverageRatingDTO {
 
-    private VetDTO vetDTO;
+    private VetResponseDTO vetDTO;
     private String vetId;
     private double averageRating;
 

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/VetService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/VetService.java
@@ -11,15 +11,17 @@ package com.petclinic.vet.servicelayer;
   * Ticket: feat(VVS-CPC-553): add veterinarian
  */
 
+import com.petclinic.vet.presentationlayer.VetRequestDTO;
+import com.petclinic.vet.presentationlayer.VetResponseDTO;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 public interface VetService {
 
-    Flux<VetDTO> getAll();
-    Mono<VetDTO> insertVet(Mono<VetDTO> VetDTOMono);
-    Mono<VetDTO> updateVet(String vetId, Mono<VetDTO> VetDTOMono);
-    Mono<VetDTO> getVetByVetId(String vetId);
+    Flux<VetResponseDTO> getAll();
+    Mono<VetResponseDTO> insertVet(Mono<VetRequestDTO> vetRequestDto);
+    Mono<VetResponseDTO> updateVet(String vetId, Mono<VetRequestDTO> vetRequestDto);
+    Mono<VetResponseDTO> getVetByVetId(String vetId);
     Mono<Void> deleteVetByVetId(String vetId);
-    Flux<VetDTO> getVetByIsActive(boolean isActive);
-    Mono<VetDTO> getVetByVetBillId(String vetBillId);
+    Flux<VetResponseDTO> getVetByIsActive(boolean isActive);
+    Mono<VetResponseDTO> getVetByVetBillId(String vetBillId);
 }

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/ratings/RatingServiceImpl.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/ratings/RatingServiceImpl.java
@@ -9,8 +9,9 @@ import com.petclinic.vet.exceptions.NotFoundException;
 
 import com.petclinic.vet.exceptions.InvalidInputException;
 
+import com.petclinic.vet.presentationlayer.VetRequestDTO;
+import com.petclinic.vet.presentationlayer.VetResponseDTO;
 import com.petclinic.vet.servicelayer.VetAverageRatingDTO;
-import com.petclinic.vet.servicelayer.VetDTO;
 import com.petclinic.vet.util.EntityDtoUtil;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -105,8 +106,6 @@ public class RatingServiceImpl implements RatingService {
 
     @Override
     public Flux<VetAverageRatingDTO> getTopThreeVetsWithHighestAverageRating() {
-
-
         return ratingRepository.findAll()
                 .groupBy(Rating::getVetId)
                 .flatMap(group -> {
@@ -118,8 +117,8 @@ public class RatingServiceImpl implements RatingService {
                 .take(3)
                 .publishOn(Schedulers.boundedElastic())
                 .flatMap(tuple -> {
-                    Mono<VetDTO> vetMono = vetRepository.findVetByVetId(tuple.getT1())
-                            .map(EntityDtoUtil::toDTO);
+                    Mono<VetResponseDTO> vetMono = vetRepository.findVetByVetId(tuple.getT1())
+                            .map(EntityDtoUtil::vetEntityToResponseDTO);
 
                     return vetMono.map(vetDTO ->
                             new VetAverageRatingDTO(vetDTO, tuple.getT1(), tuple.getT2()));

--- a/vet-service/src/main/java/com/petclinic/vet/util/EntityDtoUtil.java
+++ b/vet-service/src/main/java/com/petclinic/vet/util/EntityDtoUtil.java
@@ -18,6 +18,8 @@ import com.petclinic.vet.dataaccesslayer.ratings.Rating;
 import com.petclinic.vet.dataaccesslayer.Specialty;
 import com.petclinic.vet.dataaccesslayer.*;
 import com.petclinic.vet.exceptions.InvalidInputException;
+import com.petclinic.vet.presentationlayer.VetRequestDTO;
+import com.petclinic.vet.presentationlayer.VetResponseDTO;
 import com.petclinic.vet.servicelayer.*;
 import com.petclinic.vet.servicelayer.badges.BadgeResponseDTO;
 import com.petclinic.vet.servicelayer.education.EducationRequestDTO;
@@ -38,15 +40,14 @@ public class EntityDtoUtil {
     @Generated
     public EntityDtoUtil(){}
 
-    public static VetDTO toDTO(Vet vet) {
-        VetDTO dto = new VetDTO();
+    public static VetResponseDTO vetEntityToResponseDTO(Vet vet) {
+        VetResponseDTO dto = new VetResponseDTO();
         dto.setVetId(vet.getVetId());
         dto.setVetBillId(vet.getVetBillId());
         dto.setFirstName(vet.getFirstName());
         dto.setLastName(vet.getLastName());
         dto.setEmail(vet.getEmail());
         dto.setPhoneNumber(vet.getPhoneNumber());
-        dto.setImageId(vet.getImageId());
         dto.setResume(vet.getResume());
         dto.setWorkday(vet.getWorkday());
         dto.setActive(vet.isActive());
@@ -54,7 +55,7 @@ public class EntityDtoUtil {
         return dto;
     }
 
-    public static Vet toEntity(VetDTO dto) {
+    public static Vet vetRequestDtoToEntity(VetRequestDTO dto) {
         Vet vet = new Vet();
         vet.setVetId(dto.getVetId());
         vet.setVetBillId(dto.getVetBillId());
@@ -62,7 +63,6 @@ public class EntityDtoUtil {
         vet.setLastName(dto.getLastName());
         vet.setEmail(dto.getEmail());
         vet.setPhoneNumber(dto.getPhoneNumber());
-        vet.setImageId(dto.getImageId());
         vet.setResume(dto.getResume());
         vet.setWorkday(dto.getWorkday());
         vet.setActive(dto.isActive());
@@ -135,7 +135,7 @@ public class EntityDtoUtil {
     public static Set<SpecialtyDTO> toDTOSet(Set<Specialty> specialties) {
         Set<SpecialtyDTO> specialtyDTOS = new HashSet<>();
         for (Specialty specialty:
-             specialties) {
+                specialties) {
             SpecialtyDTO specialtyDTO = toDTO(specialty);
             specialtyDTOS.add(specialtyDTO);
         }
@@ -146,7 +146,7 @@ public class EntityDtoUtil {
     public static Set<Specialty>  toEntitySet(Set<SpecialtyDTO> specialtyDTOS){
         Set<Specialty> specialties = new HashSet<>();
         for (SpecialtyDTO specialtyDTO:
-            specialtyDTOS) {
+                specialtyDTOS) {
             Specialty specialty = toEntity(specialtyDTO);
             specialties.add(specialty);
         }

--- a/vet-service/src/main/resources/schema.sql
+++ b/vet-service/src/main/resources/schema.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS images;
 CREATE TABLE IF NOT EXISTS images(
     id SERIAL,
     vet_id varchar(36) unique,
-    filename varchar(255) unique,
+    filename varchar(255),
     img_type varchar(10),
     img_data bytea,
     PRIMARY KEY (id)

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -73,7 +73,9 @@ class VetControllerIntegrationTest {
     Rating rating2 = buildRating("12346", "db0c8f13-89d2-4ef7-bcd5-3776a3734150", 4.0);
     Rating rating3 = buildRating("12347", "db0c8f13-89d2-4ef7-bcd5-3776a3734150", 3.0);
 
-    VetDTO vetDTO = buildVetDTO("3456");
+    VetResponseDTO vetResponseDTO = buildVetResponseDTO("3456");
+    VetRequestDTO vetRequestDTO = buildVetRequestDTO("3456");
+
     String VET_ID = "db0c8f13-89d2-4ef7-bcd5-3776a3734150";
     String VET_BILL_ID = vet.getVetBillId();
     String INVALID_VET_ID = "mjbedf";
@@ -579,7 +581,7 @@ class VetControllerIntegrationTest {
 
     @Test
     void getAverageRatingByVetId_ShouldSucceed() {
-        
+
         RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
                 .vetId(vet.getVetId())
                 .rateScore(rating1.getRateScore()).build();
@@ -711,7 +713,6 @@ class VetControllerIntegrationTest {
                 .jsonPath("$[0].lastName").isEqualTo(vet.getLastName())
                 .jsonPath("$[0].firstName").isEqualTo(vet.getFirstName())
                 .jsonPath("$[0].email").isEqualTo(vet.getEmail())
-                .jsonPath("$[0].imageId").isNotEmpty()
                 .jsonPath("$[0].active").isEqualTo(vet.isActive());
     }
 
@@ -781,19 +782,18 @@ class VetControllerIntegrationTest {
         client
                 .put()
                 .uri("/vets/" + VET_ID)
-                .body(Mono.just(vetDTO), VetDTO.class)
+                .body(Mono.just(vetRequestDTO), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
-                .jsonPath("$.vetId").isEqualTo(vetDTO.getVetId())
-                .jsonPath("$.resume").isEqualTo(vetDTO.getResume())
-                .jsonPath("$.lastName").isEqualTo(vetDTO.getLastName())
-                .jsonPath("$.firstName").isEqualTo(vetDTO.getFirstName())
-                .jsonPath("$.email").isEqualTo(vetDTO.getEmail())
-                .jsonPath("$.imageId").isNotEmpty()
-                .jsonPath("$.active").isEqualTo(vetDTO.isActive());
+                .jsonPath("$.vetId").isEqualTo(vetRequestDTO.getVetId())
+                .jsonPath("$.resume").isEqualTo(vetRequestDTO.getResume())
+                .jsonPath("$.lastName").isEqualTo(vetRequestDTO.getLastName())
+                .jsonPath("$.firstName").isEqualTo(vetRequestDTO.getFirstName())
+                .jsonPath("$.email").isEqualTo(vetRequestDTO.getEmail())
+                .jsonPath("$.active").isEqualTo(vetRequestDTO.isActive());
 
     }
 
@@ -806,7 +806,7 @@ class VetControllerIntegrationTest {
                 .expectNextCount(1)
                 .verifyComplete();
 
-        VetDTO updatedVet=VetDTO.builder()
+        VetRequestDTO updatedVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementineeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
@@ -814,16 +814,14 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-28479")
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
-                .specialties(new HashSet<>())
                 .active(false)
                 .build();
 
         client
                 .put()
                 .uri("/vets/" + VET_ID)
-                .body(Mono.just(updatedVet), VetDTO.class)
+                .body(Mono.just(updatedVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -841,7 +839,7 @@ class VetControllerIntegrationTest {
                 .expectNextCount(1)
                 .verifyComplete();
 
-        VetDTO updatedVet=VetDTO.builder()
+        VetRequestDTO updatedVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
@@ -849,16 +847,14 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-28479")
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
-                .specialties(new HashSet<>())
                 .active(false)
                 .build();
 
         client
                 .put()
                 .uri("/vets/" + VET_ID)
-                .body(Mono.just(updatedVet), VetDTO.class)
+                .body(Mono.just(updatedVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -876,7 +872,7 @@ class VetControllerIntegrationTest {
                 .expectNextCount(1)
                 .verifyComplete();
 
-        VetDTO updatedVet=VetDTO.builder()
+        VetRequestDTO updatedVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
@@ -884,7 +880,6 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-28479999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999")
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
@@ -893,7 +888,7 @@ class VetControllerIntegrationTest {
         client
                 .put()
                 .uri("/vets/" + VET_ID)
-                .body(Mono.just(updatedVet), VetDTO.class)
+                .body(Mono.just(updatedVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -912,7 +907,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         String extensionNum="7654";
-        VetDTO updatedVet=VetDTO.builder()
+        VetRequestDTO updatedVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
@@ -927,7 +922,6 @@ class VetControllerIntegrationTest {
                         "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm")
                 .phoneNumber("(514)-634-8276 #"+extensionNum)
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
@@ -936,7 +930,7 @@ class VetControllerIntegrationTest {
         client
                 .put()
                 .uri("/vets/" + VET_ID)
-                .body(Mono.just(updatedVet), VetDTO.class)
+                .body(Mono.just(updatedVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -955,7 +949,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         String extensionNum="7920";
-        VetDTO updatedVet=VetDTO.builder()
+        VetRequestDTO updatedVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
@@ -963,7 +957,6 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("(514)-634-8276 #"+extensionNum)
                 .resume("Jo")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
@@ -972,7 +965,7 @@ class VetControllerIntegrationTest {
         client
                 .put()
                 .uri("/vets/" + VET_ID)
-                .body(Mono.just(updatedVet), VetDTO.class)
+                .body(Mono.just(updatedVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -991,7 +984,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         String extensionNum="7920";
-        VetDTO updatedVet=VetDTO.builder()
+        VetRequestDTO updatedVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
@@ -999,7 +992,6 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("(514)-634-8276 #"+extensionNum)
                 .resume("I've been a vet ever since I was a kid.")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(null)
                 .active(false)
@@ -1008,7 +1000,7 @@ class VetControllerIntegrationTest {
         client
                 .put()
                 .uri("/vets/" + VET_ID)
-                .body(Mono.just(updatedVet), VetDTO.class)
+                .body(Mono.just(updatedVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -1039,7 +1031,6 @@ class VetControllerIntegrationTest {
                 .jsonPath("$[0].lastName").isEqualTo(vet2.getLastName())
                 .jsonPath("$[0].firstName").isEqualTo(vet2.getFirstName())
                 .jsonPath("$[0].email").isEqualTo(vet2.getEmail())
-                .jsonPath("$[0].imageId").isNotEmpty()
                 .jsonPath("$[0].active").isEqualTo(vet2.isActive());
     }
 
@@ -1065,7 +1056,6 @@ class VetControllerIntegrationTest {
                 .jsonPath("$[0].lastName").isEqualTo(vet.getLastName())
                 .jsonPath("$[0].firstName").isEqualTo(vet.getFirstName())
                 .jsonPath("$[0].email").isEqualTo(vet.getEmail())
-                .jsonPath("$[0].imageId").isNotEmpty()
                 .jsonPath("$[0].active").isEqualTo(vet.isActive());
     }
 
@@ -1082,22 +1072,21 @@ class VetControllerIntegrationTest {
         client
                 .post()
                 .uri("/vets")
-                .body(Mono.just(vet), Vet.class)
+                .body(Mono.just(vetRequestDTO), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBody(VetDTO.class)
+                .expectBody(VetResponseDTO.class)
                 .value((dto) -> {
-                    assertThat(dto.getFirstName()).isEqualTo(vet.getFirstName());
-                    assertThat(dto.getLastName()).isEqualTo(vet.getLastName());
-                    assertThat(dto.getPhoneNumber()).isEqualTo(vet.getPhoneNumber());
-                    assertThat(dto.getResume()).isEqualTo(vet.getResume());
-                    assertThat(dto.getEmail()).isEqualTo(vet.getEmail());
-                    assertThat(dto.getWorkday()).isEqualTo(vet.getWorkday());
-                    assertThat(dto.getImageId()).isEqualTo(vet.getImageId());
-                    assertThat(dto.isActive()).isEqualTo(vet.isActive());
-                    assertThat(dto.getSpecialties()).isEqualTo(vet.getSpecialties());
+                    assertThat(dto.getFirstName()).isEqualTo(vetResponseDTO.getFirstName());
+                    assertThat(dto.getLastName()).isEqualTo(vetResponseDTO.getLastName());
+                    assertThat(dto.getPhoneNumber()).isEqualTo(vetResponseDTO.getPhoneNumber());
+                    assertThat(dto.getResume()).isEqualTo(vetResponseDTO.getResume());
+                    assertThat(dto.getEmail()).isEqualTo(vetResponseDTO.getEmail());
+                    assertThat(dto.getWorkday()).isEqualTo(vetResponseDTO.getWorkday());
+                    assertThat(dto.isActive()).isEqualTo(vetResponseDTO.isActive());
+                    assertThat(dto.getSpecialties()).isEqualTo(vetResponseDTO.getSpecialties());
                 });
     }
 
@@ -1110,7 +1099,7 @@ class VetControllerIntegrationTest {
                 .expectNextCount(0)
                 .verifyComplete();
 
-        VetDTO newVet=VetDTO.builder()
+        VetRequestDTO newVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
@@ -1118,7 +1107,6 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-28479999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999")
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
@@ -1127,7 +1115,7 @@ class VetControllerIntegrationTest {
         client
                 .post()
                 .uri("/vets")
-                .body(Mono.just(newVet), Vet.class)
+                .body(Mono.just(newVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -1146,7 +1134,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         String extensionNum="4527";
-        VetDTO newVet=VetDTO.builder()
+        VetRequestDTO newVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
@@ -1161,7 +1149,6 @@ class VetControllerIntegrationTest {
                         "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm")
                 .phoneNumber("(514)-634-8276 #"+extensionNum)
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
@@ -1170,7 +1157,7 @@ class VetControllerIntegrationTest {
         client
                 .post()
                 .uri("/vets")
-                .body(Mono.just(newVet), Vet.class)
+                .body(Mono.just(newVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -1189,7 +1176,7 @@ class VetControllerIntegrationTest {
                 .expectNextCount(0)
                 .verifyComplete();
 
-        VetDTO newVet=VetDTO.builder()
+        VetRequestDTO newVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementineeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
@@ -1197,7 +1184,6 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-28479")
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
@@ -1206,7 +1192,7 @@ class VetControllerIntegrationTest {
         client
                 .post()
                 .uri("/vets")
-                .body(Mono.just(newVet), Vet.class)
+                .body(Mono.just(newVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -1225,7 +1211,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         String extensionNum="0987";
-        VetDTO newVet=VetDTO.builder()
+        VetRequestDTO newVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
@@ -1233,7 +1219,6 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("(514)-634-8276 #"+extensionNum)
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
@@ -1242,7 +1227,7 @@ class VetControllerIntegrationTest {
         client
                 .post()
                 .uri("/vets")
-                .body(Mono.just(newVet), Vet.class)
+                .body(Mono.just(newVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -1261,7 +1246,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         String extensionNum="4527";
-        VetDTO newVet=VetDTO.builder()
+        VetRequestDTO newVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
@@ -1269,7 +1254,6 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("(514)-634-8276 #"+extensionNum)
                 .resume("Jo")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
@@ -1278,7 +1262,7 @@ class VetControllerIntegrationTest {
         client
                 .post()
                 .uri("/vets")
-                .body(Mono.just(newVet), Vet.class)
+                .body(Mono.just(newVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -1298,7 +1282,7 @@ class VetControllerIntegrationTest {
                 .verifyComplete();
 
         String extensionNum="4527";
-        VetDTO newVet=VetDTO.builder()
+        VetRequestDTO newVet = VetRequestDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("1")
                 .firstName("Clementine")
@@ -1306,7 +1290,6 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("(514)-634-8276 #"+extensionNum)
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(null)
                 .active(false)
@@ -1315,7 +1298,7 @@ class VetControllerIntegrationTest {
         client
                 .post()
                 .uri("/vets")
-                .body(Mono.just(newVet), Vet.class)
+                .body(Mono.just(newVet), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -1534,7 +1517,8 @@ class VetControllerIntegrationTest {
     @Test
     void toStringBuilders() {
         System.out.println(Vet.builder());
-        System.out.println(VetDTO.builder());
+        System.out.println(VetResponseDTO.builder());
+        System.out.println(VetRequestDTO.builder());
     }
 
 
@@ -1571,7 +1555,7 @@ class VetControllerIntegrationTest {
         client
                 .put()
                 .uri("/vets/" + INVALID_VET_ID)
-                .body(Mono.just(vetDTO), VetDTO.class)
+                .body(Mono.just(vetRequestDTO), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
@@ -1613,7 +1597,6 @@ class VetControllerIntegrationTest {
                 .phoneNumber("(514)-634-8276 #"+extensionNum)
                 .resume("Just became a vet")
                 .workday(new HashSet<>())
-                .imageId("kjd")
                 .specialties(new HashSet<>())
                 .active(false)
                 .build();
@@ -1629,10 +1612,9 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("(514)-634-8276 #"+extensionNum)
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
-                .active(true)
                 .specialties(new HashSet<>())
+                .active(true)
                 .build();
     }
 
@@ -1669,8 +1651,8 @@ class VetControllerIntegrationTest {
     }
 
     //the extension number can only be 4 digits
-    private VetDTO buildVetDTO(String extensionNum) {
-        return VetDTO.builder()
+    private VetResponseDTO buildVetResponseDTO(String extensionNum) {
+        return VetResponseDTO.builder()
                 .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
                 .vetBillId("ac90fcca-a79c-411d-93f2-b70a80da0c3a")
                 .firstName("Clementine")
@@ -1678,7 +1660,20 @@ class VetControllerIntegrationTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("(514)-634-8276 #"+extensionNum)
                 .resume("Just became a vet")
-                .imageId("kjd")
+                .workday(new HashSet<>())
+                .specialties(new HashSet<>())
+                .active(false)
+                .build();
+    }
+    private VetRequestDTO buildVetRequestDTO(String extensionNum) {
+        return VetRequestDTO.builder()
+                .vetId("db0c8f13-89d2-4ef7-bcd5-3776a3734150")
+                .vetBillId("ac90fcca-a79c-411d-93f2-b70a80da0c3a")
+                .firstName("Clementine")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.com")
+                .phoneNumber("(514)-634-8276 #"+extensionNum)
+                .resume("Just became a vet")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -61,19 +61,17 @@ class VetControllerUnitTest {
     @MockBean
     ConnectionFactoryInitializer connectionFactoryInitializer;
 
-    VetDTO vetDTO = buildVetDTO();
-    VetDTO vetDTO2 = buildVetDTO2();
+    VetRequestDTO vetRequestDTO = buildVetRequestDTO();
+    VetResponseDTO vetResponseDTO = buildVetResponseDTO();
+    VetResponseDTO vetResponseDTO2 = buildVetResponseDTO2();
 
-    VetDTO vetDTO3=buildVetDTO3();
 
     VetAverageRatingDTO averageRatingDTO=buildVetAverageRatingDTO1();
     VetAverageRatingDTO averageRatingDTO2=buildVetAverageRatingDTO2();
     VetAverageRatingDTO averageRatingDTO3=buildVetAverageRatingDTO3();
 
 
-
     EducationResponseDTO educationResponseDTO1 = buildEducation();
-    EducationResponseDTO educationResponseDTO2 = buildEducation2();
 
     Photo photo = buildPhoto();
 
@@ -129,11 +127,11 @@ class VetControllerUnitTest {
     @Test
     void addRatingWithVetId_ValidValues_ShouldSucceed() {
         RatingRequestDTO ratingRequestDTO = RatingRequestDTO.builder()
-                        .vetId(VET_ID)
-                        .rateScore(3.5)
-                        .rateDescription("The vet was decent but lacked table manners.")
-                        .rateDate("16/09/2023")
-                        .build();
+                .vetId(VET_ID)
+                .rateScore(3.5)
+                .rateDescription("The vet was decent but lacked table manners.")
+                .rateDate("16/09/2023")
+                .build();
         RatingResponseDTO rating = buildRatingResponseDTO(ratingRequestDTO.getRateDescription(), ratingRequestDTO.getRateScore());
 
         when(ratingService.addRatingToVet(anyString(), any(Mono.class)))
@@ -216,12 +214,11 @@ class VetControllerUnitTest {
 
     @Test
     void getAverageRatingForEachVetByVetId_ShouldSucceed(){
-
         String vetId = "cf25e779-548b-4788-aefa-6d58621c2feb";
         Double averageRating = 5.0;
 
         when(vetService.getVetByVetId(vetId))
-                .thenReturn(Mono.just(vetDTO));
+                .thenReturn(Mono.just(vetResponseDTO));
 
         when(ratingService.getAverageRatingByVetId(vetId))
                 .thenReturn(Mono.just(ratingDTO.getRateScore()));
@@ -240,17 +237,13 @@ class VetControllerUnitTest {
 
         Mockito.verify(ratingService, times(1))
                 .getAverageRatingByVetId(ratingDTO.getVetId());
-
     }
 
 
     @Test
     void getTopThreeVetsWithTheHighestRating() {
-
-
         when(ratingService.getTopThreeVetsWithHighestAverageRating())
                 .thenReturn(Flux.just(averageRatingDTO, averageRatingDTO2, averageRatingDTO3));
-
 
         client.get()
                 .uri("/vets/topVets")
@@ -292,7 +285,7 @@ class VetControllerUnitTest {
     @Test
     void getAllVets() {
         when(vetService.getAll())
-                .thenReturn(Flux.just(vetDTO));
+                .thenReturn(Flux.just(vetResponseDTO));
 
         client
                 .get()
@@ -302,13 +295,12 @@ class VetControllerUnitTest {
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
-                .jsonPath("$[0].vetId").isEqualTo(vetDTO.getVetId())
-                .jsonPath("$[0].resume").isEqualTo(vetDTO.getResume())
-                .jsonPath("$[0].lastName").isEqualTo(vetDTO.getLastName())
-                .jsonPath("$[0].firstName").isEqualTo(vetDTO.getFirstName())
-                .jsonPath("$[0].email").isEqualTo(vetDTO.getEmail())
-                .jsonPath("$[0].imageId").isNotEmpty()
-                .jsonPath("$[0].active").isEqualTo(vetDTO.isActive());
+                .jsonPath("$[0].vetId").isEqualTo(vetResponseDTO.getVetId())
+                .jsonPath("$[0].resume").isEqualTo(vetResponseDTO.getResume())
+                .jsonPath("$[0].lastName").isEqualTo(vetResponseDTO.getLastName())
+                .jsonPath("$[0].firstName").isEqualTo(vetResponseDTO.getFirstName())
+                .jsonPath("$[0].email").isEqualTo(vetResponseDTO.getEmail())
+                .jsonPath("$[0].active").isEqualTo(vetResponseDTO.isActive());
 
         Mockito.verify(vetService, times(1))
                 .getAll();
@@ -317,7 +309,7 @@ class VetControllerUnitTest {
     @Test
     void getVetByVetId() {
         when(vetService.getVetByVetId(anyString()))
-                .thenReturn(Mono.just(vetDTO));
+                .thenReturn(Mono.just(vetResponseDTO));
 
         client
                 .get()
@@ -333,7 +325,6 @@ class VetControllerUnitTest {
                 .jsonPath("$.lastName").isEqualTo(vet.getLastName())
                 .jsonPath("$.firstName").isEqualTo(vet.getFirstName())
                 .jsonPath("$.email").isEqualTo(vet.getEmail())
-                .jsonPath("$.imageId").isNotEmpty()
                 .jsonPath("$.active").isEqualTo(vet.isActive());
 
         Mockito.verify(vetService, times(1))
@@ -343,7 +334,7 @@ class VetControllerUnitTest {
     @Test
     void getVetByVetBillId() {
         when(vetService.getVetByVetBillId(anyString()))
-                .thenReturn(Mono.just(vetDTO));
+                .thenReturn(Mono.just(vetResponseDTO));
 
         client
                 .get()
@@ -368,7 +359,7 @@ class VetControllerUnitTest {
     @Test
     void getActiveVets() {
         when(vetService.getVetByIsActive(anyBoolean()))
-                .thenReturn(Flux.just(vetDTO2));
+                .thenReturn(Flux.just(vetResponseDTO2));
 
         client
                 .get()
@@ -378,33 +369,41 @@ class VetControllerUnitTest {
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
-                .jsonPath("$[0].vetId").isEqualTo(vetDTO2.getVetId())
-                .jsonPath("$[0].resume").isEqualTo(vetDTO2.getResume())
-                .jsonPath("$[0].lastName").isEqualTo(vetDTO2.getLastName())
-                .jsonPath("$[0].firstName").isEqualTo(vetDTO2.getFirstName())
-                .jsonPath("$[0].email").isEqualTo(vetDTO2.getEmail())
-                .jsonPath("$[0].imageId").isNotEmpty()
-                .jsonPath("$[0].active").isEqualTo(vetDTO2.isActive());
+                .jsonPath("$[0].vetId").isEqualTo(vetResponseDTO2.getVetId())
+                .jsonPath("$[0].resume").isEqualTo(vetResponseDTO2.getResume())
+                .jsonPath("$[0].lastName").isEqualTo(vetResponseDTO2.getLastName())
+                .jsonPath("$[0].firstName").isEqualTo(vetResponseDTO2.getFirstName())
+                .jsonPath("$[0].email").isEqualTo(vetResponseDTO2.getEmail())
+                .jsonPath("$[0].active").isEqualTo(vetResponseDTO2.isActive());
 
         Mockito.verify(vetService, times(1))
-                .getVetByIsActive(vetDTO2.isActive());
+                .getVetByIsActive(vetResponseDTO2.isActive());
     }
 
     @Test
     void createVet() {
-        Mono<VetDTO> dto = Mono.just(vetDTO);
         when(vetService.insertVet(any(Mono.class)))
-                .thenReturn(dto);
+                .thenReturn(Mono.just(vetResponseDTO));
 
         client
                 .post()
                 .uri("/vets")
-                .body(dto, Vet.class)
+                .body(Mono.just(vetRequestDTO), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBody();
+                .expectBody(VetResponseDTO.class)
+                .value((dto) -> {
+                    assertThat(dto.getFirstName()).isEqualTo(vetResponseDTO.getFirstName());
+                    assertThat(dto.getLastName()).isEqualTo(vetResponseDTO.getLastName());
+                    assertThat(dto.getPhoneNumber()).isEqualTo(vetResponseDTO.getPhoneNumber());
+                    assertThat(dto.getResume()).isEqualTo(vetResponseDTO.getResume());
+                    assertThat(dto.getEmail()).isEqualTo(vetResponseDTO.getEmail());
+                    assertThat(dto.getWorkday()).isEqualTo(vetResponseDTO.getWorkday());
+                    assertThat(dto.isActive()).isEqualTo(vetResponseDTO.isActive());
+                    assertThat(dto.getSpecialties()).isEqualTo(vetResponseDTO.getSpecialties());
+                });
 
         Mockito.verify(vetService, times(1))
                 .insertVet(any(Mono.class));
@@ -413,24 +412,23 @@ class VetControllerUnitTest {
     @Test
     void updateVet() {
         when(vetService.updateVet(anyString(), any(Mono.class)))
-                .thenReturn(Mono.just(vetDTO));
+                .thenReturn(Mono.just(vetResponseDTO));
 
         client
                 .put()
                 .uri("/vets/" + VET_ID)
-                .body(Mono.just(vetDTO), VetDTO.class)
+                .body(Mono.just(vetRequestDTO), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
-                .jsonPath("$.vetId").isEqualTo(vetDTO.getVetId())
-                .jsonPath("$.resume").isEqualTo(vetDTO.getResume())
-                .jsonPath("$.lastName").isEqualTo(vetDTO.getLastName())
-                .jsonPath("$.firstName").isEqualTo(vetDTO.getFirstName())
-                .jsonPath("$.email").isEqualTo(vetDTO.getEmail())
-                .jsonPath("$.imageId").isNotEmpty()
-                .jsonPath("$.active").isEqualTo(vetDTO.isActive());
+                .jsonPath("$.vetId").isEqualTo(vetResponseDTO.getVetId())
+                .jsonPath("$.resume").isEqualTo(vetResponseDTO.getResume())
+                .jsonPath("$.lastName").isEqualTo(vetResponseDTO.getLastName())
+                .jsonPath("$.firstName").isEqualTo(vetResponseDTO.getFirstName())
+                .jsonPath("$.email").isEqualTo(vetResponseDTO.getEmail())
+                .jsonPath("$.active").isEqualTo(vetResponseDTO.isActive());
 
         Mockito.verify(vetService, times(1))
                 .updateVet(anyString(), any(Mono.class));
@@ -439,7 +437,7 @@ class VetControllerUnitTest {
     @Test
     void getInactiveVets() {
         when(vetService.getVetByIsActive(anyBoolean()))
-                .thenReturn(Flux.just(vetDTO));
+                .thenReturn(Flux.just(vetResponseDTO));
 
         client
                 .get()
@@ -449,16 +447,15 @@ class VetControllerUnitTest {
                 .expectStatus().isOk()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody()
-                .jsonPath("$[0].vetId").isEqualTo(vetDTO.getVetId())
-                .jsonPath("$[0].resume").isEqualTo(vetDTO.getResume())
-                .jsonPath("$[0].lastName").isEqualTo(vetDTO.getLastName())
-                .jsonPath("$[0].firstName").isEqualTo(vetDTO.getFirstName())
-                .jsonPath("$[0].email").isEqualTo(vetDTO.getEmail())
-                .jsonPath("$[0].imageId").isNotEmpty()
-                .jsonPath("$[0].active").isEqualTo(vetDTO.isActive());
+                .jsonPath("$[0].vetId").isEqualTo(vetResponseDTO.getVetId())
+                .jsonPath("$[0].resume").isEqualTo(vetResponseDTO.getResume())
+                .jsonPath("$[0].lastName").isEqualTo(vetResponseDTO.getLastName())
+                .jsonPath("$[0].firstName").isEqualTo(vetResponseDTO.getFirstName())
+                .jsonPath("$[0].email").isEqualTo(vetResponseDTO.getEmail())
+                .jsonPath("$[0].active").isEqualTo(vetResponseDTO.isActive());
 
         Mockito.verify(vetService, times(1))
-                .getVetByIsActive(vetDTO.isActive());
+                .getVetByIsActive(vetResponseDTO.isActive());
     }
 
     @Test
@@ -480,7 +477,7 @@ class VetControllerUnitTest {
     @Test
     void getByVetId_Invalid() {
         when(vetService.getVetByVetId(anyString()))
-                .thenReturn(Mono.just(vetDTO));
+                .thenReturn(Mono.just(vetResponseDTO));
 
         client
                 .get()
@@ -496,12 +493,12 @@ class VetControllerUnitTest {
     @Test
     void updateByVetId_Invalid() {
         when(vetService.updateVet(anyString(), any(Mono.class)))
-                .thenReturn(Mono.just(vetDTO));
+                .thenReturn(Mono.just(vetResponseDTO));
 
         client
                 .put()
                 .uri("/vets/" + INVALID_VET_ID)
-                .body(Mono.just(vetDTO), VetDTO.class)
+                .body(Mono.just(vetRequestDTO), VetRequestDTO.class)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -740,15 +737,14 @@ class VetControllerUnitTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-2847")
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
                 .build();
     }
 
-    private VetDTO buildVetDTO() {
-        return VetDTO.builder()
+    private VetRequestDTO buildVetRequestDTO() {
+        return VetRequestDTO.builder()
                 .vetId("cf25e779-548b-4788-aefa-6d58621c2feb")
                 .vetBillId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
                 .firstName("Pauline")
@@ -757,37 +753,33 @@ class VetControllerUnitTest {
                 .phoneNumber("947-238-2847")
                 .resume("Just became a vet")
                 .workday(new HashSet<>())
-                .imageId("kjd")
                 .specialties(new HashSet<>())
                 .active(false)
                 .build();
     }
-    private VetDTO buildVetDTO2() {
-        return VetDTO.builder()
+    private VetResponseDTO buildVetResponseDTO() {
+        return VetResponseDTO.builder()
                 .vetId("cf25e779-548b-4788-aefa-6d58621c2feb")
-                .vetBillId("2")
+                .vetBillId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
                 .firstName("Pauline")
                 .lastName("LeBlanc")
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-2847")
-                .imageId("kjd")
                 .resume("Just became a vet")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
-                .active(true)
+                .active(false)
                 .build();
     }
-
-    private VetDTO buildVetDTO3() {
-        return VetDTO.builder()
-                .vetId("678910Hi")
-                .vetBillId("3")
-                .firstName("Olivia")
-                .lastName("Shaun")
-                .email("asdhbw@gmail.com")
-                .phoneNumber("543-201-2547")
-                .imageId("kjd")
-                .resume("Still a vet")
+    private VetResponseDTO buildVetResponseDTO2() {
+        return VetResponseDTO.builder()
+                .vetId("cf25e779-548b-4788-aefa-6d58621c2feb")
+                .vetBillId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
+                .firstName("Pauline")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.com")
+                .phoneNumber("947-238-2847")
+                .resume("Just became a vet")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(true)
@@ -803,18 +795,6 @@ class VetControllerUnitTest {
                 .schoolName("University of Montreal")
                 .startDate("2010")
                 .endDate("2014")
-                .build();
-    }
-
-    private EducationResponseDTO buildEducation2(){
-        return  EducationResponseDTO.builder()
-                .educationId("2")
-                .vetId(VET_ID)
-                .degree("Doctor of Veterinary Medicine")
-                .fieldOfStudy("Veterinary Medicine")
-                .schoolName("University of Veterinary Sciences")
-                .startDate("2008")
-                .endDate("2013")
                 .build();
     }
 

--- a/vet-service/src/test/java/com/petclinic/vet/servicelayer/VetServiceImplTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/servicelayer/VetServiceImplTest.java
@@ -3,6 +3,8 @@ package com.petclinic.vet.servicelayer;
 import com.petclinic.vet.dataaccesslayer.PhotoRepository;
 import com.petclinic.vet.dataaccesslayer.Vet;
 import com.petclinic.vet.dataaccesslayer.VetRepository;
+import com.petclinic.vet.presentationlayer.VetRequestDTO;
+import com.petclinic.vet.presentationlayer.VetResponseDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.r2dbc.init.R2dbcScriptDatabaseInitializer;
@@ -37,17 +39,17 @@ class VetServiceImplTest {
     @MockBean
     R2dbcScriptDatabaseInitializer r2dbcScriptDatabaseInitializer;
 
-    VetDTO vetDTO = buildVetDTO();
+    VetResponseDTO vetResponseDTO = buildVetResponseDTO();
+    VetRequestDTO vetRequestDTO = buildVetRequestDTO();
     Vet vet = buildVet();
     String VET_ID = vet.getVetId();
     String VET_BILL_ID = vet.getVetBillId();
 
     @Test
     void getAllVets() {
-
         when(vetRepository.findAll()).thenReturn(Flux.just(vet));
 
-        Flux<VetDTO> vetDTO = vetService.getAll();
+        Flux<VetResponseDTO> vetDTO = vetService.getAll();
 
         StepVerifier
                 .create(vetDTO)
@@ -62,23 +64,21 @@ class VetServiceImplTest {
                     assertEquals(vet.getWorkday(), foundVet.getWorkday());
                     assertFalse(foundVet.isActive());
                 })
-
                 .verifyComplete();
     }
 
     @Test
     void createVet() {
-        vetService.insertVet(Mono.just(vetDTO))
+        vetService.insertVet(Mono.just(vetRequestDTO))
                 .map(vetDTO1 -> {
-                    assertEquals(vetDTO1.getVetId(), vetDTO.getVetId());
-                    assertEquals(vetDTO1.getEmail(), vetDTO.getEmail());
-                    assertEquals(vetDTO1.getResume(), vetDTO.getResume());
-                    assertNotNull(vetDTO1.getImageId());
-                    assertEquals(vetDTO1.getLastName(), vetDTO.getLastName());
-                    assertEquals(vetDTO1.getFirstName(), vetDTO.getFirstName());
-                    assertEquals(vetDTO1.getWorkday(), vetDTO.getWorkday());
-                    assertEquals(vetDTO1.getPhoneNumber(), vetDTO.getPhoneNumber());
-                    assertEquals(vetDTO1.getSpecialties(), vetDTO.getSpecialties());
+                    assertEquals(vetDTO1.getVetId(), vetRequestDTO.getVetId());
+                    assertEquals(vetDTO1.getEmail(), vetRequestDTO.getEmail());
+                    assertEquals(vetDTO1.getResume(), vetRequestDTO.getResume());
+                    assertEquals(vetDTO1.getLastName(), vetRequestDTO.getLastName());
+                    assertEquals(vetDTO1.getFirstName(), vetRequestDTO.getFirstName());
+                    assertEquals(vetDTO1.getWorkday(), vetRequestDTO.getWorkday());
+                    assertEquals(vetDTO1.getPhoneNumber(), vetRequestDTO.getPhoneNumber());
+                    assertEquals(vetDTO1.getSpecialties(), vetRequestDTO.getSpecialties());
                     return vetDTO1;
                 });
     }
@@ -89,28 +89,26 @@ class VetServiceImplTest {
         when(vetRepository.save(any(Vet.class))).thenReturn(Mono.just(vet));
 
         when(vetRepository.findVetByVetId(anyString())).thenReturn(Mono.just(vet));
-        vetService.updateVet(VET_ID, (Mono.just(vetDTO)))
+        vetService.updateVet(VET_ID, (Mono.just(vetRequestDTO)))
                 .map(vetDTO1 -> {
-                    assertEquals(vetDTO1.getVetId(), vetDTO.getVetId());
-                    assertEquals(vetDTO1.getEmail(), vetDTO.getEmail());
-                    assertEquals(vetDTO1.getResume(), vetDTO.getResume());
-                    assertNotNull(vetDTO1.getImageId());
-                    assertEquals(vetDTO1.getLastName(), vetDTO.getLastName());
-                    assertEquals(vetDTO1.getFirstName(), vetDTO.getFirstName());
-                    assertEquals(vetDTO1.getWorkday(), vetDTO.getWorkday());
-                    assertEquals(vetDTO1.getPhoneNumber(), vetDTO.getPhoneNumber());
-                    assertEquals(vetDTO1.getSpecialties(), vetDTO.getSpecialties());
+                    assertEquals(vetDTO1.getVetId(), vetRequestDTO.getVetId());
+                    assertEquals(vetDTO1.getEmail(), vetRequestDTO.getEmail());
+                    assertEquals(vetDTO1.getResume(), vetRequestDTO.getResume());
+                    assertEquals(vetDTO1.getLastName(), vetRequestDTO.getLastName());
+                    assertEquals(vetDTO1.getFirstName(), vetRequestDTO.getFirstName());
+                    assertEquals(vetDTO1.getWorkday(), vetRequestDTO.getWorkday());
+                    assertEquals(vetDTO1.getPhoneNumber(), vetRequestDTO.getPhoneNumber());
+                    assertEquals(vetDTO1.getSpecialties(), vetRequestDTO.getSpecialties());
                     return vetDTO1;
                 });
     }
-
 
     @Test
     void getVetByVetId() {
 
         when(vetRepository.findVetByVetId(anyString())).thenReturn(Mono.just(vet));
 
-        Mono<VetDTO> vetDTOMono = vetService.getVetByVetId(VET_ID);
+        Mono<VetResponseDTO> vetDTOMono = vetService.getVetByVetId(VET_ID);
 
 
         StepVerifier
@@ -135,7 +133,7 @@ class VetServiceImplTest {
 
         when(vetRepository.findVetByVetBillId(anyString())).thenReturn(Mono.just(vet));
 
-        Mono<VetDTO> vetDTOMono = vetService.getVetByVetBillId(VET_BILL_ID);
+        Mono<VetResponseDTO> vetDTOMono = vetService.getVetByVetBillId(VET_BILL_ID);
 
 
         StepVerifier
@@ -160,7 +158,7 @@ class VetServiceImplTest {
 
         when(vetRepository.findVetsByActive(anyBoolean())).thenReturn(Flux.just(vet));
 
-        Flux<VetDTO> vetDTO = vetService.getVetByIsActive(vet.isActive());
+        Flux<VetResponseDTO> vetDTO = vetService.getVetByIsActive(vet.isActive());
 
         StepVerifier
                 .create(vetDTO)
@@ -184,7 +182,7 @@ class VetServiceImplTest {
 
         when(vetRepository.findVetsByActive(anyBoolean())).thenReturn(Flux.just(vet));
 
-        Flux<VetDTO> vetDTO = vetService.getVetByIsActive(vet.isActive());
+        Flux<VetResponseDTO> vetDTO = vetService.getVetByIsActive(vet.isActive());
 
         StepVerifier
                 .create(vetDTO)
@@ -225,14 +223,13 @@ class VetServiceImplTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-2847")
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
                 .build();
     }
-    private VetDTO buildVetDTO() {
-        return VetDTO.builder()
+    private VetRequestDTO buildVetRequestDTO() {
+        return VetRequestDTO.builder()
                 .vetId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
                 .vetBillId("53c2d16e-1ba3-4dbc-8e31-6decd2eaa99a")
                 .firstName("Pauline")
@@ -240,12 +237,26 @@ class VetServiceImplTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-2847")
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(false)
                 .build();
     }
+    private VetResponseDTO buildVetResponseDTO() {
+        return VetResponseDTO.builder()
+                .vetId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
+                .vetBillId("53c2d16e-1ba3-4dbc-8e31-6decd2eaa99a")
+                .firstName("Pauline")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.com")
+                .phoneNumber("947-238-2847")
+                .resume("Just became a vet")
+                .workday(new HashSet<>())
+                .specialties(new HashSet<>())
+                .active(false)
+                .build();
+    }
+
     private Vet buildVet2() {
         return Vet.builder()
                 .vetId("d9d3a7ac-6817-4c13-9a09-c09da74fb65f")
@@ -255,7 +266,6 @@ class VetServiceImplTest {
                 .email("skjfhf@gmail.com")
                 .phoneNumber("947-238-2847")
                 .resume("Just became a vet")
-                .imageId("kjd")
                 .workday(new HashSet<>())
                 .specialties(new HashSet<>())
                 .active(true)


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-838?atlOrigin=eyJpIjoiZDY2NjY4YWUyYmQzNGRhNWEwY2YyZGZhZDI0MGFkMDAiLCJwIjoiaiJ9
## Context:
The vet-service only had a VetDTO, so I split it into a VetRequestDTO and a VetResponseDTO to follow better practice.
## Changes
- The DTO was split
- All calls to the VetDTO in the vet-service was changed to use the response and request DTOs appropriately
- The tests in the vet-service were updated to use the request and response DTOs
- All calls to the VetDTO in the api-gateway was changed to use the response and request DTOs appropriately
- The tests in the api-gateway were updated to use the request and response DTOs
This can be bullet point or sentence format.
## Dev notes (Optional)
- Specific technical changes that should be noted
## Linked pull requests (Optional)
- pull request link
