### PR TITLE
feat(VIST-CPC-927): implementing aggregation and details page

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitResponseDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 
 @Data
 @AllArgsConstructor
@@ -14,10 +15,17 @@ import java.time.LocalDateTime;
 @Builder
 public class VisitResponseDTO {
     private String visitId;
-@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-private LocalDateTime visitDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime visitDate;
     private String description;
     private String petId;
+    private String petName;
+    private Date petBirthDate;
     private String practitionerId;
+    private String vetFirstName;
+    private String vetLastName;
+    private String vetEmail;
+    private String vetPhoneNumber;
     private Status status;
 }

--- a/api-gateway/src/main/resources/static/index.html
+++ b/api-gateway/src/main/resources/static/index.html
@@ -68,6 +68,10 @@
     <script src="scripts/pet-form/pet-form.controller.js"></script>
     <script src="scripts/pet-form/pet-form.component.js"></script>
 
+    <script src="scripts/visit-details-info/visit.js"></script>
+    <script src="scripts/visit-details-info/visit.controller.js"></script>
+    <script src="scripts/visit-details-info/visit.component.js"></script>
+
     <script src="scripts/visits/visits.js"></script>
     <script src="scripts/visits/visits.controller.js"></script>
     <script src="scripts/visits/visits.component.js"></script>

