### PR TITLE
bug(VETS-CPC-996): fix predefined description of vet rating: rating cannot be unchecked

### DIFF
--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.controller.js
@@ -29,6 +29,42 @@ angular.module('vetDetails')
             child.classList.add("modalOff");
         }
 
+        self.checkedCheckboxesUpdate = {};
+        self.handleCheckboxClick = function(value, ratingId) {
+            // Update the checked state for the specific ratingId.
+            self.checkedCheckboxesUpdate[ratingId] = value;
+            // Uncheck other checkboxes for the same ratingId.
+            const checkboxes = document.querySelectorAll('input[type="checkbox"][name="predefinedDescriptionUpdate' + ratingId + '"]');
+            checkboxes.forEach((checkbox) => {
+                if (checkbox.value !== value) {
+                    checkbox.checked = false;
+                }
+            });
+        };
+
+        const checkboxesForAddRating = document.querySelectorAll('.col-sm-12 input[type="checkbox"]');
+        let lastCheckedCheckbox = null;
+        checkboxesForAddRating.forEach(checkbox => {
+            checkbox.addEventListener('click', function () {
+                if (this !== lastCheckedCheckbox) {
+                    if (lastCheckedCheckbox) {
+                        lastCheckedCheckbox.checked = false;
+                    }
+                    lastCheckedCheckbox = this;
+                }
+                const value = lastCheckedCheckbox.checked ? lastCheckedCheckbox.value : null;
+                console.log('Last checked value:', value);
+            });
+        });
+        self.togglePredefinedDescription = function (rating, value) {
+            console.log("Toggling predefinedDescription: ", value);
+            if (rating['predefinedDescription' + value] === value) {
+                rating['predefinedDescription' + value] = null;
+            } else {
+                rating['predefinedDescription' + value] = value;
+            }
+        };
+
         /* added /{{vet.vetID}} in the url */
         $http.get('api/gateway/vets/' + $stateParams.vetId).then(function (resp) {
             self.vet = resp.data;
@@ -312,9 +348,13 @@ angular.module('vetDetails')
                 rateScore: parseFloat(document.getElementById("ratingScore").value),
                 rateDate: new Date().toLocaleDateString(),
                 rateDescription: document.getElementById("ratingDescription").value,
-                predefinedDescription: document.querySelector('input[name="predefinedDescription"]:checked')
-                    ? document.querySelector('input[name="predefinedDescription"]:checked').value
-                    : null,
+                predefinedDescription: document.querySelector('input[name="predefinedDescriptionPOOR"]:checked')
+                    ? document.querySelector('input[name="predefinedDescriptionPOOR"]:checked').value
+                    : document.querySelector('input[name="predefinedDescriptionGOOD"]:checked')
+                        ? document.querySelector('input[name="predefinedDescriptionGOOD"]:checked').value
+                        : document.querySelector('input[name="predefinedDescriptionEXCELLENT"]:checked')
+                            ? document.querySelector('input[name="predefinedDescriptionEXCELLENT"]:checked').value
+                            : null,
                 //ADDITION
                 ratingDate: document.querySelector('input[name="Year"]:checked')
                     ? document.querySelector('input[name="Year"]:checked').value: null,

--- a/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/vet-details/vet-details.template.html
@@ -261,9 +261,9 @@
                                 </div>
                                 <div class="col-sm-12 form-label-rating">
                                     <label>Predefined Description:</label>
-                                    <input type="radio" name="predefinedDescription{{rating.ratingId}}" value="POOR" ng-model="rating.predefinedDescription"> Poor
-                                    <input type="radio" name="predefinedDescription{{rating.ratingId}}" value="GOOD" ng-model="rating.predefinedDescription"> Good
-                                    <input type="radio" name="predefinedDescription{{rating.ratingId}}" value="EXCELLENT" ng-model="rating.predefinedDescription"> Excellent
+                                    <input type="checkbox" name="predefinedDescriptionPOOR{{rating.ratingId}}" value="POOR" ng-model="rating.predefinedDescriptionPOOR" ng-click="togglePredefinedDescription(rating, 'POOR')"> Poor
+                                    <input type="checkbox" name="predefinedDescriptionGOOD{{rating.ratingId}}" value="GOOD" ng-model="rating.predefinedDescriptionGOOD" ng-click="togglePredefinedDescription(rating, 'GOOD')"> Good
+                                    <input type="checkbox" name="predefinedDescriptionEXCELLENT{{rating.ratingId}}" value="EXCELLENT" ng-model="rating.predefinedDescriptionEXCELLENT" ng-click="togglePredefinedDescription(rating, 'EXCELLENT')"> Excellent
                                 </div>
 
                                 <br />
@@ -326,9 +326,9 @@
                                                   title="Maximum of 350 characters."></textarea>
                                         <div class="col-sm-12 form-label-rating">
                                             <label>Predefined Description:</label>
-                                            <input type="radio" name="predefinedDescriptionUpdate{{rating.ratingId}}" value="POOR" ng-model="updatedRating.predefinedDescription"> Poor
-                                            <input type="radio" name="predefinedDescriptionUpdate{{rating.ratingId}}" value="GOOD" ng-model="updatedRating.predefinedDescription"> Good
-                                            <input type="radio" name="predefinedDescriptionUpdate{{rating.ratingId}}" value="EXCELLENT" ng-model="updatedRating.predefinedDescription"> Excellent
+                                            <input type="checkbox" name="predefinedDescriptionUpdate{{rating.ratingId}}" value="POOR" ng-click="$ctrl.handleCheckboxClick('POOR', rating.ratingId)"> Poor
+                                            <input type="checkbox" name="predefinedDescriptionUpdate{{rating.ratingId}}" value="GOOD" ng-click="$ctrl.handleCheckboxClick('GOOD', rating.ratingId)"> Good
+                                            <input type="checkbox" name="predefinedDescriptionUpdate{{rating.ratingId}}" value="EXCELLENT" ng-click="$ctrl.handleCheckboxClick('EXCELLENT', rating.ratingId)"> Excellent
                                         </div>
                                     </div>
                                 </form>


### PR DESCRIPTION
JIRA: link to jira ticket
CPC-996
https://champlainsaintlambert.atlassian.net/browse/CPC-996
## Context:
This ticket is about fixing a bug: when selecting a predefined description for the rating of a vet, the predefined description cannot be unchecked (if the user decides to write a custom description). The radio buttons had to be changed to checkboxes (because radio buttons cannot be unselected) while also ensuring that only one checkbox can be checked at a time (keeping track of the most recently checked checkbox).
## Changes
- Change radio button to checkbox in vet-details.template.html.
- Add function that ensures that only one checkbox can be checked at a time (keeping track of the most recently checked checkbox) in vet-details.controller.js.
## Before and After UI (Required for UI-impacting PRs)
### Before
#### Add Rating Before
![image](https://github.com/cgerard321/champlain_petclinic/assets/46633364/e7a66300-0c13-4540-9968-b288fb763210)
#### Update Rating Before
![image](https://github.com/cgerard321/champlain_petclinic/assets/46633364/9d93e7e3-3eb9-43a3-806a-486cb1ed1483)
### After
#### Add Rating After
![image](https://github.com/cgerard321/champlain_petclinic/assets/46633364/8febc968-9d95-4bd4-9f1e-7a9248edc4a5)
#### Update Rating After
![image](https://github.com/cgerard321/champlain_petclinic/assets/46633364/5c8ab608-4c64-4008-9e4c-c6e4c2266c53)
## Dev notes (Optional)
- Specific technical changes that should be noted
## Linked pull requests (Optional)
- pull request link
