### PR TITLE
feat(VIST-CPC-997): make status tables collapsible

### DIFF
--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.controller.js
@@ -8,6 +8,13 @@ angular.module('visitList')
         self.cancelledVisits = []
         self.completedVisits = []
 
+
+        $scope.showUpcomingVisits = true;
+        $scope.showConfirmedVisits = true;
+        $scope.showCancelledVisits = true;
+        $scope.showCompletedVisits = true;
+
+
         let url
         //sorted by order or most to least permissions
         if ($window.localStorage.getItem("roles").includes("ADMIN")){
@@ -123,6 +130,8 @@ angular.module('visitList')
             $scope.reverse = ($scope.propertyName === propertyName) ? !$scope.reverse : false
             $scope.propertyName = propertyName
         }
+
+
         function delayedReload() {
             let loadingIndicator = document.getElementById('loadingIndicator')
             loadingIndicator.style.display = 'block'
@@ -137,21 +146,21 @@ angular.module('visitList')
     }])
 
 //     // self.sortFetchedVisits = function() {
-    //     //     let currentDate = getCurrentDate()
-    //     //     $.each(self.visits, function(i, visit) {
-    //     //         let selectedVisitDate = Date.parse(visit.date);
-    //     //         if(selectedVisitDate >= currentDate) {
-    //     //             self.upcomingVisits.push(visit)
-    //     //         } else {
-    //     //             self.previousVisits.push(visit)
-    //     //         }
-    //     //     })
-    //     // }
-    //     // function getCurrentDate() {
-    //     //     let dateObj = new Date()
-    //     //     var dd = String(dateObj.getDate()).padStart(2, '0')
-    //     //     var mm = String(dateObj.getMonth() + 1).padStart(2, '0')
-    //     //     var yyyy = dateObj.getFullYear()
-    //     //     return Date.parse(yyyy + '-' + mm + '-' + dd)
-    //     // }
-    // }])
+//     //     let currentDate = getCurrentDate()
+//     //     $.each(self.visits, function(i, visit) {
+//     //         let selectedVisitDate = Date.parse(visit.date);
+//     //         if(selectedVisitDate >= currentDate) {
+//     //             self.upcomingVisits.push(visit)
+//     //         } else {
+//     //             self.previousVisits.push(visit)
+//     //         }
+//     //     })
+//     // }
+//     // function getCurrentDate() {
+//     //     let dateObj = new Date()
+//     //     var dd = String(dateObj.getDate()).padStart(2, '0')
+//     //     var mm = String(dateObj.getMonth() + 1).padStart(2, '0')
+//     //     var yyyy = dateObj.getFullYear()
+//     //     return Date.parse(yyyy + '-' + mm + '-' + dd)
+//     // }
+// }])

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.controller.js
@@ -9,7 +9,7 @@ angular.module('visitList')
         self.completedVisits = []
 
 
-        $scope.showUpcomingVisits = true;
+        $scope.showUpcomingVisits = true; //initialize to true to show automatically
         $scope.showConfirmedVisits = true;
         $scope.showCancelledVisits = true;
         $scope.showCompletedVisits = true;

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
@@ -45,20 +45,30 @@
         transform: translateY(2px);
     }
 
+    .arrow {
+        font-size: 24px; /* Adjust the size as needed */
+        color: black; /* Adjust the color as needed */
+    }
+
 
 </style>
 
 <div id="loadingIndicator" style="display: none;">Loading...</div> <!--Page loading message-->
 
 <div class="button-wrapper" ng-controller="VisitListController">
-        <a ui-sref="visitsNew"> <button class="original-bttn" id="addBtn">Create Visit</button> </a>
-        <button class="delete-all-bttn" ng-click="deleteAllCancelledVisits()">Delete All Cancelled Visits</button>
+    <a ui-sref="visitsNew"> <button class="original-bttn" id="addBtn">Create Visit</button> </a>
+    <button class="delete-all-bttn" ng-click="deleteAllCancelledVisits()">Delete All Cancelled Visits</button>
 </div>
 
 
