### PR TITLE
feat(VETS-CPC-835): Get all ratings older and newest by year

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -11,10 +11,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.webjars.NotFoundException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.Map;
 
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -213,6 +217,19 @@ public class VetsServiceClient {
                 .retrieve()
                 .bodyToFlux(VetAverageRatingDTO.class);
     }
+    public Flux<RatingResponseDTO> getRatingsOfAVetBasedOnDate(String vetId, Map<String,String> queryParams){
+        return webClientBuilder
+                .baseUrl(vetsServiceUrl)
+                .build()
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/" + vetId + "/ratings/date")
+                        .queryParam("year",queryParams.get("year"))
+                        .build())
+                .retrieve()
+                .bodyToFlux(RatingResponseDTO.class);
+    }
+
     public Mono<Double> getAverageRatingByVetId(String vetId) {
         return webClientBuilder
                 .build()
@@ -230,9 +247,6 @@ public class VetsServiceClient {
                 )
                 .bodyToMono(Double.class);
     }
-
-
-
     //Vets
     public Flux<VetResponseDTO> getVets() {
 

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/RatingResponseDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Vets/RatingResponseDTO.java
@@ -17,4 +17,5 @@ public class RatingResponseDTO {
     private String rateDescription;
     private PredefinedDescription predefinedDescription;
     private String rateDate;
+    private String date;
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -22,7 +22,6 @@ import com.petclinic.bffapigateway.utils.VetsEntityDtoUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.validation.annotation.Validated;
@@ -30,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -401,7 +401,14 @@ public class BFFApiGatewayController {
         return vetsServiceClient.getTopThreeVetsWithHighestAverageRating();
     }
 
+
+
     @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS})
+    @GetMapping("vets/{vetId}/ratings/date")
+    public Flux<RatingResponseDTO> getRatingsOfAVetBasedOnDate(@PathVariable String vetId, @RequestParam Map<String,String> queryParams){
+        return vetsServiceClient.getRatingsOfAVetBasedOnDate(vetId,queryParams);
+    }
+
     @GetMapping(value = "vets/{vetId}/ratings/average")
     public Mono<ResponseEntity<Double>> getAverageRatingByVetId(@PathVariable String vetId){
         return vetsServiceClient.getAverageRatingByVetId(VetsEntityDtoUtil.verifyId(vetId))

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
@@ -147,6 +147,33 @@ angular.module('vetDetails')
                 ratingsContainer.innerHTML = html.slice(0, -2);
             });
 
+        $scope.getRecentRatingBasedOnDate = function () {
+            console.log("In function based on date")
+            const wrongYearPattern = /^\d{4}$/;
+
+            let yearQuery = document.getElementById("queryDate").value
+            let year = new Date().getFullYear()
+
+            if (!wrongYearPattern.test(yearQuery)) {
+                // Throw an exception with a custom error message
+               alert("Invalid year format. Please enter a valid year.");
+               return;
+            }
+           else if (self.query === undefined || self.query === ''){
+                let newYear = year - 2
+                $http.get('api/gateway/vets/'+$stateParams.vetId +'/ratings/date?year='+newYear).then(function (resp) {
+                    console.log(resp.data);
+                    self.ratings = resp.data;
+                    arr = resp.data;
+                });
+            }else{
+                $http.get('api/gateway/vets/'+$stateParams.vetId +'/ratings/date?year='+yearQuery).then(function (resp) {
+                    console.log(resp.data);
+                    self.ratings = resp.data;
+                    arr = resp.data;
+                });
+            }
+        };
 
         $scope.deleteVetRating = function (ratingId) { //added $scope in this class
             let varIsConf = confirm('Are you sure you want to delete this ratingId: ' + ratingId + '?');
@@ -200,6 +227,10 @@ angular.module('vetDetails')
                 ? document.querySelector('input[name="predefinedDescriptionUpdate' + ratingId + '"]:checked').value
                 : null;
 
+            //CHECK
+            const ratingDate = document.querySelector('input[name="Year' + ratingId + '"]:checked')
+                ? document.querySelector('input[name="Year' + ratingId + '"]:checked').value :null;
+
             let updatedRating = {
                 ratingId: ratingId,
                 rateScore: selectedValue,
@@ -244,6 +275,11 @@ angular.module('vetDetails')
                 document.querySelectorAll('input[name="predefinedDescriptionUpdate' + ratingId + '"]').forEach(function (radio) {
                     radio.checked = false;
                 });
+
+                //ADDTIION
+                document.querySelectorAll('input[name="Year:' + ratingId + '"]').forEach(function (radio) {
+                    radio.checked = true;
+                });
             }
         };
 
