### PR TITLE
bug(BILL-CPC-920) Implement Negative Testing In BillServiceClientIntegration tests

### DIFF
--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientIntegrationTest.java
@@ -394,12 +394,12 @@ class BillServiceClientIntegrationTest {
 
     @Test
     void getBillsByInvalidCustomerId() {
-        server.enqueue(new MockResponse().setResponseCode(500));
+        server.enqueue(new MockResponse().setResponseCode(400));
 
         Flux<BillResponseDTO> billResponseDTOMono = billServiceClient.getBillsByOwnerId("invalidCustomerId");
 
         StepVerifier.create(billResponseDTOMono)
-                .expectError(WebClientResponseException.InternalServerError.class)
+                .expectError(WebClientResponseException.BadRequest.class)
                 .verify();
     }
 
@@ -427,19 +427,19 @@ class BillServiceClientIntegrationTest {
 
     @Test
     void deleteBillWithInvalidCustomerId() {
-        server.enqueue(new MockResponse().setResponseCode(500));
+        server.enqueue(new MockResponse().setResponseCode(400));
 
         Flux<Void> empty = billServiceClient.deleteBillsByCustomerId("invalidCustomerId");
 
         StepVerifier.create(empty)
-                .expectError(WebClientResponseException.InternalServerError.class)
+                .expectError(WebClientResponseException.BadRequest.class)
                 .verify();
     }
 
     @Test
     void createBillWithInvalidRequest() {
         BillRequestDTO invalidRequest = new BillRequestDTO();
-        String requestJson = ""; 
+        String requestJson = "";
 
         prepareResponse(response -> response
                 .setResponseCode(400)


### PR DESCRIPTION
JIRA: (https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/35?selectedIssue=CPC-920&sprints=315)
## Context:
This ticket involves adding negative tests to the BillServiceClient integration tests to assess how the system behaves under the wrong conditions, ensuring reliability and error handling.
## Changes
###  Created 7 negative tests

- getNonExistentBillById
- getBillByInvalidVetId
- getBillsByInvalidCustomerId
- deleteNonExistentBill
- deleteBillWithInvalidVetId
- deleteBillWithInvalidCustomerId
- createBillWithInvalidRequest