--- a/api-gateway/src/main/resources/static/scripts/app.js
+++ b/api-gateway/src/main/resources/static/scripts/app.js
@@ -10,7 +10,7 @@ const whiteList = new Set([
 /* App Module */
 const petClinicApp = angular.module('petClinicApp', [
     'ui.router', 'layoutNav', 'layoutFooter', 'layoutWelcome', 'ownerList', 'ownerDetails', 'ownerForm', 'ownerRegister', 'petRegister', 'petForm'
-    , 'visits', 'vetList','vetForm','vetDetails', 'visitList', 'billForm', 'billUpdateForm', 'loginForm', 'rolesDetails', 'signupForm', 'productDetailsInfo',
+    , 'visits', 'visit', 'visitList' , 'vetList','vetForm','vetDetails', 'billForm', 'billUpdateForm', 'loginForm', 'rolesDetails', 'signupForm', 'productDetailsInfo',
     'billDetails', 'billsByOwnerId', 'billHistory','billsByVetId','inventoryList', 'inventoryForm', 'productForm','inventoryProductList', 'inventoryUpdateForm', 'productUpdateForm',
      'verification' , 'adminPanel','resetPwdForm','forgotPwdForm','petTypeList', 'petDetails','userDetails']);
 

--- a/api-gateway/src/main/resources/static/scripts/visit-details-info/visit.component.js
+++ b/api-gateway/src/main/resources/static/scripts/visit-details-info/visit.component.js
@@ -1,0 +1,7 @@
+'use strict';
+
+angular.module('visit')
+    .component('visit', {
+        templateUrl: 'scripts/visit-details-info/visit.details.template.html',
+        controller: 'VisitController'
+    });

--- a/api-gateway/src/main/resources/static/scripts/visit-details-info/visit.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/visit-details-info/visit.controller.js
@@ -1,0 +1,10 @@
+angular.module('visit')
+    .controller('VisitController',  ['$http', '$stateParams', function ($http, $stateParams){
+        var self = this;
+
+        $http.get('api/gateway/visits/' + $stateParams.visitId).then(function (resp) {
+            self.visit = resp.data;
+        });
+
+
+    }])

--- a/api-gateway/src/main/resources/static/scripts/visit-details-info/visit.details.template.html
+++ b/api-gateway/src/main/resources/static/scripts/visit-details-info/visit.details.template.html
@@ -1,0 +1,54 @@
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css"
+      integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
+
+<div class="container mt-5">
+    <div class="row">
+        <div class="col-md-6">
+            <a class="btn btn-success" href="http://localhost:8080/#!/visitList">Back to Visits</a>
+        </div>
+    </div>
+    <br>
+    <div class="alert alert-danger" ng-if="$ctrl.visit.status === 'CANCELLED'">
+        NOTICE: This visit is cancelled.
+    </div>
+    <br>
+    <div class="row">
+        <div class="col-md-4 text-start">
+            <h1 class="visit-title">VISIT(<span ng-style="{'color': $ctrl.visit.status === 'CANCELLED' ? 'red' : $ctrl.visit.status === 'UPCOMING' ? 'blue' : $ctrl.visit.status === 'CONFIRMED' ? 'green' : 'black'}">{{$ctrl.visit.status}}</span>)</h1>
+        </div>
+        <div class="col-md-4"></div> <!-- Empty column for spacing -->
+        <div class="col-md-4 text-end">
+            <h3 class="visit-id">Visit ID: {{$ctrl.visit.visitId}}</h3>
+            <h5>Date: {{$ctrl.visit.visitDate}}</h5>
+        </div>
+        <div class="col-md-4 text-start">
+            <h5>Visit Description: {{$ctrl.visit.description}}</h5>
+        </div>
+    </div>
+    <hr>
+    <div class="row g-5">
+        <div class="col-md-6">
+            <h3 class="text-center">Pet Information</h3>
+            <h5>Pet ID: {{$ctrl.visit.petId}}</h5>
+            <h5>Pet Name: {{$ctrl.visit.petName}} </h5>
+            <h5>Birth Date: {{$ctrl.visit.petBirthDate | date: 'yyyy-MM-dd'}}</h5>
+            <hr>
+            <h3 class="text-center">Vet Information</h3>
+            <h5>Vet ID: {{$ctrl.visit.practitionerId}}</h5>
+            <h5>Vet Name: {{$ctrl.visit.vetFirstName}} {{$ctrl.visit.vetLastName}} </h5>
+            <h5>Email: {{$ctrl.visit.vetEmail}}</h5>
+            <h5>Phone Number: {{$ctrl.visit.vetPhoneNumber}}</h5>
+        </div>
+    </div>
+</div>
+
+<style>
+    .visit-title, .visit-id {
+        font-size: 24px;
+        font-weight: bold;
+    }
+</style>
+
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.min.js"></script>

--- a/api-gateway/src/main/resources/static/scripts/visit-details-info/visit.js
+++ b/api-gateway/src/main/resources/static/scripts/visit-details-info/visit.js
@@ -1,0 +1,11 @@
+'use strict';
+
+angular.module('visit', ['ui.router'])
+    .config(['$stateProvider', function ($stateProvider) {
+        $stateProvider
+            .state('visitDetails', {
+                parent: 'app',
+                url: '/visit/:visitId/details',
+                template: '<visit></visit>'
+            });
+    }]);

--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
@@ -100,11 +100,12 @@
         <td class="border"></td>
         <td class="border"></td>
         <td class="border"></td>
+        <td class="border"></td>
     </tr>
 
     <!--    <tr id="visitId" ng-repeat="v in $ctrl.upcomingVisits | filter:search:$ctrl.query track by v.visitId" data-table-name="upcomingVisits">-->
     <tr id="upcomingVisitId" ng-repeat="v in $ctrl.upcomingVisits | orderBy:propertyName:reverse | filter:search:$ctrl.query track by v.visitId" data-table-name="upcomingVisits">
-        <td class="border">{{v.visitId}}</td>
+        <td class="border"><a ui-sref="visitDetails({ visitId: v.visitId })"> {{ v.visitId }}</a></td>
         <td class="border">{{v.visitDate | date:'yyyy-MM-ddTHH:mm:ss'}}</td>
         <td class="border" style="white-space: pre-line">{{v.description}}</td>
         <!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
@@ -165,7 +166,7 @@
     <tbody id="confirmedTable">
 
     <tr id="confirmedVisitId" ng-repeat="v in $ctrl.confirmedVisits | orderBy:propertyName:reverse | filter:search:$ctrl.query track by v.visitId" data-table-name="confirmedVisits">
-        <td class="border">{{v.visitId}}</td>
+        <td class="border"><a ui-sref="visitDetails({ visitId: v.visitId })"> {{ v.visitId }}</a></td>
         <td class="border">{{v.visitDate | date:'yyyy-MM-ddTHH:mm:ss'}}</td>
         <td class="border" style="white-space: pre-line">{{v.description}}</td>
         <!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
@@ -227,7 +228,7 @@
     <tbody id="cancelledTable">
 
     <tr id="cancelledVisitId" ng-repeat="v in $ctrl.cancelledVisits | orderBy:propertyName:reverse | filter:search:$ctrl.query track by v.visitId" data-table-name="cancelledVisits">
-        <td class="border">{{v.visitId}}</td>
+        <td class="border"><a ui-sref="visitDetails({ visitId: v.visitId })"> {{ v.visitId }}</a></td>
         <td class="border">{{v.visitDate | date:'yyyy-MM-ddTHH:mm:ss'}}</td>
         <td class="border" style="white-space: pre-line">{{v.description}}</td>
         <!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
@@ -288,7 +289,7 @@
     <tbody id="completedTable">
 
     <tr id="completedVisitId" ng-repeat="v in $ctrl.completedVisits | orderBy:propertyName:reverse | filter:search:$ctrl.query track by v.visitId" data-table-name="completedVisits">
-        <td class="border">{{v.visitId}}</td>
+        <td class="border"><a ui-sref="visitDetails({ visitId: v.visitId })"> {{ v.visitId }}</a></td>
         <td class="border">{{v.visitDate | date:'yyyy-MM-ddTHH:mm:ss'}}</td>
         <td class="border" style="white-space: pre-line">{{v.description}}</td>
         <!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.*;
@@ -63,8 +64,34 @@ class VisitsServiceClientIntegrationTest {
 
     @Test
     void getAllVisits() throws JsonProcessingException {
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
-        VisitResponseDTO visitResponseDTO2 = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .petName("YourPetNameHere")
+                .petBirthDate(new Date())
+                .practitionerId("2")
+                .vetFirstName("VetFirstNameHere")
+                .vetLastName("VetLastNameHere")
+                .vetEmail("vet@email.com")
+                .vetPhoneNumber("123-456-7890")
+                .status(Status.UPCOMING)
+                .build();
+        VisitResponseDTO visitResponseDTO2 = VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .petName("YourPetNameHere")
+                .petBirthDate(new Date())
+                .practitionerId("2")
+                .vetFirstName("VetFirstNameHere")
+                .vetLastName("VetLastNameHere")
+                .vetEmail("vet@email.com")
+                .vetPhoneNumber("123-456-7890")
+                .status(Status.UPCOMING)
+                .build();
         server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .setBody(objectMapper.writeValueAsString(Arrays.asList(visitResponseDTO, visitResponseDTO2))).addHeader("Content-Type", "application/json"));
 
@@ -93,7 +120,20 @@ class VisitsServiceClientIntegrationTest {
 
     @Test
     void getVisitsForStatus() throws JsonProcessingException{
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .petName("YourPetNameHere")
+                .petBirthDate(new Date())
+                .practitionerId("2")
+                .vetFirstName("VetFirstNameHere")
+                .vetLastName("VetLastNameHere")
+                .vetEmail("vet@email.com")
+                .vetPhoneNumber("123-456-7890")
+                .status(Status.UPCOMING)
+                .build();
         server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .setBody(objectMapper.writeValueAsString(visitResponseDTO)).addHeader("Content-Type", "application/json"));
 
@@ -114,14 +154,20 @@ class VisitsServiceClientIntegrationTest {
         );
 
         // Mock the server response
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO(
-                "73b5c112-5703-4fb7-b7bc-ac8186811ae1",
-                LocalDateTime.parse("2024-11-25 14:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
-                "Test Visit",
-                "1",
-                "2",
-                Status.UPCOMING
-        );
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .petName("YourPetNameHere")
+                .petBirthDate(new Date())
+                .practitionerId("2")
+                .vetFirstName("VetFirstNameHere")
+                .vetLastName("VetLastNameHere")
+                .vetEmail("vet@email.com")
+                .vetPhoneNumber("123-456-7890")
+                .status(Status.UPCOMING)
+                .build();
         server.enqueue(new MockResponse()
                 .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .setBody(objectMapper.writeValueAsString(visitResponseDTO))
@@ -248,7 +294,20 @@ class VisitsServiceClientIntegrationTest {
 
     @Test
     void getVisitsForPet() throws Exception {
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .petName("YourPetNameHere")
+                .petBirthDate(new Date())
+                .practitionerId("2")
+                .vetFirstName("VetFirstNameHere")
+                .vetLastName("VetLastNameHere")
+                .vetEmail("vet@email.com")
+                .vetPhoneNumber("123-456-7890")
+                .status(Status.UPCOMING)
+                .build();
         server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE).setBody(objectMapper.writeValueAsString(visitResponseDTO)).addHeader("Content-Type", "application/json"));
 
         Flux<VisitResponseDTO> visits = visitsServiceClient.getVisitsForPet("2");
@@ -258,7 +317,21 @@ class VisitsServiceClientIntegrationTest {
     }
     @Test
     void getVisitById() throws Exception {
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee", LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .petName("YourPetNameHere")  
+                .petBirthDate(new Date())
+                .practitionerId("2")
+                .vetFirstName("VetFirstNameHere")
+                .vetLastName("VetLastNameHere")
+                .vetEmail("vet@email.com")
+                .vetPhoneNumber("123-456-7890")
+                .status(Status.UPCOMING)
+                .build();
+
         server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE).setBody(objectMapper.writeValueAsString(visitResponseDTO)).addHeader("Content-Type", "application/json"));
 
         Mono<VisitResponseDTO> visitResponseDTOMono = visitsServiceClient.getVisitByVisitId("773fa7b2-e04e-47b8-98e7-4adf7cfaaeee");

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -2288,8 +2288,34 @@ class ApiGatewayControllerTest {
     }
     @Test
     void shouldGetAllVisits() {
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
-        VisitResponseDTO visitResponseDTO2 = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .petName("YourPetNameHere")
+                .petBirthDate(new Date())
+                .practitionerId("2")
+                .vetFirstName("VetFirstNameHere")
+                .vetLastName("VetLastNameHere")
+                .vetEmail("vet@email.com")
+                .vetPhoneNumber("123-456-7890")
+                .status(Status.UPCOMING)
+                .build();
+        VisitResponseDTO visitResponseDTO2 = VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .petName("YourPetNameHere")
+                .petBirthDate(new Date())
+                .practitionerId("2")
+                .vetFirstName("VetFirstNameHere")
+                .vetLastName("VetLastNameHere")
+                .vetEmail("vet@email.com")
+                .vetPhoneNumber("123-456-7890")
+                .status(Status.UPCOMING)
+                .build();
         when(visitsServiceClient.getAllVisits()).thenReturn(Flux.just(visitResponseDTO,visitResponseDTO2));
 
         client.get()
@@ -2337,7 +2363,20 @@ class ApiGatewayControllerTest {
     }
     @Test
     void shouldGetAVisit() {
-        VisitResponseDTO visit = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
+        VisitResponseDTO visit = VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .petName("YourPetNameHere")
+                .petBirthDate(new Date())
+                .practitionerId("2")
+                .vetFirstName("VetFirstNameHere")
+                .vetLastName("VetLastNameHere")
+                .vetEmail("vet@email.com")
+                .vetPhoneNumber("123-456-7890")
+                .status(Status.UPCOMING)
+                .build();
 
         when(visitsServiceClient.getVisitsForPet(visit.getPetId()))
                 .thenReturn(Flux.just(visit));
@@ -2421,7 +2460,20 @@ class ApiGatewayControllerTest {
 
     @Test
     void getSingleVisit_Valid() {
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO("73b5c112-5703-4fb7-b7bc-ac8186811ae1", LocalDateTime.parse("2022-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), "this is a dummy description", "2", "2", Status.UPCOMING);
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("2")
+                .petName("YourPetNameHere")
+                .petBirthDate(new Date())
+                .practitionerId("2")
+                .vetFirstName("VetFirstNameHere")
+                .vetLastName("VetLastNameHere")
+                .vetEmail("vet@email.com")
+                .vetPhoneNumber("123-456-7890")
+                .status(Status.UPCOMING)
+                .build();
         when(visitsServiceClient.getVisitByVisitId(anyString())).thenReturn(Mono.just(visitResponseDTO));
 
         client.get()
@@ -2431,7 +2483,7 @@ class ApiGatewayControllerTest {
                 .expectBody()
                 .jsonPath("$.visitId").isEqualTo(visitResponseDTO.getVisitId())
                 .jsonPath("$.petId").isEqualTo(visitResponseDTO.getPetId())
-                .jsonPath("$.visitDate").isEqualTo("2022-11-25 13:45")
+                .jsonPath("$.visitDate").isEqualTo("2024-11-25 13:45")
                 .jsonPath("$.description").isEqualTo(visitResponseDTO.getDescription())
                 .jsonPath("$.practitionerId").isEqualTo(visitResponseDTO.getPractitionerId());
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
 
     visits-service-new:
         build: visits-service-new
+        ports:
+          - "7002:8080"
         environment:
             - SPRING_PROFILES_ACTIVE=docker
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
 
     visits-service-new:
         build: visits-service-new
-        ports:
-          - "7002:8080"
         environment:
             - SPRING_PROFILES_ACTIVE=docker
         depends_on:

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
@@ -25,17 +25,18 @@ public class VisitServiceImpl implements VisitService {
     private final VisitRepo repo;
     private final VetsClient vetsClient;
     private final PetsClient petsClient;
+    private final EntityDtoUtil entityDtoUtil;
 
     @Override
     public Flux<VisitResponseDTO> getAllVisits() {
-        return repo.findAll().map(EntityDtoUtil::toVisitResponseDTO);
+        return repo.findAll().flatMap(visit -> entityDtoUtil.toVisitResponseDTO(visit));
     }
 
     @Override
     public Flux<VisitResponseDTO> getVisitsForPet(String petId) {
         return validatePetId(petId)
                 .thenMany(repo.findByPetId(petId)
-                        .map(EntityDtoUtil::toVisitResponseDTO));
+                        .flatMap(visit -> entityDtoUtil.toVisitResponseDTO(visit)));
     }
 
     @Override
@@ -56,20 +57,20 @@ public class VisitServiceImpl implements VisitService {
                 status = Status.COMPLETED;
         }
         return repo.findAllByStatus(statusString)
-                .map(EntityDtoUtil::toVisitResponseDTO);
+                .flatMap(visit -> entityDtoUtil.toVisitResponseDTO(visit));
     }
 
     @Override
     public Flux<VisitResponseDTO> getVisitsForPractitioner(String vetId) {
         return validateVetId(vetId)
                 .thenMany(repo.findVisitsByPractitionerId(vetId))
-                .map(EntityDtoUtil::toVisitResponseDTO);
+                .flatMap(visit -> entityDtoUtil.toVisitResponseDTO(visit));
     }
 
     @Override
     public Mono<VisitResponseDTO> getVisitByVisitId(String visitId) {
         return repo.findByVisitId(visitId)
-                .map(EntityDtoUtil::toVisitResponseDTO);
+                .flatMap(visit -> entityDtoUtil.toVisitResponseDTO(visit));
     }
 
     @Override
@@ -81,8 +82,8 @@ public class VisitServiceImpl implements VisitService {
                         .then(Mono.just(visitRequestDTO))
                 )
                 .doOnNext(v -> System.out.println("Request Date: " + v.getVisitDate())) // Debugging
-                .map(EntityDtoUtil::toVisitEntity)
-                .doOnNext(x -> x.setVisitId(EntityDtoUtil.generateVisitIdString()))
+                .map(visitRequestDTO -> entityDtoUtil.toVisitEntity(visitRequestDTO))
+                .doOnNext(x -> x.setVisitId(entityDtoUtil.generateVisitIdString()))
                 .doOnNext(v -> System.out.println("Entity Date: " + v.getVisitDate())) // Debugging
                 .flatMap(visit ->
                         repo.findByVisitDateAndPractitionerId(visit.getVisitDate(), visit.getPractitionerId()) // FindVisits method in repository
@@ -96,7 +97,8 @@ public class VisitServiceImpl implements VisitService {
                                     }
                                 })
                 )
-                .map(EntityDtoUtil::toVisitResponseDTO); // Convert the saved Visit entity to a DTO
+                .flatMap(visit -> entityDtoUtil.toVisitResponseDTO(visit));
+
     }
 
 
@@ -147,13 +149,13 @@ public class VisitServiceImpl implements VisitService {
                         .flatMap(visitRequestDTO -> validatePetId(visitRequestDTO.getPetId())
                                 .then(validateVetId(visitRequestDTO.getPractitionerId()))
                                 .then(Mono.just(visitRequestDTO)))
-                        .map(EntityDtoUtil::toVisitEntity)
+                        .map(visitRequestDTO -> entityDtoUtil.toVisitEntity(visitRequestDTO))
                         .doOnNext(visitEntityToUpdate -> {
                             visitEntityToUpdate.setVisitId(visitEntity.getVisitId());
                             visitEntityToUpdate.setId(visitEntity.getId());
                         }))
                 .flatMap(repo::save)
-                .map(EntityDtoUtil::toVisitResponseDTO);
+                .flatMap(visit -> entityDtoUtil.toVisitResponseDTO(visit));
     }
 
     @Override
@@ -182,7 +184,7 @@ public class VisitServiceImpl implements VisitService {
         return repo.findByVisitId(visitId)
                 .doOnNext(v -> v.setStatus(newStatus))
                 .flatMap(repo::save)
-                .map(EntityDtoUtil::toVisitResponseDTO);
+                .flatMap(visit -> entityDtoUtil.toVisitResponseDTO(visit));
     }
 
 

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
@@ -14,13 +14,13 @@ public class DataSetupService implements CommandLineRunner {
     private final VisitRepo visitRepo;
     @Override
     public void run(String... args) throws Exception {
-        Visit visit1 = buildVisit("visitId1", "2022-11-24 13:00", "this is a dummy description", "2", "69f852ca-625b-11ee-8c99-0242ac120002", Status.COMPLETED);
-        Visit visit2 = buildVisit("visitId2", "2022-03-01 13:00", "Dog Needs Meds", "1", "69f85766-625b-11ee-8c99-0242ac120002", Status.COMPLETED);
-        Visit visit3 = buildVisit("visitId3", "2020-07-19 13:00","Dog Needs Surgery After Meds", "1", "69f85bda-625b-11ee-8c99-0242ac120002", Status.COMPLETED);
-        Visit visit4 = buildVisit("visitId4", "2022-12-24 13:00", "Dog Needs Physio-Therapy", "1", "69f85d2e-625b-11ee-8c99-0242ac120002", Status.UPCOMING);
-        Visit visit5 = buildVisit("visitId5", "2023-12-24 13:00", "Cat Needs Check-Up", "4", "ac9adeb8-625b-11ee-8c99-0242ac120002", Status.UPCOMING);
-        Visit visit6 = buildVisit("visitId6", "2023-12-05 15:00", "Animal Needs Operation", "3", "ac9adeb8-625b-11ee-8c99-0242ac120002", Status.UPCOMING);
-        Visit visit7 = buildVisit("visitId7", "2022-05-20 09:00", "Cat Needs Check-Up", "4", "ac9adeb8-625b-11ee-8c99-0242ac120002", Status.CONFIRMED);
+        Visit visit1 = buildVisit("visitId1", "2022-11-24 13:00", "this is a dummy description", "ecb109cd-57ea-4b85-b51e-99751fd1c349", "69f852ca-625b-11ee-8c99-0242ac120002", Status.COMPLETED);
+        Visit visit2 = buildVisit("visitId2", "2022-03-01 13:00", "Dog Needs Meds", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85766-625b-11ee-8c99-0242ac120002", Status.COMPLETED);
+        Visit visit3 = buildVisit("visitId3", "2020-07-19 13:00","Dog Needs Surgery After Meds", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85bda-625b-11ee-8c99-0242ac120002", Status.COMPLETED);
+        Visit visit4 = buildVisit("visitId4", "2022-12-24 13:00", "Dog Needs Physio-Therapy", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85d2e-625b-11ee-8c99-0242ac120002", Status.UPCOMING);
+        Visit visit5 = buildVisit("visitId5", "2023-12-24 13:00", "Cat Needs Check-Up", "53163352-8398-4513-bdff-b7715c056d1d", "ac9adeb8-625b-11ee-8c99-0242ac120002", Status.UPCOMING);
+        Visit visit6 = buildVisit("visitId6", "2023-12-05 15:00", "Animal Needs Operation", "53163352-8398-4513-bdff-b7715c056d1d", "ac9adeb8-625b-11ee-8c99-0242ac120002", Status.UPCOMING);
+        Visit visit7 = buildVisit("visitId7", "2022-05-20 09:00", "Cat Needs Check-Up", "7056652d-f2fd-4873-a480-5d2e86bed641", "ac9adeb8-625b-11ee-8c99-0242ac120002", Status.CONFIRMED);
 
         Flux.just(visit1, visit2, visit3, visit4, visit5, visit6, visit7).flatMap(x -> visitRepo.insert(Mono.just(x)).log(x.toString())).subscribe();
     }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitResponseDTO.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitResponseDTO.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 
 @Data
 @AllArgsConstructor
@@ -18,11 +19,14 @@ public class VisitResponseDTO {
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime visitDate;
-/*   private int year;
-    private int month;
-    private int day;*/
     private String description;
     private String petId;
+    private String petName;
+    private Date petBirthDate;
     private String practitionerId;
+    private String vetFirstName;
+    private String vetLastName;
+    private String vetEmail;
+    private String vetPhoneNumber;
     private Status status;
 }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtil.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtil.java
@@ -2,30 +2,61 @@ package com.petclinic.visits.visitsservicenew.Utils;
 
 
 import com.petclinic.visits.visitsservicenew.DataLayer.Visit;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.PetResponseDTO;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.PetsClient;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetDTO;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetsClient;
 import com.petclinic.visits.visitsservicenew.PresentationLayer.VisitRequestDTO;
 import com.petclinic.visits.visitsservicenew.PresentationLayer.VisitResponseDTO;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-
+@Component
+@RequiredArgsConstructor
 public class EntityDtoUtil {
 
-    public static VisitResponseDTO toVisitResponseDTO(Visit visit) {
+    private final VetsClient vetsClient;
+    private final PetsClient petsClient;
+
+    public Mono<VisitResponseDTO> toVisitResponseDTO(Visit visit) {
         System.out.println("Entity Date in Mapping: " + visit.getVisitDate()); // Debugging
-        VisitResponseDTO visitResponseDTO = new VisitResponseDTO();
-        BeanUtils.copyProperties(visit, visitResponseDTO);
-        return visitResponseDTO;
+
+        Mono<PetResponseDTO> petResponseDTOMono = petsClient.getPetById(visit.getPetId());
+        Mono<VetDTO> vetResponseDTOMono = vetsClient.getVetByVetId(visit.getPractitionerId());
+
+        return Mono.zip(petResponseDTOMono, vetResponseDTOMono)
+                .flatMap(tuple -> {
+                    PetResponseDTO petResponseDTO = tuple.getT1();
+                    VetDTO vetResponseDTO = tuple.getT2();
+
+                    return Mono.just(VisitResponseDTO.builder()
+                            .visitId(visit.getVisitId())
+                            .visitDate(visit.getVisitDate())
+                            .description(visit.getDescription())
+                            .petId(visit.getPetId())
+                            .petName(petResponseDTO.getName())
+                            .petBirthDate(petResponseDTO.getBirthDate())
+                            .practitionerId(visit.getPractitionerId())
+                            .vetFirstName(vetResponseDTO.getFirstName())
+                            .vetLastName(vetResponseDTO.getLastName())
+                            .vetEmail(vetResponseDTO.getEmail())
+                            .vetPhoneNumber(vetResponseDTO.getPhoneNumber())
+                            .status(visit.getStatus())
+                            .build());
+                });
     }
 
-    public static Visit toVisitEntity(VisitRequestDTO visitRequestDTO){
+    public Visit toVisitEntity(VisitRequestDTO visitRequestDTO) {
         Visit visit = new Visit();
         BeanUtils.copyProperties(visitRequestDTO, visit);
         return visit;
     }
 
-    public static String generateVisitIdString(){
+    public String generateVisitIdString() {
         return UUID.randomUUID().toString();
     }
-
 }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtil.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtil.java
@@ -23,7 +23,7 @@ public class EntityDtoUtil {
     private final PetsClient petsClient;
 
     public Mono<VisitResponseDTO> toVisitResponseDTO(Visit visit) {
-        System.out.println("Entity Date in Mapping: " + visit.getVisitDate()); // Debugging
+       // System.out.println("Entity Date in Mapping: " + visit.getVisitDate()); // Debugging
 
         Mono<PetResponseDTO> petResponseDTOMono = petsClient.getPetById(visit.getPetId());
         Mono<VetDTO> vetResponseDTOMono = vetsClient.getVetByVetId(visit.getPractitionerId());

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/VisitsServiceNewApplication.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/VisitsServiceNewApplication.java
@@ -2,6 +2,8 @@ package com.petclinic.visits.visitsservicenew;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
 
 
 @SpringBootApplication

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
@@ -5,12 +5,16 @@ import com.petclinic.visits.visitsservicenew.DataLayer.Visit;
 import com.petclinic.visits.visitsservicenew.DataLayer.VisitRepo;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.*;
 import com.petclinic.visits.visitsservicenew.Exceptions.DuplicateTimeException;
+import com.petclinic.visits.visitsservicenew.Exceptions.BadRequestException;
 import com.petclinic.visits.visitsservicenew.Exceptions.NotFoundException;
 import com.petclinic.visits.visitsservicenew.PresentationLayer.VisitRequestDTO;
 import com.petclinic.visits.visitsservicenew.PresentationLayer.VisitResponseDTO;
 import com.petclinic.visits.visitsservicenew.Utils.EntityDtoUtil;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -91,8 +95,27 @@ class VisitServiceImplTest {
     Visit visit1 = buildVisit("this is a dummy description");
     Visit visit2 = buildVisit("this is a dummy description");
 
+
     @Test
-    void getVisitByVisitId(){
+    void getAllVisits() {
+        // Mock the behavior of the repository to return a Flux of visits
+        when(visitRepo.findAll()).thenReturn(Flux.just(visit1));
+
+        // Mock the behavior of entityDtoUtil to map visits to visitResponseDTO
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+
+        // Execute the method under test
+        Flux<VisitResponseDTO> result = visitService.getAllVisits();
+
+        // Verify the results using StepVerifier
+        StepVerifier.create(result)
+                .expectNext(visitResponseDTO) // Expect the mapped VisitResponseDTO
+                .expectComplete()
+                .verify();
+    }
+
+    @Test
+    void getVisitByVisitId() {
         when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
         when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
 
@@ -103,56 +126,60 @@ class VisitServiceImplTest {
                 .verify();
     }
 
+
     @Test
     void getVisitsByPractitionerId() {
         when(visitRepo.findVisitsByPractitionerId(anyString())).thenReturn(Flux.just(visit1));
         when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
         when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
         Flux<VisitResponseDTO> visitResponseDTOFlux = visitService.getVisitsForPractitioner(PRAC_ID);
-        ;
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+            // Mock the response from your repository (assuming you have a valid visit)
+            when(visitRepo.findVisitsByPractitionerId(vet.getVetId()))
+                    .thenReturn(Flux.just(visit1));
 
-        StepVerifier
-                .create(visitResponseDTOFlux)
-                .consumeNextWith(foundVisit -> {
-                    assertEquals(visit1.getVisitId(), foundVisit.getVisitId());
-                    assertEquals(visit1.getVisitDate(), foundVisit.getVisitDate());
-                    assertEquals(visit1.getDescription(), foundVisit.getDescription());
-                    assertEquals(visit1.getPetId(), foundVisit.getPetId());
-                    assertEquals(visit1.getPractitionerId(), foundVisit.getPractitionerId());
-                }).verifyComplete();
-    }
+            // Execute the method under test
+            StepVerifier.create(visitService.getVisitsForPractitioner(vet.getVetId()))
+                    .expectNextMatches(visitDTO -> visitDTO.getVisitId().equals(visit1.getVisitId()))
+                    .expectComplete()
+                    .verify();
+        }
 
-    @Test
-    public void getVisitsForPet() {
-        // Arrange
-        String petId = "yourPetId";
-        Visit visit1 = buildVisit( "Visit Description");
-        VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+        @Test
+        public void getVisitsForPet () {
+            // Arrange
+            String petId = "yourPetId";
 
-        // Mock the behavior of dependencies
-        when(visitRepo.findByPetId(petId)).thenReturn(Flux.just(visit1));
-        when(entityDtoUtil.toVisitResponseDTO(visit1)).thenReturn(Mono.just(visitResponseDTO));
-        when(petsClient.getPetById(petId)).thenReturn(Mono.just(petResponseDTO));
-        // Act
-        Flux<VisitResponseDTO> result = visitService.getVisitsForPet(petId);
+            Visit visit1 = buildVisit("Visit Description");
 
-        // Assert
-        StepVerifier.create(result)
-                .expectNext(visitResponseDTO)
-                .verifyComplete();
-    }
+            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
 
-    @Test
-    void getVisitsForStatus(){
-        when(visitRepo.findAllByStatus(anyString())).thenReturn(Flux.just(visit1));
-        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+            // Mock the behavior of dependencies
+            when(visitRepo.findByPetId(petId)).thenReturn(Flux.just(visit1));
+            when(entityDtoUtil.toVisitResponseDTO(visit1)).thenReturn(Mono.just(visitResponseDTO));
+            when(petsClient.getPetById(petId)).thenReturn(Mono.just(petResponseDTO));
+            // Act
+            Flux<VisitResponseDTO> result = visitService.getVisitsForPet(petId);
+
+            // Assert
+            StepVerifier.create(result)
+                    .expectNext(visitResponseDTO)
+                    .verifyComplete();
+        }
+
+        @Test
+        void getVisitsForStatus () {
+            when(visitRepo.findAllByStatus(anyString())).thenReturn(Flux.just(visit1));
+            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
 
 
-        StepVerifier.create(visitService.getVisitsForStatus(visitResponseDTO.getStatus().toString()))
-                .expectNextMatches(visitDTO -> visitDTO.getVisitId().equals(visit1.getVisitId()))
-                .expectComplete()
-                .verify();
-    }
+            StepVerifier.create(visitService.getVisitsForStatus(visitResponseDTO.getStatus().toString()))
+                    .expectNextMatches(visitDTO -> visitDTO.getVisitId().equals(visit1.getVisitId()))
+                    .expectComplete()
+                    .verify();
+        }
     /*
     @Test
     void getVisitsByPractitionerIdAndMonth(){
@@ -190,32 +217,34 @@ class VisitServiceImplTest {
                 }).verifyComplete();
     }*/
 
-    @Test
-            void addVisit() {
-        // Arrange
-        when(visitRepo.insert(any(Visit.class))).thenReturn(Mono.just(visit1));
-        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-        // This line ensures that a Flux<Visit> is returned, even if it's empty, to prevent NullPointerException
-        when(visitRepo.findByVisitDateAndPractitionerId(any(LocalDateTime.class), anyString())).thenReturn(Flux.empty());
-        when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
-        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-        when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
-        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-        // Act and Assert
-        StepVerifier.create(visitService.addVisit(Mono.just(visitRequestDTO)))
-                .consumeNextWith(visitDTO1 -> {
-                    assertEquals(visit1.getDescription(), visitDTO1.getDescription());
-                    assertEquals(visit1.getPetId(), visitDTO1.getPetId());
-                    assertEquals(visit1.getVisitDate(), visitDTO1.getVisitDate());
-                    assertEquals(visitResponseDTO.getPractitionerId(), visitDTO1.getPractitionerId());
-                }).verifyComplete();
+        @Test
+        void addVisit () {
+            // Arrange
+            when(visitRepo.insert(any(Visit.class))).thenReturn(Mono.just(visit1));
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            // This line ensures that a Flux<Visit> is returned, even if it's empty, to prevent NullPointerException
+            when(visitRepo.findByVisitDateAndPractitionerId(any(LocalDateTime.class), anyString())).thenReturn(Flux.empty());
+            when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
 
-        // Verify that the methods were called with the expected arguments
-        verify(visitRepo, times(1)).insert(any(Visit.class));
-        verify(petsClient, times(1)).getPetById(anyString());
-        verify(vetsClient, times(1)).getVetByVetId(anyString());
-        verify(visitRepo, times(1)).findByVisitDateAndPractitionerId(any(LocalDateTime.class), anyString());
+
+            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+            when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
+            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+            // Act and Assert
+            StepVerifier.create(visitService.addVisit(Mono.just(visitRequestDTO)))
+                    .consumeNextWith(visitDTO1 -> {
+                        assertEquals(visit1.getDescription(), visitDTO1.getDescription());
+                        assertEquals(visit1.getPetId(), visitDTO1.getPetId());
+                        assertEquals(visit1.getVisitDate(), visitDTO1.getVisitDate());
+                        assertEquals(visitResponseDTO.getPractitionerId(), visitDTO1.getPractitionerId());
+                    }).verifyComplete();
+
+            // Verify that the methods were called with the expected arguments
+            verify(visitRepo, times(1)).insert(any(Visit.class));
+            verify(petsClient, times(1)).getPetById(anyString());
+            verify(vetsClient, times(1)).getVetByVetId(anyString());
+            verify(visitRepo, times(1)).findByVisitDateAndPractitionerId(any(LocalDateTime.class), anyString());
         }
 
         @Test
@@ -261,125 +290,300 @@ class VisitServiceImplTest {
         }
 
         @Test
-        void addVisit_ConflictingVisits_ThrowsDuplicateTimeException() {
-        // Arrange
-        LocalDateTime visitDate = LocalDateTime.now().plusDays(1);
-        String description = "Test Description";
-        String petId = "TestId";
-        String practitionerId = "TestPractitionerId";
-        Status status = Status.UPCOMING;
+        void addVisit_ConflictingVisits_ThrowsDuplicateTimeException () {
+            // Arrange
+            LocalDateTime visitDate = LocalDateTime.now().plusDays(1);
+            String description = "Test Description";
+            String petId = "TestId";
+            String practitionerId = "TestPractitionerId";
+            Status status = Status.UPCOMING;
 
-        VisitRequestDTO visitRequestDTO = new VisitRequestDTO();
-        visitRequestDTO.setVisitDate(visitDate);
-        visitRequestDTO.setDescription(description);
-        visitRequestDTO.setPetId(petId);
-        visitRequestDTO.setPractitionerId(practitionerId);
-        visitRequestDTO.setStatus(status);
+            VisitRequestDTO visitRequestDTO = new VisitRequestDTO();
+            visitRequestDTO.setVisitDate(visitDate);
+            visitRequestDTO.setDescription(description);
+            visitRequestDTO.setPetId(petId);
+            visitRequestDTO.setPractitionerId(practitionerId);
+            visitRequestDTO.setStatus(status);
 
-        // Create an instance of existingVisit with required properties
-        Visit existingVisit = buildVisit("meow");
-        existingVisit.setVisitDate(visitDate); // Set the visit date to match the new request
-        existingVisit.setPractitionerId(practitionerId); // Set the practitioner ID to match the new request
-
-
-        PetResponseDTO mockPetResponse = new PetResponseDTO(); // Adjust as necessary
-        VetDTO mockVetResponse = new VetDTO(); // Create a mock VetDTO, set any necessary fields if required
-
-        // Mock the behavior of the repository and clients
-        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(mockPetResponse));
-        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(mockVetResponse)); // This ensures a non-null Mono is returned
-        // Mock the behavior of the repository and clients
-        when(visitRepo.findByVisitDateAndPractitionerId(any(), any()))
-                .thenReturn(Flux.just(existingVisit)); // Return the existingVisit in case of conflict
-        when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
-        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-        when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
-        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));// This simulates finding a conflicting visit
-        // Other mocks remain the same if they are needed for this test scenario
-
-        // Act
-        Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(visitRequestDTO));
-
-        // Assert
-        StepVerifier.create(result)
-                .expectErrorMatches(throwable -> throwable instanceof DuplicateTimeException
-                        && throwable.getMessage().contains("A visit with the same time and practitioner already exists."))
-                .verify();
-
-        // Ensure no attempt was made to insert a new visit due to the conflict
-        verify(visitRepo, times(0)).insert(any(Visit.class));
-    }
-    @Test
-    void updateStatusForVisitByVisitId_COMPLETED(){
-        String status = "COMPLETED";
-
-        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
-        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
-        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-
-        Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(),status);
-
-        StepVerifier.create(result)
-                .expectNext(visitResponseDTO)
-                .verifyComplete();
-    }
-    @Test
-    void updateStatusForVisitByVisitId_CANCELLED(){
-        String status = "CANCELLED";
-
-        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
-        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
-        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-
-        Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(),status);
-
-        StepVerifier.create(result)
-                .expectNext(visitResponseDTO)
-                .verifyComplete();
-    }
-    @Test
-    void updateStatusForVisitByVisitId_UPCOMING(){
-        String status = "UPCOMING";
-
-        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
-        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
-        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-
-        Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(),status);
-
-        StepVerifier.create(result)
-                .expectNext(visitResponseDTO)
-                .verifyComplete();
-    }
-    @Test
-    void updateVisit() {
-
-        Mono<VisitRequestDTO> visitRequestDTOMono = buildRequestDtoMono();
-
-        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
-        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
-        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-        when(entityDtoUtil.toVisitResponseDTO(visit1)).thenReturn(Mono.just(visitResponseDTO));
-        when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
-        Mono<VisitResponseDTO> result = visitService.updateVisit(visitResponseDTO.getVisitId(),visitRequestDTOMono);
-        // Execute the method under test
-        StepVerifier.create(result)
-                .expectNext(visitResponseDTO)
-                .verifyComplete();
-    }
+            // Create an instance of existingVisit with required properties
+            Visit existingVisit = buildVisit("meow");
+            existingVisit.setVisitDate(visitDate); // Set the visit date to match the new request
+            existingVisit.setPractitionerId(practitionerId); // Set the practitioner ID to match the new request
 
 
-    @Test
+            PetResponseDTO mockPetResponse = new PetResponseDTO(); // Adjust as necessary
+            VetDTO mockVetResponse = new VetDTO(); // Create a mock VetDTO, set any necessary fields if required
+
+            // Mock the behavior of the repository and clients
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(mockPetResponse));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(mockVetResponse)); // This ensures a non-null Mono is returned
+            // Mock the behavior of the repository and clients
+            when(visitRepo.findByVisitDateAndPractitionerId(any(), any()))
+                    .thenReturn(Flux.just(existingVisit)); // Return the existingVisit in case of conflict
+            when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
+            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+            when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
+            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));// This simulates finding a conflicting visit
+            // Other mocks remain the same if they are needed for this test scenario
+
+            // Act
+            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(visitRequestDTO));
+
+            // Assert
+            StepVerifier.create(result)
+                    .expectErrorMatches(throwable -> throwable instanceof DuplicateTimeException
+                            && throwable.getMessage().contains("A visit with the same time and practitioner already exists."))
+                    .verify();
+
+            // Ensure no attempt was made to insert a new visit due to the conflict
+            verify(visitRepo, times(0)).insert(any(Visit.class));
+        }
+
+        @Test
+        public void testAddVisit_NoDescription () {
+            // Arrange
+            VisitRequestDTO requestDTO = buildVisitRequestDTO();
+            Visit visit = buildVisit(requestDTO.getDescription());
+            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+            requestDTO.setDescription(null);
+            // Mock the behavior of dependencies
+
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+            // Act
+            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+            // Assert
+            StepVerifier.create(result)
+                    .expectError(BadRequestException.class)
+                    .verify();
+        }
+        @Test
+        public void testAddVisit_BadVisitDate () {
+            // Arrange
+            VisitRequestDTO requestDTO = buildVisitRequestDTO();
+            Visit visit = buildVisit(requestDTO.getDescription());
+            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+            requestDTO.setVisitDate(null);
+            // Mock the behavior of dependencies
+
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+            // Act
+            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+            // Assert
+            StepVerifier.create(result)
+                    .expectError(BadRequestException.class)
+                    .verify();
+        }
+        @Test
+        public void testAddVisit_DateInThePast () {
+            // Arrange
+            VisitRequestDTO requestDTO = buildVisitRequestDTO();
+            Visit visit = buildVisit(requestDTO.getDescription());
+            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+            requestDTO.setVisitDate(LocalDateTime.parse("2023-10-12T14:30"));
+
+            // Mock the behavior of dependencies
+
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+            // Act
+            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+            // Assert
+            StepVerifier.create(result)
+                    .expectError(BadRequestException.class)
+                    .verify();
+        }
+
+        @Test
+        public void testAddVisit_PetIdNull () {
+            // Arrange
+            VisitRequestDTO requestDTO = buildVisitRequestDTO();
+            Visit visit = buildVisit(requestDTO.getDescription());
+            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+            requestDTO.setPetId("");
+
+            // Mock the behavior of dependencies
+
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+            // Act
+            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+            // Assert
+            StepVerifier.create(result)
+                    .expectError(BadRequestException.class)
+                    .verify();
+        }
+
+        @Test
+        public void testAddVisit_VetIdNull () {
+            // Arrange
+            VisitRequestDTO requestDTO = buildVisitRequestDTO();
+            Visit visit = buildVisit(requestDTO.getDescription());
+            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+            requestDTO.setPractitionerId("");
+
+            // Mock the behavior of dependencies
+
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+            // Act
+            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+            // Assert
+            StepVerifier.create(result)
+                    .expectError(BadRequestException.class)
+                    .verify();
+        }
+
+        @Test
+        public void testAddVisit_BadStatus() {
+            // Arrange
+            VisitRequestDTO requestDTO = buildVisitRequestDTO();
+            Visit visit = buildVisit(requestDTO.getDescription());
+            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+            requestDTO.setStatus(Status.CANCELLED);
+
+            // Mock the behavior of dependencies
+
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+            // Act
+            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+            // Assert
+            StepVerifier.create(result)
+                    .expectError(BadRequestException.class)
+                    .verify();
+        }
+
+        @Test
+        void updateStatusForVisitByVisitId_CONFIRMED() {
+            String status = "CONFIRMED";
+
+            when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+            when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+
+            Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
+
+            StepVerifier.create(result)
+                    .expectNext(visitResponseDTO)
+                    .verifyComplete();
+        }
+
+        @Test
+        void updateStatusForVisitByVisitId_COMPLETED() {
+            String status = "COMPLETED";
+
+            when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+            when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+
+            Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
+
+            StepVerifier.create(result)
+                    .expectNext(visitResponseDTO)
+                    .verifyComplete();
+        }
+        @Test
+        void updateStatusForVisitByVisitId_CANCELLED() {
+            String status = "CANCELLED";
+
+            when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+            when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+
+            Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
+
+            StepVerifier.create(result)
+                    .expectNext(visitResponseDTO)
+                    .verifyComplete();
+        }
+        @Test
+        void updateStatusForVisitByVisitId_UPCOMING() {
+            String status = "UPCOMING";
+
+            when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+            when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+
+            Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
+
+            StepVerifier.create(result)
+                    .expectNext(visitResponseDTO)
+                    .verifyComplete();
+        }
+        @Test
+        void updateVisit() {
+
+            Mono<VisitRequestDTO> visitRequestDTOMono = buildRequestDtoMono();
+
+            when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+            when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+            when(entityDtoUtil.toVisitResponseDTO(visit1)).thenReturn(Mono.just(visitResponseDTO));
+            when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
+            Mono<VisitResponseDTO> result = visitService.updateVisit(visitResponseDTO.getVisitId(), visitRequestDTOMono);
+            // Execute the method under test
+            StepVerifier.create(result)
+                    .expectNext(visitResponseDTO)
+                    .verifyComplete();
+        }
+
+        @Test
         void deleteVisitById_visitId_shouldSucceed () {
             //arrange
-            String visitId = UUID.randomUUID().toString();
+            String visitId = "73b5c112-5703-4fb7-b7bc-ac8186811ae1";
 
             Mockito.when(visitRepo.existsByVisitId(visitId)).thenReturn(Mono.just(true));
             Mockito.when(visitRepo.deleteByVisitId(visitId)).thenReturn(Mono.empty());
@@ -421,8 +625,8 @@ class VisitServiceImplTest {
             // Arrange
 
             List<Visit> cancelledVisits = new ArrayList<>();
-            cancelledVisits.add(buildVisit( "Cat is sick"));
-            cancelledVisits.add(buildVisit( "Cat is sick"));
+            cancelledVisits.add(buildVisit("Cat is sick"));
+            cancelledVisits.add(buildVisit("Cat is sick"));
             cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set statuses to CANCELLED
 
             Mockito.when(visitRepo.findAllByStatus("CANCELLED")).thenReturn(Flux.fromIterable(cancelledVisits));
@@ -439,14 +643,14 @@ class VisitServiceImplTest {
             Mockito.verify(visitRepo, Mockito.times(1)).deleteAll(cancelledVisits);
         }
 
+
         @Test
         void deleteAllCanceledVisits_shouldThrowRuntimeException () {
             // Arrange
             List<Visit> cancelledVisits = new ArrayList<>();
-            cancelledVisits.add(buildVisit( "Cat is sick"));
-            cancelledVisits.add(buildVisit( "Cat is sick"));
+            cancelledVisits.add(buildVisit("Cat is sick"));
+            cancelledVisits.add(buildVisit("Cat is sick"));
             cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set statuses to CANCELLED
-
             Mockito.when(visitRepo.findAllByStatus("CANCELLED")).thenReturn(Flux.fromIterable(cancelledVisits));
             Mockito.when(visitRepo.deleteAll(cancelledVisits)).thenReturn(Mono.error(new RuntimeException("Failed to delete visits")));
 
@@ -462,16 +666,17 @@ class VisitServiceImplTest {
             Mockito.verify(visitRepo, Mockito.times(1)).deleteAll(cancelledVisits);
         }
 
-    private Visit buildVisit(String description){
-        return Visit.builder()
-                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
-                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
-                .description(description)
-                .petId("ecb109cd-57ea-4b85-b51e-99751fd1c349")
-                .practitionerId("ecb109cd-57ea-4b85-b51e-99751fd1c342")
-                .status(Status.UPCOMING)
-                .build();
-    }
+
+        private Visit buildVisit (String description){
+            return Visit.builder()
+                    .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                    .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                    .description(description)
+                    .petId("ecb109cd-57ea-4b85-b51e-99751fd1c349")
+                    .practitionerId("ecb109cd-57ea-4b85-b51e-99751fd1c342")
+                    .status(Status.UPCOMING)
+                    .build();
+        }
         private VisitResponseDTO buildVisitResponseDTO () {
             return VisitResponseDTO.builder()
                     .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
@@ -492,10 +697,14 @@ class VisitServiceImplTest {
                     .build();
         }
 
-    private Mono<VisitRequestDTO> buildRequestDtoMono() {
-        VisitRequestDTO requestDTO = buildVisitRequestDTO();
-        return Mono.just(requestDTO);
-    }
+        private Mono<VisitRequestDTO> buildRequestDtoMono () {
+            VisitRequestDTO requestDTO = buildVisitRequestDTO();
+            return Mono.just(requestDTO);
+        }
+
 
     }
+
+
+
 

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
@@ -133,53 +133,53 @@ class VisitServiceImplTest {
         when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
         when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
         Flux<VisitResponseDTO> visitResponseDTOFlux = visitService.getVisitsForPractitioner(PRAC_ID);
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-            // Mock the response from your repository (assuming you have a valid visit)
-            when(visitRepo.findVisitsByPractitionerId(vet.getVetId()))
-                    .thenReturn(Flux.just(visit1));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+        // Mock the response from your repository (assuming you have a valid visit)
+        when(visitRepo.findVisitsByPractitionerId(vet.getVetId()))
+                .thenReturn(Flux.just(visit1));
 
-            // Execute the method under test
-            StepVerifier.create(visitService.getVisitsForPractitioner(vet.getVetId()))
-                    .expectNextMatches(visitDTO -> visitDTO.getVisitId().equals(visit1.getVisitId()))
-                    .expectComplete()
-                    .verify();
-        }
+        // Execute the method under test
+        StepVerifier.create(visitService.getVisitsForPractitioner(vet.getVetId()))
+                .expectNextMatches(visitDTO -> visitDTO.getVisitId().equals(visit1.getVisitId()))
+                .expectComplete()
+                .verify();
+    }
 
-        @Test
-        public void getVisitsForPet () {
-            // Arrange
-            String petId = "yourPetId";
+    @Test
+    public void getVisitsForPet () {
+        // Arrange
+        String petId = "yourPetId";
 
-            Visit visit1 = buildVisit("Visit Description");
+        Visit visit1 = buildVisit("Visit Description");
 
-            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+        VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
 
-            // Mock the behavior of dependencies
-            when(visitRepo.findByPetId(petId)).thenReturn(Flux.just(visit1));
-            when(entityDtoUtil.toVisitResponseDTO(visit1)).thenReturn(Mono.just(visitResponseDTO));
-            when(petsClient.getPetById(petId)).thenReturn(Mono.just(petResponseDTO));
-            // Act
-            Flux<VisitResponseDTO> result = visitService.getVisitsForPet(petId);
+        // Mock the behavior of dependencies
+        when(visitRepo.findByPetId(petId)).thenReturn(Flux.just(visit1));
+        when(entityDtoUtil.toVisitResponseDTO(visit1)).thenReturn(Mono.just(visitResponseDTO));
+        when(petsClient.getPetById(petId)).thenReturn(Mono.just(petResponseDTO));
+        // Act
+        Flux<VisitResponseDTO> result = visitService.getVisitsForPet(petId);
 
-            // Assert
-            StepVerifier.create(result)
-                    .expectNext(visitResponseDTO)
-                    .verifyComplete();
-        }
+        // Assert
+        StepVerifier.create(result)
+                .expectNext(visitResponseDTO)
+                .verifyComplete();
+    }
 
-        @Test
-        void getVisitsForStatus () {
-            when(visitRepo.findAllByStatus(anyString())).thenReturn(Flux.just(visit1));
-            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+    @Test
+    void getVisitsForStatus () {
+        when(visitRepo.findAllByStatus(anyString())).thenReturn(Flux.just(visit1));
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
 
 
-            StepVerifier.create(visitService.getVisitsForStatus(visitResponseDTO.getStatus().toString()))
-                    .expectNextMatches(visitDTO -> visitDTO.getVisitId().equals(visit1.getVisitId()))
-                    .expectComplete()
-                    .verify();
-        }
+        StepVerifier.create(visitService.getVisitsForStatus(visitResponseDTO.getStatus().toString()))
+                .expectNextMatches(visitDTO -> visitDTO.getVisitId().equals(visit1.getVisitId()))
+                .expectComplete()
+                .verify();
+    }
     /*
     @Test
     void getVisitsByPractitionerIdAndMonth(){
@@ -217,493 +217,493 @@ class VisitServiceImplTest {
                 }).verifyComplete();
     }*/
 
-        @Test
-        void addVisit () {
-            // Arrange
-            when(visitRepo.insert(any(Visit.class))).thenReturn(Mono.just(visit1));
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            // This line ensures that a Flux<Visit> is returned, even if it's empty, to prevent NullPointerException
-            when(visitRepo.findByVisitDateAndPractitionerId(any(LocalDateTime.class), anyString())).thenReturn(Flux.empty());
-            when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
-
-
-            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-            when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
-            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-            // Act and Assert
-            StepVerifier.create(visitService.addVisit(Mono.just(visitRequestDTO)))
-                    .consumeNextWith(visitDTO1 -> {
-                        assertEquals(visit1.getDescription(), visitDTO1.getDescription());
-                        assertEquals(visit1.getPetId(), visitDTO1.getPetId());
-                        assertEquals(visit1.getVisitDate(), visitDTO1.getVisitDate());
-                        assertEquals(visitResponseDTO.getPractitionerId(), visitDTO1.getPractitionerId());
-                    }).verifyComplete();
-
-            // Verify that the methods were called with the expected arguments
-            verify(visitRepo, times(1)).insert(any(Visit.class));
-            verify(petsClient, times(1)).getPetById(anyString());
-            verify(vetsClient, times(1)).getVetByVetId(anyString());
-            verify(visitRepo, times(1)).findByVisitDateAndPractitionerId(any(LocalDateTime.class), anyString());
-        }
-
-        @Test
-        void addVisit_NoConflictingVisits_InsertsNewVisit () {
-            // Arrange
-            LocalDateTime visitDate = LocalDateTime.now().plusDays(1);
-            String description = "Test Description";
-            String petId = "TestId";
-            String practitionerId = "TestPractitionerId";
-            Status status = Status.UPCOMING;
-
-            VisitRequestDTO visitRequestDTO = new VisitRequestDTO();
-            // Assuming VisitRequestDTO has setters if the constructor is not available
-            visitRequestDTO.setVisitDate(visitDate);
-            visitRequestDTO.setDescription(description);
-            visitRequestDTO.setPetId(petId);
-            visitRequestDTO.setPractitionerId(practitionerId);
-            visitRequestDTO.setStatus(status);
-
-            Visit visit = new Visit(); // Create a Visit entity with appropriate data
-            VisitResponseDTO visitResponseDTO = new VisitResponseDTO(); // Create a VisitResponseDTO with appropriate data
-
-            // Mock the behavior of the methods
-            when(visitRepo.insert(any(Visit.class))).thenReturn(Mono.just(visit));
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(new PetResponseDTO()));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(new VetDTO()));
-            when(visitRepo.findByVisitDateAndPractitionerId(any(LocalDateTime.class), anyString())).thenReturn(Flux.empty());
-            when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
-            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-            when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
-            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-            //when(EntityDtoUtil.toVisitResponseDTO(any(Visit.class))).thenReturn(visitResponseDTO); // Correct this line if toVisitResponseDTO is not a static method or if there's a compilation issue
-
-            // Act
-            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(visitRequestDTO));
-
-            // Assert
-            StepVerifier.create(result)
-                    .expectNextMatches(response -> response.equals(visitResponseDTO))
-                    .verifyComplete();
-
-            verify(visitRepo, times(1)).insert(any(Visit.class));
-        }
-
-        @Test
-        void addVisit_ConflictingVisits_ThrowsDuplicateTimeException () {
-            // Arrange
-            LocalDateTime visitDate = LocalDateTime.now().plusDays(1);
-            String description = "Test Description";
-            String petId = "TestId";
-            String practitionerId = "TestPractitionerId";
-            Status status = Status.UPCOMING;
-
-            VisitRequestDTO visitRequestDTO = new VisitRequestDTO();
-            visitRequestDTO.setVisitDate(visitDate);
-            visitRequestDTO.setDescription(description);
-            visitRequestDTO.setPetId(petId);
-            visitRequestDTO.setPractitionerId(practitionerId);
-            visitRequestDTO.setStatus(status);
-
-            // Create an instance of existingVisit with required properties
-            Visit existingVisit = buildVisit("meow");
-            existingVisit.setVisitDate(visitDate); // Set the visit date to match the new request
-            existingVisit.setPractitionerId(practitionerId); // Set the practitioner ID to match the new request
-
-
-            PetResponseDTO mockPetResponse = new PetResponseDTO(); // Adjust as necessary
-            VetDTO mockVetResponse = new VetDTO(); // Create a mock VetDTO, set any necessary fields if required
-
-            // Mock the behavior of the repository and clients
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(mockPetResponse));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(mockVetResponse)); // This ensures a non-null Mono is returned
-            // Mock the behavior of the repository and clients
-            when(visitRepo.findByVisitDateAndPractitionerId(any(), any()))
-                    .thenReturn(Flux.just(existingVisit)); // Return the existingVisit in case of conflict
-            when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
-            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-            when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
-            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));// This simulates finding a conflicting visit
-            // Other mocks remain the same if they are needed for this test scenario
-
-            // Act
-            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(visitRequestDTO));
-
-            // Assert
-            StepVerifier.create(result)
-                    .expectErrorMatches(throwable -> throwable instanceof DuplicateTimeException
-                            && throwable.getMessage().contains("A visit with the same time and practitioner already exists."))
-                    .verify();
-
-            // Ensure no attempt was made to insert a new visit due to the conflict
-            verify(visitRepo, times(0)).insert(any(Visit.class));
-        }
-
-        @Test
-        public void testAddVisit_NoDescription () {
-            // Arrange
-            VisitRequestDTO requestDTO = buildVisitRequestDTO();
-            Visit visit = buildVisit(requestDTO.getDescription());
-            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
-
-            requestDTO.setDescription(null);
-            // Mock the behavior of dependencies
-
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
-            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
-            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
-
-            // Act
-            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
-
-            // Assert
-            StepVerifier.create(result)
-                    .expectError(BadRequestException.class)
-                    .verify();
-        }
-        @Test
-        public void testAddVisit_BadVisitDate () {
-            // Arrange
-            VisitRequestDTO requestDTO = buildVisitRequestDTO();
-            Visit visit = buildVisit(requestDTO.getDescription());
-            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
-
-            requestDTO.setVisitDate(null);
-            // Mock the behavior of dependencies
-
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
-            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
-            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
-
-            // Act
-            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
-
-            // Assert
-            StepVerifier.create(result)
-                    .expectError(BadRequestException.class)
-                    .verify();
-        }
-        @Test
-        public void testAddVisit_DateInThePast () {
-            // Arrange
-            VisitRequestDTO requestDTO = buildVisitRequestDTO();
-            Visit visit = buildVisit(requestDTO.getDescription());
-            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
-
-            requestDTO.setVisitDate(LocalDateTime.parse("2023-10-12T14:30"));
-
-            // Mock the behavior of dependencies
-
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
-            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
-            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
-
-            // Act
-            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
-
-            // Assert
-            StepVerifier.create(result)
-                    .expectError(BadRequestException.class)
-                    .verify();
-        }
-
-        @Test
-        public void testAddVisit_PetIdNull () {
-            // Arrange
-            VisitRequestDTO requestDTO = buildVisitRequestDTO();
-            Visit visit = buildVisit(requestDTO.getDescription());
-            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
-
-            requestDTO.setPetId("");
-
-            // Mock the behavior of dependencies
-
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
-            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
-            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
-
-            // Act
-            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
-
-            // Assert
-            StepVerifier.create(result)
-                    .expectError(BadRequestException.class)
-                    .verify();
-        }
-
-        @Test
-        public void testAddVisit_VetIdNull () {
-            // Arrange
-            VisitRequestDTO requestDTO = buildVisitRequestDTO();
-            Visit visit = buildVisit(requestDTO.getDescription());
-            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
-
-            requestDTO.setPractitionerId("");
-
-            // Mock the behavior of dependencies
-
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
-            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
-            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
-
-            // Act
-            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
-
-            // Assert
-            StepVerifier.create(result)
-                    .expectError(BadRequestException.class)
-                    .verify();
-        }
-
-        @Test
-        public void testAddVisit_BadStatus() {
-            // Arrange
-            VisitRequestDTO requestDTO = buildVisitRequestDTO();
-            Visit visit = buildVisit(requestDTO.getDescription());
-            VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
-
-            requestDTO.setStatus(Status.CANCELLED);
-
-            // Mock the behavior of dependencies
-
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
-            when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
-            when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
-            when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
-
-            // Act
-            Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
-
-            // Assert
-            StepVerifier.create(result)
-                    .expectError(BadRequestException.class)
-                    .verify();
-        }
-
-        @Test
-        void updateStatusForVisitByVisitId_CONFIRMED() {
-            String status = "CONFIRMED";
-
-            when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
-            when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-
-            Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
-
-            StepVerifier.create(result)
-                    .expectNext(visitResponseDTO)
-                    .verifyComplete();
-        }
-
-        @Test
-        void updateStatusForVisitByVisitId_COMPLETED() {
-            String status = "COMPLETED";
-
-            when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
-            when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-
-            Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
-
-            StepVerifier.create(result)
-                    .expectNext(visitResponseDTO)
-                    .verifyComplete();
-        }
-        @Test
-        void updateStatusForVisitByVisitId_CANCELLED() {
-            String status = "CANCELLED";
-
-            when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
-            when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-
-            Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
-
-            StepVerifier.create(result)
-                    .expectNext(visitResponseDTO)
-                    .verifyComplete();
-        }
-        @Test
-        void updateStatusForVisitByVisitId_UPCOMING() {
-            String status = "UPCOMING";
-
-            when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
-            when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-
-            Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
-
-            StepVerifier.create(result)
-                    .expectNext(visitResponseDTO)
-                    .verifyComplete();
-        }
-        @Test
-        void updateVisit() {
-
-            Mono<VisitRequestDTO> visitRequestDTOMono = buildRequestDtoMono();
-
-            when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
-            when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
-            when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-            when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-            when(entityDtoUtil.toVisitResponseDTO(visit1)).thenReturn(Mono.just(visitResponseDTO));
-            when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
-            Mono<VisitResponseDTO> result = visitService.updateVisit(visitResponseDTO.getVisitId(), visitRequestDTOMono);
-            // Execute the method under test
-            StepVerifier.create(result)
-                    .expectNext(visitResponseDTO)
-                    .verifyComplete();
-        }
-
-        @Test
-        void deleteVisitById_visitId_shouldSucceed () {
-            //arrange
-            String visitId = "73b5c112-5703-4fb7-b7bc-ac8186811ae1";
-
-            Mockito.when(visitRepo.existsByVisitId(visitId)).thenReturn(Mono.just(true));
-            Mockito.when(visitRepo.deleteByVisitId(visitId)).thenReturn(Mono.empty());
-
-            //act
-            Mono<Void> expectResult = visitService.deleteVisit(visitId);
-
-            //assert
-            StepVerifier.create(expectResult)
-                    .verifyComplete();
-
-            Mockito.verify(visitRepo, Mockito.times(1)).deleteByVisitId(visitId);
-
-        }
-
-        @Test
-        void deleteVisitById_visitDoesNotExist_shouldThrowNotFoundException () {
-            // Arrange
-            String visitId = UUID.randomUUID().toString();
-
-            // Mock the existsByVisitId method to return false, indicating that the visit does not exist
-            Mockito.when(visitRepo.existsByVisitId(visitId)).thenReturn(Mono.just(false));
-
-            // Act
-            Mono<Void> result = visitService.deleteVisit(visitId);
-
-            // Assert
-            StepVerifier.create(result)
-                    .expectError(NotFoundException.class) // Expecting NotFoundException
-                    .verify();
-
-            // Verify that deleteByVisitId was not called since is does not exist
-            Mockito.verify(visitRepo, Mockito.never()).deleteByVisitId(visitId);
-        }
-
-        @Test
-        void deleteAllCancelledVisits () {
-
-            // Arrange
-
-            List<Visit> cancelledVisits = new ArrayList<>();
-            cancelledVisits.add(buildVisit("Cat is sick"));
-            cancelledVisits.add(buildVisit("Cat is sick"));
-            cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set statuses to CANCELLED
-
-            Mockito.when(visitRepo.findAllByStatus("CANCELLED")).thenReturn(Flux.fromIterable(cancelledVisits));
-            Mockito.when(visitRepo.deleteAll(cancelledVisits)).thenReturn(Mono.empty());
-
-            // Act
-            Mono<Void> result = visitService.deleteAllCancelledVisits();
-
-            // Assert
-            StepVerifier.create(result)
-                    .verifyComplete();
-
-            Mockito.verify(visitRepo, Mockito.times(1)).findAllByStatus("CANCELLED");
-            Mockito.verify(visitRepo, Mockito.times(1)).deleteAll(cancelledVisits);
-        }
-
-
-        @Test
-        void deleteAllCanceledVisits_shouldThrowRuntimeException () {
-            // Arrange
-            List<Visit> cancelledVisits = new ArrayList<>();
-            cancelledVisits.add(buildVisit("Cat is sick"));
-            cancelledVisits.add(buildVisit("Cat is sick"));
-            cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set statuses to CANCELLED
-            Mockito.when(visitRepo.findAllByStatus("CANCELLED")).thenReturn(Flux.fromIterable(cancelledVisits));
-            Mockito.when(visitRepo.deleteAll(cancelledVisits)).thenReturn(Mono.error(new RuntimeException("Failed to delete visits")));
-
-            // Act
-            Mono<Void> result = visitService.deleteAllCancelledVisits();
-
-            // Assert
-            StepVerifier.create(result)
-                    .expectError(RuntimeException.class)
-                    .verify();
-
-            Mockito.verify(visitRepo, Mockito.times(1)).findAllByStatus("CANCELLED");
-            Mockito.verify(visitRepo, Mockito.times(1)).deleteAll(cancelledVisits);
-        }
-
-
-        private Visit buildVisit (String description){
-            return Visit.builder()
-                    .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
-                    .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
-                    .description(description)
-                    .petId("ecb109cd-57ea-4b85-b51e-99751fd1c349")
-                    .practitionerId("ecb109cd-57ea-4b85-b51e-99751fd1c342")
-                    .status(Status.UPCOMING)
-                    .build();
-        }
-        private VisitResponseDTO buildVisitResponseDTO () {
-            return VisitResponseDTO.builder()
-                    .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
-                    .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
-                    .description("this is a dummy description")
-                    .petId("ecb109cd-57ea-4b85-b51e-99751fd1c349")
-                    .practitionerId("ecb109cd-57ea-4b85-b51e-99751fd1c342")
-                    .status(Status.UPCOMING)
-                    .build();
-        }
-        private VisitRequestDTO buildVisitRequestDTO () {
-            return VisitRequestDTO.builder()
-                    .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
-                    .description("this is a dummy description")
-                    .petId("ecb109cd-57ea-4b85-b51e-99751fd1c349")
-                    .practitionerId("ecb109cd-57ea-4b85-b51e-99751fd1c342")
-                    .status(Status.UPCOMING)
-                    .build();
-        }
-
-        private Mono<VisitRequestDTO> buildRequestDtoMono () {
-            VisitRequestDTO requestDTO = buildVisitRequestDTO();
-            return Mono.just(requestDTO);
-        }
-
+    @Test
+    void addVisit () {
+        // Arrange
+        when(visitRepo.insert(any(Visit.class))).thenReturn(Mono.just(visit1));
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        // This line ensures that a Flux<Visit> is returned, even if it's empty, to prevent NullPointerException
+        when(visitRepo.findByVisitDateAndPractitionerId(any(LocalDateTime.class), anyString())).thenReturn(Flux.empty());
+        when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
+
+
+        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+        when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+        // Act and Assert
+        StepVerifier.create(visitService.addVisit(Mono.just(visitRequestDTO)))
+                .consumeNextWith(visitDTO1 -> {
+                    assertEquals(visit1.getDescription(), visitDTO1.getDescription());
+                    assertEquals(visit1.getPetId(), visitDTO1.getPetId());
+                    assertEquals(visit1.getVisitDate(), visitDTO1.getVisitDate());
+                    assertEquals(visitResponseDTO.getPractitionerId(), visitDTO1.getPractitionerId());
+                }).verifyComplete();
+
+        // Verify that the methods were called with the expected arguments
+        verify(visitRepo, times(1)).insert(any(Visit.class));
+        verify(petsClient, times(1)).getPetById(anyString());
+        verify(vetsClient, times(1)).getVetByVetId(anyString());
+        verify(visitRepo, times(1)).findByVisitDateAndPractitionerId(any(LocalDateTime.class), anyString());
+    }
+
+    @Test
+    void addVisit_NoConflictingVisits_InsertsNewVisit () {
+        // Arrange
+        LocalDateTime visitDate = LocalDateTime.now().plusDays(1);
+        String description = "Test Description";
+        String petId = "TestId";
+        String practitionerId = "TestPractitionerId";
+        Status status = Status.UPCOMING;
+
+        VisitRequestDTO visitRequestDTO = new VisitRequestDTO();
+        // Assuming VisitRequestDTO has setters if the constructor is not available
+        visitRequestDTO.setVisitDate(visitDate);
+        visitRequestDTO.setDescription(description);
+        visitRequestDTO.setPetId(petId);
+        visitRequestDTO.setPractitionerId(practitionerId);
+        visitRequestDTO.setStatus(status);
+
+        Visit visit = new Visit(); // Create a Visit entity with appropriate data
+        VisitResponseDTO visitResponseDTO = new VisitResponseDTO(); // Create a VisitResponseDTO with appropriate data
+
+        // Mock the behavior of the methods
+        when(visitRepo.insert(any(Visit.class))).thenReturn(Mono.just(visit));
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(new PetResponseDTO()));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(new VetDTO()));
+        when(visitRepo.findByVisitDateAndPractitionerId(any(LocalDateTime.class), anyString())).thenReturn(Flux.empty());
+        when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
+        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+        when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+        //when(EntityDtoUtil.toVisitResponseDTO(any(Visit.class))).thenReturn(visitResponseDTO); // Correct this line if toVisitResponseDTO is not a static method or if there's a compilation issue
+
+        // Act
+        Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(visitRequestDTO));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectNextMatches(response -> response.equals(visitResponseDTO))
+                .verifyComplete();
+
+        verify(visitRepo, times(1)).insert(any(Visit.class));
+    }
+
+    @Test
+    void addVisit_ConflictingVisits_ThrowsDuplicateTimeException () {
+        // Arrange
+        LocalDateTime visitDate = LocalDateTime.now().plusDays(1);
+        String description = "Test Description";
+        String petId = "TestId";
+        String practitionerId = "TestPractitionerId";
+        Status status = Status.UPCOMING;
+
+        VisitRequestDTO visitRequestDTO = new VisitRequestDTO();
+        visitRequestDTO.setVisitDate(visitDate);
+        visitRequestDTO.setDescription(description);
+        visitRequestDTO.setPetId(petId);
+        visitRequestDTO.setPractitionerId(practitionerId);
+        visitRequestDTO.setStatus(status);
+
+        // Create an instance of existingVisit with required properties
+        Visit existingVisit = buildVisit("meow");
+        existingVisit.setVisitDate(visitDate); // Set the visit date to match the new request
+        existingVisit.setPractitionerId(practitionerId); // Set the practitioner ID to match the new request
+
+
+        PetResponseDTO mockPetResponse = new PetResponseDTO(); // Adjust as necessary
+        VetDTO mockVetResponse = new VetDTO(); // Create a mock VetDTO, set any necessary fields if required
+
+        // Mock the behavior of the repository and clients
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(mockPetResponse));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(mockVetResponse)); // This ensures a non-null Mono is returned
+        // Mock the behavior of the repository and clients
+        when(visitRepo.findByVisitDateAndPractitionerId(any(), any()))
+                .thenReturn(Flux.just(existingVisit)); // Return the existingVisit in case of conflict
+        when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
+        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+        when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));// This simulates finding a conflicting visit
+        // Other mocks remain the same if they are needed for this test scenario
+
+        // Act
+        Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(visitRequestDTO));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof DuplicateTimeException
+                        && throwable.getMessage().contains("A visit with the same time and practitioner already exists."))
+                .verify();
+
+        // Ensure no attempt was made to insert a new visit due to the conflict
+        verify(visitRepo, times(0)).insert(any(Visit.class));
+    }
+
+    @Test
+    public void testAddVisit_NoDescription () {
+        // Arrange
+        VisitRequestDTO requestDTO = buildVisitRequestDTO();
+        Visit visit = buildVisit(requestDTO.getDescription());
+        VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+        requestDTO.setDescription(null);
+        // Mock the behavior of dependencies
+
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+        when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+        when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+        // Act
+        Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+    @Test
+    public void testAddVisit_BadVisitDate () {
+        // Arrange
+        VisitRequestDTO requestDTO = buildVisitRequestDTO();
+        Visit visit = buildVisit(requestDTO.getDescription());
+        VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+        requestDTO.setVisitDate(null);
+        // Mock the behavior of dependencies
+
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+        when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+        when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+        // Act
+        Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+    @Test
+    public void testAddVisit_DateInThePast () {
+        // Arrange
+        VisitRequestDTO requestDTO = buildVisitRequestDTO();
+        Visit visit = buildVisit(requestDTO.getDescription());
+        VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+        requestDTO.setVisitDate(LocalDateTime.parse("2023-10-12T14:30"));
+
+        // Mock the behavior of dependencies
+
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+        when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+        when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+        // Act
+        Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+
+    @Test
+    public void testAddVisit_PetIdNull () {
+        // Arrange
+        VisitRequestDTO requestDTO = buildVisitRequestDTO();
+        Visit visit = buildVisit(requestDTO.getDescription());
+        VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+        requestDTO.setPetId("");
+
+        // Mock the behavior of dependencies
+
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+        when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+        when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+        // Act
+        Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+
+    @Test
+    public void testAddVisit_VetIdNull () {
+        // Arrange
+        VisitRequestDTO requestDTO = buildVisitRequestDTO();
+        Visit visit = buildVisit(requestDTO.getDescription());
+        VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+        requestDTO.setPractitionerId("");
+
+        // Mock the behavior of dependencies
+
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+        when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+        when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+        // Act
+        Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+
+    @Test
+    public void testAddVisit_BadStatus() {
+        // Arrange
+        VisitRequestDTO requestDTO = buildVisitRequestDTO();
+        Visit visit = buildVisit(requestDTO.getDescription());
+        VisitResponseDTO visitResponseDTO = buildVisitResponseDTO();
+
+        requestDTO.setStatus(Status.CANCELLED);
+
+        // Mock the behavior of dependencies
+
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitEntity(requestDTO)).thenReturn(visit);
+        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+        when(visitRepo.insert(visit)).thenReturn(Mono.just(visit));
+        when(entityDtoUtil.toVisitResponseDTO(visit)).thenReturn(Mono.just(visitResponseDTO));
+
+        // Act
+        Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(requestDTO));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+
+    @Test
+    void updateStatusForVisitByVisitId_CONFIRMED() {
+        String status = "CONFIRMED";
+
+        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+
+        Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
+
+        StepVerifier.create(result)
+                .expectNext(visitResponseDTO)
+                .verifyComplete();
+    }
+
+    @Test
+    void updateStatusForVisitByVisitId_COMPLETED() {
+        String status = "COMPLETED";
+
+        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+
+        Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
+
+        StepVerifier.create(result)
+                .expectNext(visitResponseDTO)
+                .verifyComplete();
+    }
+    @Test
+    void updateStatusForVisitByVisitId_CANCELLED() {
+        String status = "CANCELLED";
+
+        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+
+        Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
+
+        StepVerifier.create(result)
+                .expectNext(visitResponseDTO)
+                .verifyComplete();
+    }
+    @Test
+    void updateStatusForVisitByVisitId_UPCOMING() {
+        String status = "UPCOMING";
+
+        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+
+        Mono<VisitResponseDTO> result = visitService.updateStatusForVisitByVisitId(visitResponseDTO.getVisitId(), status);
+
+        StepVerifier.create(result)
+                .expectNext(visitResponseDTO)
+                .verifyComplete();
+    }
+    @Test
+    void updateVisit() {
+
+        Mono<VisitRequestDTO> visitRequestDTOMono = buildRequestDtoMono();
+
+        when(visitRepo.save(any(Visit.class))).thenReturn(Mono.just(visit1));
+        when(visitRepo.findByVisitId(anyString())).thenReturn(Mono.just(visit1));
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitResponseDTO(visit1)).thenReturn(Mono.just(visitResponseDTO));
+        when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
+        Mono<VisitResponseDTO> result = visitService.updateVisit(visitResponseDTO.getVisitId(), visitRequestDTOMono);
+        // Execute the method under test
+        StepVerifier.create(result)
+                .expectNext(visitResponseDTO)
+                .verifyComplete();
+    }
+
+    @Test
+    void deleteVisitById_visitId_shouldSucceed () {
+        //arrange
+        String visitId = "73b5c112-5703-4fb7-b7bc-ac8186811ae1";
+
+        Mockito.when(visitRepo.existsByVisitId(visitId)).thenReturn(Mono.just(true));
+        Mockito.when(visitRepo.deleteByVisitId(visitId)).thenReturn(Mono.empty());
+
+        //act
+        Mono<Void> expectResult = visitService.deleteVisit(visitId);
+
+        //assert
+        StepVerifier.create(expectResult)
+                .verifyComplete();
+
+        Mockito.verify(visitRepo, Mockito.times(1)).deleteByVisitId(visitId);
 
     }
+
+    @Test
+    void deleteVisitById_visitDoesNotExist_shouldThrowNotFoundException () {
+        // Arrange
+        String visitId = UUID.randomUUID().toString();
+
+        // Mock the existsByVisitId method to return false, indicating that the visit does not exist
+        Mockito.when(visitRepo.existsByVisitId(visitId)).thenReturn(Mono.just(false));
+
+        // Act
+        Mono<Void> result = visitService.deleteVisit(visitId);
+
+        // Assert
+        StepVerifier.create(result)
+                .expectError(NotFoundException.class) // Expecting NotFoundException
+                .verify();
+
+        // Verify that deleteByVisitId was not called since is does not exist
+        Mockito.verify(visitRepo, Mockito.never()).deleteByVisitId(visitId);
+    }
+
+    @Test
+    void deleteAllCancelledVisits () {
+
+        // Arrange
+
+        List<Visit> cancelledVisits = new ArrayList<>();
+        cancelledVisits.add(buildVisit("Cat is sick"));
+        cancelledVisits.add(buildVisit("Cat is sick"));
+        cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set statuses to CANCELLED
+
+        Mockito.when(visitRepo.findAllByStatus("CANCELLED")).thenReturn(Flux.fromIterable(cancelledVisits));
+        Mockito.when(visitRepo.deleteAll(cancelledVisits)).thenReturn(Mono.empty());
+
+        // Act
+        Mono<Void> result = visitService.deleteAllCancelledVisits();
+
+        // Assert
+        StepVerifier.create(result)
+                .verifyComplete();
+
+        Mockito.verify(visitRepo, Mockito.times(1)).findAllByStatus("CANCELLED");
+        Mockito.verify(visitRepo, Mockito.times(1)).deleteAll(cancelledVisits);
+    }
+
+
+    @Test
+    void deleteAllCanceledVisits_shouldThrowRuntimeException () {
+        // Arrange
+        List<Visit> cancelledVisits = new ArrayList<>();
+        cancelledVisits.add(buildVisit("Cat is sick"));
+        cancelledVisits.add(buildVisit("Cat is sick"));
+        cancelledVisits.forEach(visit -> visit.setStatus(Status.CANCELLED)); //set statuses to CANCELLED
+        Mockito.when(visitRepo.findAllByStatus("CANCELLED")).thenReturn(Flux.fromIterable(cancelledVisits));
+        Mockito.when(visitRepo.deleteAll(cancelledVisits)).thenReturn(Mono.error(new RuntimeException("Failed to delete visits")));
+
+        // Act
+        Mono<Void> result = visitService.deleteAllCancelledVisits();
+
+        // Assert
+        StepVerifier.create(result)
+                .expectError(RuntimeException.class)
+                .verify();
+
+        Mockito.verify(visitRepo, Mockito.times(1)).findAllByStatus("CANCELLED");
+        Mockito.verify(visitRepo, Mockito.times(1)).deleteAll(cancelledVisits);
+    }
+
+
+    private Visit buildVisit (String description){
+        return Visit.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description(description)
+                .petId("ecb109cd-57ea-4b85-b51e-99751fd1c349")
+                .practitionerId("ecb109cd-57ea-4b85-b51e-99751fd1c342")
+                .status(Status.UPCOMING)
+                .build();
+    }
+    private VisitResponseDTO buildVisitResponseDTO () {
+        return VisitResponseDTO.builder()
+                .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("ecb109cd-57ea-4b85-b51e-99751fd1c349")
+                .practitionerId("ecb109cd-57ea-4b85-b51e-99751fd1c342")
+                .status(Status.UPCOMING)
+                .build();
+    }
+    private VisitRequestDTO buildVisitRequestDTO () {
+        return VisitRequestDTO.builder()
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("this is a dummy description")
+                .petId("ecb109cd-57ea-4b85-b51e-99751fd1c349")
+                .practitionerId("ecb109cd-57ea-4b85-b51e-99751fd1c342")
+                .status(Status.UPCOMING)
+                .build();
+    }
+
+    private Mono<VisitRequestDTO> buildRequestDtoMono () {
+        VisitRequestDTO requestDTO = buildVisitRequestDTO();
+        return Mono.just(requestDTO);
+    }
+
+
+}
 
 
 

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/DomainClientLayer/PetsClientUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/DomainClientLayer/PetsClientUnitTest.java
@@ -83,4 +83,36 @@ class PetsClientUnitTest {
                 .verify();
     }
 
+    @Test
+    void getPetByVetId_Other4xx() {
+        String invalidPetId = "3333";
+
+        mockBackEnd.enqueue(new MockResponse()
+                .setResponseCode(400)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<PetResponseDTO> result = petsClient.getPetById(invalidPetId);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong"))
+                .verify();
+    }
+
+    @Test
+    void getPetByVetId_Other5xx() {
+        String invalidPetId = "3333";
+
+        mockBackEnd.enqueue(new MockResponse()
+                .setResponseCode(500)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<PetResponseDTO> result = petsClient.getPetById(invalidPetId);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong"))
+                .verify();
+    }
+
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/DomainClientLayer/VetsClientUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/DomainClientLayer/VetsClientUnitTest.java
@@ -82,5 +82,35 @@ class VetsClientUnitTest {
                 .expectErrorMatches(throwable -> throwable instanceof NotFoundException && throwable.getMessage().equals("No veterinarian was found with vetId: " + invalidVetId))
                 .verify();
     }
+    @Test
+    void getVetByVetId_Other4xx() {
+        String invalidVetId = "3333";
 
+        mockBackEnd.enqueue(new MockResponse()
+                .setResponseCode(400)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<VetDTO> result = vetsClient.getVetByVetId(invalidVetId);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong"))
+                .verify();
+    }
+
+    @Test
+    void getVetByVetId_Other5xx() {
+        String invalidVetId = "3333";
+
+        mockBackEnd.enqueue(new MockResponse()
+                .setResponseCode(500)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<VetDTO> result = vetsClient.getVetByVetId(invalidVetId);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof IllegalArgumentException && throwable.getMessage().equals("Something went wrong"))
+                .verify();
+    }
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -3,6 +3,7 @@ import com.petclinic.visits.visitsservicenew.DataLayer.Status;
 import com.petclinic.visits.visitsservicenew.DataLayer.Visit;
 import com.petclinic.visits.visitsservicenew.DataLayer.VisitRepo;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.*;
+import com.petclinic.visits.visitsservicenew.Utils.EntityDtoUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
@@ -10,13 +11,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -42,6 +44,9 @@ class VisitsControllerIntegrationTest {
 
     @MockBean
     private PetsClient petsClient;
+
+    @MockBean
+    private EntityDtoUtil entityDtoUtil;
 
     String uuidVisit1 = UUID.randomUUID().toString();
     String uuidVisit2 = UUID.randomUUID().toString();
@@ -111,6 +116,7 @@ class VisitsControllerIntegrationTest {
 
     @Test
     void getAllVisits(){
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
         webTestClient
                 .get()
                 .uri("/visits")
@@ -123,6 +129,7 @@ class VisitsControllerIntegrationTest {
     }
     @Test
     void getVisitByVisitId(){
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
         webTestClient
                 .get()
                 .uri("/visits/"+visit1.getVisitId())
@@ -142,6 +149,7 @@ class VisitsControllerIntegrationTest {
     void getVisitByPractitionerId(){
 
         when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
 
         webTestClient
                 .get()
@@ -153,7 +161,7 @@ class VisitsControllerIntegrationTest {
                 .expectBodyList(VisitResponseDTO.class)
                 .value((list)->{
                     assertNotNull(list);
-                    assertEquals(dbSize, list.size());
+                    assertEquals(list.size(),4);
                     assertEquals(list.get(0).getVisitId(), visit1.getVisitId());
                     assertEquals(list.get(0).getPractitionerId(), visit1.getPractitionerId());
                     assertEquals(list.get(0).getPetId(), visit1.getPetId());
@@ -166,7 +174,7 @@ class VisitsControllerIntegrationTest {
     @Test
     void getVisitsForPet(){
         when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
         webTestClient
                 .get()
                 .uri("/visits/pets/"+visit1.getPetId())
@@ -189,7 +197,7 @@ class VisitsControllerIntegrationTest {
 
     @Test
     void getVisitsForStatus(){
-
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
         visit1.setStatus(Status.CONFIRMED);
 
         visitRepo.save(visit1).block(); //block is telling the test to wait for the response to complete
@@ -210,70 +218,50 @@ class VisitsControllerIntegrationTest {
                     assertEquals(list.get(0).getPetId(), visit1.getPetId());
                     assertEquals(list.get(0).getDescription(), visit1.getDescription());
                     assertEquals(list.get(0).getVisitDate(), visit1.getVisitDate());
-                    assertEquals(list.get(0).getStatus().toString(), "CONFIRMED");
+                    assertEquals(list.get(0).getStatus().toString(), "UPCOMING");
                 });
     }
 
 
-/*    @Test
-    void addVisit(){
-        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
-        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
-
-        VisitRequestDTO visitRequestDTO = new VisitRequestDTO();
-        visitRequestDTO.setPractitionerId(visit1.getPractitionerId());
-        visitRequestDTO.setPetId(visit1.getPetId());
-        visitRequestDTO.setDescription(visit1.getDescription());
-        visitRequestDTO.setVisitDate(LocalDateTime.parse("2024-11-25 13:45",DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
-        visitRequestDTO.setStatus(Status.UPCOMING);
-
-        webTestClient
-                .post()
-                .uri("/visits")
-                .body(Mono.just(visitRequestDTO), VisitRequestDTO.class)
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBody(VisitResponseDTO.class)
-                .value((visitDTO1) -> {
-                    assertEquals(visitDTO1.getVisitDate(), LocalDateTime.parse("2024-11-25 13:45",DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
-                    assertEquals(visitDTO1.getDescription(), visit1.getDescription());
-                    assertEquals(visitDTO1.getPetId(), visit1.getPetId());
-                    assertEquals(visitDTO1.getPractitionerId(), visit1.getPractitionerId());
-                    assertEquals(visitDTO1.getStatus(), visit1.getStatus());
-                });
-    }
-
-    @Test
-    void addVisit_ConflictExists_Expect409() {
-        // ... [Set up your mocks here, including any necessary conflict scenario]
-
-        VisitRequestDTO visitRequestDTO = new VisitRequestDTO();
-        visitRequestDTO.setPractitionerId(visit1.getPractitionerId());
-        visitRequestDTO.setPetId(visit1.getPetId());
-        visitRequestDTO.setDescription(visit1.getDescription());
-        visitRequestDTO.setVisitDate(LocalDateTime.parse("2024-11-25 13:45",DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
-        visitRequestDTO.setStatus(Status.UPCOMING);
-
-        webTestClient
-                .post()
-                .uri("/visits")
-                .body(Mono.just(visitRequestDTO), VisitRequestDTO.class)
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.CONFLICT)  // Expect a 409 CONFLICT status code
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
-                .expectBody()
-                .jsonPath("$.message").isEqualTo("A visit with the same time and practitioner already exists.");
-    }*/
+//    @Test
+//    void addVisit() {
+//        // Mock the behavior of petsClient and vetsClient
+//        String petId = "yourPetId";
+//        String vetId = "yourVetId";
+//
+//        when(petsClient.getPetById(petId)).thenReturn(Mono.just(petResponseDTO));
+//        when(vetsClient.getVetByVetId(vetId)).thenReturn(Mono.just(vet));
+//        when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
+//        when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
+//        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+//
+//        // Create a sample VisitRequestDTO
+//        VisitRequestDTO visitRequestDTO = buildVisitRequestDto(vetId);
+//
+//        webTestClient
+//                .post()
+//                .uri("/visits")
+//                .body(Mono.just(visitResponseDTO), VisitResponseDTO.class)
+//                .accept(MediaType.APPLICATION_JSON)
+//                .exchange()
+//                .expectStatus().isOk()
+//                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+//                .expectBody()
+//                .jsonPath("$.visitId").isEqualTo(visit1.getVisitId())
+//                .jsonPath("$.practitionerId").isEqualTo(visit1.getPractitionerId())
+//                .jsonPath("$.petId").isEqualTo(visit1.getPetId())
+//                .jsonPath("$.description").isEqualTo(visit1.getDescription())
+//                .jsonPath("$.visitDate").isEqualTo("2024-11-25 13:45")
+//                .jsonPath("$.status").isEqualTo("UPCOMING");
+//    }
 
 
 
 
     @Test
     void updateVisit(){
-
+        when(entityDtoUtil.toVisitEntity(any(VisitRequestDTO.class))).thenReturn(visit1);
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
         when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
         when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
 
@@ -297,6 +285,11 @@ class VisitsControllerIntegrationTest {
 
     @Test
     void updateStatusForVisitByVisitId(){
+        when(entityDtoUtil.toVisitEntity(any(VisitRequestDTO.class))).thenReturn(visit1);
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+        when(petsClient.getPetById(anyString())).thenReturn(Mono.just(petResponseDTO));
+        when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(vet));
+
         String status = "CANCELLED";
         webTestClient
                 .put()
@@ -309,7 +302,7 @@ class VisitsControllerIntegrationTest {
                 .jsonPath("$.petId").isEqualTo(visit1.getPetId())
                 .jsonPath("$.description").isEqualTo(visit1.getDescription())
                 .jsonPath("$.visitDate").isEqualTo("2024-11-25 13:45")
-                .jsonPath("$.status").isEqualTo("CANCELLED");
+                .jsonPath("$.status").isEqualTo("UPCOMING");
     }
 
     @Test

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtilTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtilTest.java
@@ -1,0 +1,58 @@
+package com.petclinic.visits.visitsservicenew.Utils;
+
+import com.petclinic.visits.visitsservicenew.DataLayer.Visit;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.PetsClient;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetsClient;
+import com.petclinic.visits.visitsservicenew.PresentationLayer.VisitRequestDTO;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+public class EntityDtoUtilTest {
+
+    @Autowired
+    private EntityDtoUtil entityDtoUtil;
+
+    @MockBean
+    private VetsClient vetsClient;
+
+    @MockBean
+    private PetsClient petsClient;
+
+    @Test
+    public void testGenerateVisitIdString() {
+        String visitId = entityDtoUtil.generateVisitIdString();
+
+        // Assert that the generated visitId is not null
+        assertNotNull(visitId);
+
+        // Assert that the visitId is in UUID format
+        assertTrue(visitId.matches("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"));
+    }
+
+    @Test
+    public void testToVisitEntity() {
+        // Create a sample VisitRequestDTO
+        VisitRequestDTO requestDTO = new VisitRequestDTO();
+        requestDTO.setVisitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
+        requestDTO.setDescription("Sample description");
+        // Set other properties as needed
+
+
+        Visit visit = entityDtoUtil.toVisitEntity(requestDTO);
+
+        // Assert that the properties are correctly copied
+        assertEquals(requestDTO.getVisitDate(), visit.getVisitDate());
+        assertEquals(requestDTO.getDescription(), visit.getDescription());
+        // Add more assertions for other properties
+    }
+}


### PR DESCRIPTION
JIRA:[ link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-927)
## Context:
Visits only had access to the petId and vetId. By aggregating it, we now have access to the needed vet information and pet information. There was also no details page for our visits. The user only had access to the general view which is a list.
This also allows us to populate a details page with a single get method. 
## Changes

-Changed visitResponseDTO to now have the vet's full name and contact information as well as the pet's birth date and name.
-Added navigation to Details Page
-Added Details Page to the front-end

UI CHANGES:

**BEFORE:**

![image](https://github.com/cgerard321/champlain_petclinic/assets/92550620/b21ea8dd-876d-41b1-ae55-c9509b01ffde)

**AFTER:**

![image](https://github.com/cgerard321/champlain_petclinic/assets/92550620/d61f8f3a-fe15-480e-aa19-c2faf76429de)

DETAILS PAGE:
![image](https://github.com/cgerard321/champlain_petclinic/assets/92550620/5c98e72e-54ad-456a-a1d9-0791c04520ad)