@@ -279,6 +315,11 @@ angular.module('vetDetails')
                 predefinedDescription: document.querySelector('input[name="predefinedDescription"]:checked')
                     ? document.querySelector('input[name="predefinedDescription"]:checked').value
                     : null,
+                //ADDITION
+                ratingDate: document.querySelector('input[name="Year"]:checked')
+                    ? document.querySelector('input[name="Year"]:checked').value: null,
+
+
             };
             if (!rating.rateScore) {
                 alert("Please select a rating score");
@@ -411,4 +452,46 @@ angular.module('vetDetails')
             self.addEducationFormVisible = false; // Hide the education form
         };
 
+
     }]);
+
+// function getOlderRatingBasedOnDate(vet){
+//     let year = new Date().getFullYear()
+//
+//     let old = year - 4
+//
+//     $http.get('api/gateway/vets/{vetId}/ratings/date?year=' + old).then(function (resp) {
+//         console.log(resp.data);
+//         vet.showRating=true;
+//         vet.ratingDate = parseFloat(resp.data.toFixed(1));
+//
+//     });
+//
+// }
+
+    // $scope.refreshList = self.vetList;
+    //
+    // $scope.ReloadData = function () {
+    //     let url = 'api/gateway/vets/' + $stateParams.vetId + '/ratings/date?year=' + year;
+    //     let optionSelection = document.getElementById("filterOption").value;
+    //     if (optionSelection === "Recent") {
+    //         url+= '/date?year=2024';
+    //     } else if (optionSelection === "Old") {
+    //         url += '/date?year=2020';
+    //     }
+    //     self.selectedFilter=optionSelection;
+    //
+    //     $http.get(url).then(function (resp) {
+    //         self.vetList = resp.data;
+    //         arr = resp.data;
+    //         angular.forEach(self.vetList, function(vet) {
+    //             getRecentRatingBasedOnDate(vet)
+    //             // getOlderRatingBasedOnDate(ratingsOld)
+    //         });
+    //
+    //     });
+    //
+    // }
+
+
+

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
@@ -276,7 +276,15 @@
                     </div>
                 </div>
             </div>
-
+<!--            RECENT & OLDER RATINGS-->
+            <form onsubmit="void(0)" style="max-width: 20em; margin-top: 2em;">
+                <div class="form-group">
+                    <input id="queryDate" class="form-control" ng-model="$ctrl.query" placeholder="Search" type="text"/>
+                </div>
+                <button class="btn btn-primary ratingButton" ng-click="getRecentRatingBasedOnDate()" type="submit">
+                    Search
+                </button>
+            </form>
 
             <!-- Ratings Chart -->
             <div class="col-md-12" ng-if="$ctrl.ratings.length > 0" style="margin-top: 5%">

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -199,6 +199,25 @@ class ApiGatewayControllerTest {
     }
 
     @Test