-
-<h3 style="margin: 0;" ng-show="$ctrl.upcomingVisits.length > 0">Upcoming Visits</h3>
-<table class="table table-striped" ng-show="$ctrl.upcomingVisits.length > 0">
+<div ng-show="$ctrl.upcomingVisits.length > 0">
+    <h3 style="margin: 0; display: inline-block;">Upcoming Visits</h3>
+    <button class="btn btn-link" ng-click="showUpcomingVisits = !showUpcomingVisits" style="vertical-align: middle;">
+        <span ng-if="showUpcomingVisits">&#9660;</span>
+        <span ng-if="!showUpcomingVisits">&#9650;</span>
+    </button>
+</div>
+<table class="table table-striped" ng-show="showUpcomingVisits && $ctrl.upcomingVisits.length > 0">
     <thead>
     <tr>
         <th><button class="btn btn-default" ng-click="sortBy('visitId')" style="color: white">VisitId<span class="sortorder" ng-show="propertyName === 'visitId'" ng-class="{reverse: reverse}"></span></button></th>
@@ -68,7 +78,7 @@
         <th><button class="btn btn-default" ng-click="sortBy('petId')" style="color: white">Sort by pet<span class="sortorder" ng-show="propertyName === 'petId'" ng-class="{reverse: reverse}"></span></button></th>
         <th>
             <button class="btn btn-default" style="color: white">Sort by Bill</button>
-<!--            <button class="btn btn-default" ng-click="sortBy('bill')" style="color: white">Sort by Bill</button><span class="sortorder" ng-show="propertyName === 'bill'" ng-class="{reverse: reverse}"></span>-->
+            <!--            <button class="btn btn-default" ng-click="sortBy('bill')" style="color: white">Sort by Bill</button><span class="sortorder" ng-show="propertyName === 'bill'" ng-class="{reverse: reverse}"></span>-->
         </th>
         <th style="text-align:center; vertical-align:middle"><label>Status</label></th>
         <th style="text-align:center; vertical-align:middle"><label>Confirm</label></th>
@@ -92,12 +102,12 @@
         <td class="border"></td>
     </tr>
 
-<!--    <tr id="visitId" ng-repeat="v in $ctrl.upcomingVisits | filter:search:$ctrl.query track by v.visitId" data-table-name="upcomingVisits">-->
+    <!--    <tr id="visitId" ng-repeat="v in $ctrl.upcomingVisits | filter:search:$ctrl.query track by v.visitId" data-table-name="upcomingVisits">-->
     <tr id="upcomingVisitId" ng-repeat="v in $ctrl.upcomingVisits | orderBy:propertyName:reverse | filter:search:$ctrl.query track by v.visitId" data-table-name="upcomingVisits">
         <td class="border">{{v.visitId}}</td>
         <td class="border">{{v.visitDate | date:'yyyy-MM-ddTHH:mm:ss'}}</td>
         <td class="border" style="white-space: pre-line">{{v.description}}</td>
-<!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
+        <!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
         <td class="border" style="white-space: pre-line">{{v.practitionerId}}</td>
         <td class="border" style="white-space: pre-line">{{v.petId}}</td>
         <td class="status-text" style="white-space: pre-line"></td>
@@ -126,8 +136,14 @@
 </table>
 
 <br>
-<h3 style="margin: 0;" ng-show="$ctrl.confirmedVisits.length > 0">Confirmed Visits</h3>
-<table class="table table-striped" ng-show="$ctrl.confirmedVisits.length > 0">
+<div ng-show="$ctrl.confirmedVisits.length > 0">
+    <h3 style="margin: 0; display: inline-block;">Confirmed Visits</h3>
+    <button class="btn btn-link" ng-click="showConfirmedVisits = !showConfirmedVisits" style="vertical-align: middle;">
+        <span ng-if="showConfirmedVisits">&#9660;</span>
+        <span ng-if="!showConfirmedVisits">&#9650;</span>
+    </button>
+</div>
+<table class="table table-striped" ng-show="showConfirmedVisits && $ctrl.confirmedVisits.length > 0">
     <thead>
     <tr>
         <th><button class="btn btn-default" ng-click="sortBy('visitId')" style="color: white">VisitId<span class="sortorder" ng-show="propertyName === 'visitId'" ng-class="{reverse: reverse}"></span></button></th>