+    void getRatingsBasedOnDate(){
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("year", "2023");
+
+
+        when(vetsServiceClient.getRatingsOfAVetBasedOnDate(vetResponseDTO.getVetId(), queryParams))
+                .thenReturn(Flux.just(buildRatingResponseDTO(),buildRatingResponseDTO2()));
+        client
+                .get()
+                .uri("/api/gateway/vets/"+VET_ID+"/ratings/date?year="+queryParams.get("year"))
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$[0].date").isEqualTo("2023");
+
+    }
+
+    @Test
     void getAverageRatingsByVetId(){
         RatingResponseDTO ratingResponseDTO = buildRatingResponseDTO();
 
@@ -3089,6 +3108,15 @@ void deleteAllInventory_shouldSucceed() {
                 .ratingId("123456")
                 .vetId("181faeb5-c024-425c-9f08-663600008f06")
                 .rateScore(4.0)
+                .date("2023")
+                .build();
+    }
+    private RatingResponseDTO buildRatingResponseDTO2() {
+        return RatingResponseDTO.builder()
+                .ratingId("123456")
+                .vetId("181faeb5-c024-425c-9f08-663600008f06")
+                .rateScore(4.0)
+                .date("2022")
                 .build();
     }
 private VetAverageRatingDTO buildVetAverageRatingDTO(){

--- a/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/ratings/Rating.java
+++ b/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/ratings/Rating.java
@@ -17,4 +17,5 @@ public class Rating {
     private String rateDescription;
     private PredefinedDescription predefinedDescription;
     private String rateDate;
+    private String date;
 }

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -11,6 +11,7 @@ package com.petclinic.vet.presentationlayer;
   * Ticket: feat(VVS-CPC-553): add veterinarian
  */
 
+import com.petclinic.vet.exceptions.NotFoundException;
 import com.petclinic.vet.servicelayer.*;
 import com.petclinic.vet.servicelayer.badges.BadgeResponseDTO;
 import com.petclinic.vet.servicelayer.badges.BadgeService;
@@ -31,6 +32,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
@@ -76,6 +79,20 @@ public class VetController {
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
+    @GetMapping("{vetId}/ratings/date")
+    public Flux<RatingResponseDTO> getRatingsOfAVetBasedOnDate(@PathVariable String vetId, @RequestParam Map<String,String> queryParams) {
+        if (queryParams.containsKey("year")) {
+            String year = queryParams.get("year");
+
+            //This regex signifies that it required 4 numbers input for the year
+            if (!year.matches("^\\d{4}$")) {
+                throw new NotFoundException("Invalid year format. Please enter a valid year.");
+            }
+        }
+        return ratingService.getRatingsOfAVetBasedOnDate(vetId, queryParams)
+                .switchIfEmpty(Mono.error(new NotFoundException("No valid ratings were found for " + vetId)));
+    }
+
 
     @GetMapping("topVets")
     public Flux<VetAverageRatingDTO> getTopThreeVetsWithHighestAverageRating() {

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/DataSetupService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/DataSetupService.java
@@ -28,6 +28,12 @@ import java.util.UUID;
 
 @Service
 public class DataSetupService implements CommandLineRunner {
+
+
+    String date3 = ("2023");
+    String date4 = ("2024");
+    String date2 = ("2022");
+    String date1 = ("2021");
     private final VetRepository vetRepository;
     private final RatingRepository ratingRepository;
     private final EducationRepository educationRepository;
@@ -166,6 +172,7 @@ public class DataSetupService implements CommandLineRunner {
                 .rateScore(5.0)
                 .rateDescription(null)
                 .predefinedDescription(PredefinedDescription.EXCELLENT)
+                .date(date1)
                 .build();
         Rating r2 = Rating.builder()
                 .ratingId(UUID.randomUUID().toString())
@@ -173,6 +180,7 @@ public class DataSetupService implements CommandLineRunner {
                 .rateScore(4.0)
                 .predefinedDescription(null)
                 .rateDescription("Good vet.")
+                .date(date2)
                 .build();
         Rating r3 = Rating.builder()
                 .ratingId(UUID.randomUUID().toString())
@@ -180,6 +188,7 @@ public class DataSetupService implements CommandLineRunner {
                 .rateScore(3.0)
                 .rateDescription("The vet is ok.")
                 .predefinedDescription(null)
+                .date(date3)
                 .build();
         Rating r4 = Rating.builder()
                 .ratingId(UUID.randomUUID().toString())
@@ -187,6 +196,7 @@ public class DataSetupService implements CommandLineRunner {
                 .rateScore(4.0)
                 .rateDescription(null)
                 .predefinedDescription(PredefinedDescription.GOOD)
+                .date(date4)
                 .build();
         Flux.just(r1, r2, r3, r4)
                 .flatMap(ratingRepository::insert)

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/ratings/RatingResponseDTO.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/ratings/RatingResponseDTO.java
@@ -17,4 +17,5 @@ public class RatingResponseDTO {
     private String rateDescription;
     private PredefinedDescription predefinedDescription;
     private String rateDate;
+    private String date;
 }

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/ratings/RatingService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/ratings/RatingService.java
@@ -4,6 +4,8 @@ import com.petclinic.vet.servicelayer.VetAverageRatingDTO;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.Map;
+
 public interface RatingService {
     Flux<RatingResponseDTO> getAllRatingsByVetId(String vetId);
     Mono<Integer> getNumberOfRatingsByVetId(String vetId);
@@ -11,6 +13,7 @@ public interface RatingService {
     Mono<RatingResponseDTO> updateRatingByVetIdAndRatingId(String vetId, String ratingId, Mono<RatingRequestDTO> ratingRequestDTOMono);
     Mono<Void> deleteRatingByRatingId(String vetId, String ratingId);
     Mono<Double> getAverageRatingByVetId(String vetId);
+    Flux<RatingResponseDTO> getRatingsOfAVetBasedOnDate(String vetId, Map<String,String> queryParams);
     Flux<VetAverageRatingDTO> getTopThreeVetsWithHighestAverageRating();
     Mono<String> getRatingPercentagesByVetId(String vetId);
 }

--- a/vet-service/src/test/java/com/petclinic/vet/servicelayer/RatingServiceImplTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/servicelayer/RatingServiceImplTest.java
@@ -19,7 +19,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -230,6 +232,50 @@ class RatingServiceImplTest {
         StepVerifier
                 .create(averageRatingDTOFlux)
                 .expectNextCount(3)
+                .verifyComplete();
+
+    }
+    @Test
+    void getRatingBasedOnDate()throws JsonProcessingException{
+        rating.setRateScore(4.0);
+        rating.setDate("2021");
+        rating.setVetId("68790");
+        rating2.setRateScore(1.0);
+        rating2.setVetId("68792");
+        rating2.setDate("2022");
+        rating3.setRateScore(2.0);
+        rating3.setVetId("68793");
+        rating3.setDate("2023");
+
+
+        Vet vet1 = Vet.builder()
+                .vetId("vetId")
+                .vetBillId("1")
+                .firstName("Clementine")
+                .lastName("LeBlanc")
+                .email("skjfhf@gmail.com")
+                .phoneNumber("947-238-2847")
+                .resume("Just became a vet")
+                .imageId("kjd")
+                .workday(new HashSet<>())
+                .specialties(new HashSet<>())
+                .active(false)
+                .build();
+
+
+
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("year", "2023");
+
+        when(vetRepository.findVetByVetId(vet1.getVetId())).thenReturn(Mono.just(vet1));
+
+        when(ratingRepository.findAllByVetId(anyString())).thenReturn(Flux.just(rating, rating2, rating3));
+
+        Flux<RatingResponseDTO> ratingResponseDTOFlux = ratingService.getRatingsOfAVetBasedOnDate(vet1.getVetId(),queryParams);
+
+        StepVerifier
+                .create(ratingResponseDTOFlux)
+                .expectNextCount(1)
                 .verifyComplete();
     }
 


### PR DESCRIPTION
JIRA:https://champlainsaintlambert.atlassian.net/browse/CPC-835

## Context:
This feature is to be able to get all the ratings for each vet depending on the year entered by the user.
## Changes
90% Vet-Service Coverage
90% Coverage of feature in API-Gateway
Added a search query in vet details

## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://github.com/cgerard321/champlain_petclinic/assets/91993350/1746d132-c094-4738-8bdf-bc6a1ba59edc)

After:
![image](https://github.com/cgerard321/champlain_petclinic/assets/91993350/246562cf-775a-411b-8319-617287032ef1)
![image](https://github.com/cgerard321/champlain_petclinic/assets/91993350/57c247f8-29f8-4fb2-a799-bfab6c93ca29)