@@ -182,8 +198,14 @@
 
 
 <br>
-<h3 style="margin: 0;" ng-show="$ctrl.cancelledVisits.length > 0">Cancelled Visits</h3>
-<table class="table table-striped" ng-show="$ctrl.cancelledVisits.length > 0">
+<div ng-show="$ctrl.cancelledVisits.length > 0">
+    <h3 style="margin: 0; display: inline-block;">Cancelled Visits</h3>
+    <button class="btn btn-link" ng-click="showCancelledVisits = !showCancelledVisits" style="vertical-align: middle;">
+        <span ng-if="showCancelledVisits">&#9660;</span>
+        <span ng-if="!showCancelledVisits">&#9650;</span>
+    </button>
+</div>
+<table class="table table-striped" ng-show="showCancelledVisits && $ctrl.cancelledVisits.length > 0">
     <thead>
     <tr>
         <th><button class="btn btn-default" ng-click="sortBy('visitId')" style="color: white">VisitId<span class="sortorder" ng-show="propertyName === 'visitId'" ng-class="{reverse: reverse}"></span></button></th>
@@ -237,8 +259,14 @@
 </table>
 
 <br>
-<h3 style="margin: 0;" ng-show="$ctrl.completedVisits.length > 0">Completed Visits</h3>
-<table class="table table-striped" ng-show="$ctrl.completedVisits.length > 0">
+<div ng-show="$ctrl.completedVisits.length > 0">
+    <h3 style="margin: 0; display: inline-block;">Completed Visits</h3>
+    <button class="btn btn-link" ng-click="showCompletedVisits = !showCompletedVisits" style="vertical-align: middle;">
+        <span ng-if="showCompletedVisits">&#9660;</span>
+        <span ng-if="!showCompletedVisits">&#9650;</span>
+    </button>
+</div>
+<table class="table table-striped" ng-show="showCompletedVisits && $ctrl.completedVisits.length > 0">
     <thead>
     <tr>
         <th><button class="btn btn-default" ng-click="sortBy('visitId')" style="color: white">VisitId<span class="sortorder" ng-show="propertyName === 'visitId'" ng-class="{reverse: reverse}"></span></button></th>
@@ -290,4 +318,3 @@
     </tr>
     </tbody>
 </table>
-


### PR DESCRIPTION
link to JIRA ticket:
https://champlainsaintlambert.atlassian.net/browse/CPC-997

## Context:
This ticket is pertaining to adding the ability to collapse the visit status tables. This ticket was inspired by a discussion in a scrum meeting when analyzing the implemented status tables sorting. The possibility of our user (secretary in this case) needing to scroll through many visits before reaching another status table is unlikely, but is a possibility to take into account nonetheless. This inspired this UI adjustment.
## Changes
- Adding a boolean scope to the visit-list controller for each status table
- Adding 'Collapse Arrow Buttons' to each table header

## Before and After UI (Required for UI-impacting PRs)
Before Changes:

![273793093-cdf1b26c-4eb8-4fa5-8c28-e8a08aead452](https://github.com/cgerard321/champlain_petclinic/assets/77695020/8d473038-e7c2-4a48-971d-c224bd0826cb)

After Changes:

- Collapsed Table View (Upcoming)
![Table_Collapsed](https://github.com/cgerard321/champlain_petclinic/assets/77695020/18ed6849-b54d-454f-b3d7-95c8c60d28b4)

- Closed Table View (Upcoming)
![Closed_Tables](https://github.com/cgerard321/champlain_petclinic/assets/77695020/00de634c-1ed1-4e96-9a32-b691c04a5b68)

- Header, Arrows & Table hidden when visits in table reaches 0 (Upcoming)

![Table_Header_Arrows_Hidden_VisitList0](https://github.com/cgerard321/champlain_petclinic/assets/77695020/db8ffc92-c42b-45f5-a162-e50cba06d9c9)

## Linked pull requests
https://champlainsaintlambert.atlassian.net/browse/CPC-913
