### PR TITLE
feat(VIST-CPC-925): changing vet id and pet id to vet name and pet name in the visits-list page

### DIFF
--- a/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
+++ b/api-gateway/src/main/resources/static/scripts/visit-list/visit-list.template.html
@@ -109,8 +109,8 @@
         <td class="border">{{v.visitDate | date:'yyyy-MM-ddTHH:mm:ss'}}</td>
         <td class="border" style="white-space: pre-line">{{v.description}}</td>
         <!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
-        <td class="border" style="white-space: pre-line">{{v.practitionerId}}</td>
-        <td class="border" style="white-space: pre-line">{{v.petId}}</td>
+        <td class="border" style="white-space: pre-line">{{v.vetFirstName}} {{v.vetLastName}}</td>
+        <td class="border" style="white-space: pre-line">{{v.petName}}</td>
         <td class="status-text" style="white-space: pre-line"></td>
         <td class="status-text border" style="white-space: pre-line">{{v.status}}</td>
         <td class="border">
@@ -170,8 +170,8 @@
         <td class="border">{{v.visitDate | date:'yyyy-MM-ddTHH:mm:ss'}}</td>
         <td class="border" style="white-space: pre-line">{{v.description}}</td>
         <!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
-        <td class="border" style="white-space: pre-line">{{v.practitionerId}}</td>
-        <td class="border" style="white-space: pre-line">{{v.petId}}</td>
+        <td class="border" style="white-space: pre-line">{{v.vetFirstName}} {{v.vetLastName}}</td>
+        <td class="border" style="white-space: pre-line">{{v.petName}}</td>
         <td class="status-text" style="white-space: pre-line"></td>
         <td class="status-text border" style="white-space: pre-line">{{v.status}}</td>
         <td class="border">
@@ -232,8 +232,8 @@
         <td class="border">{{v.visitDate | date:'yyyy-MM-ddTHH:mm:ss'}}</td>
         <td class="border" style="white-space: pre-line">{{v.description}}</td>
         <!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
-        <td class="border" style="white-space: pre-line">{{v.practitionerId}}</td>
-        <td class="border" style="white-space: pre-line">{{v.petId}}</td>
+        <td class="border" style="white-space: pre-line">{{v.vetFirstName}} {{v.vetLastName}}</td>
+        <td class="border" style="white-space: pre-line">{{v.petName}}</td>
         <td class="status-text" style="white-space: pre-line"></td>
         <td class="status-text border" style="white-space: pre-line">{{v.status}}</td>
         <td class="border">
@@ -293,8 +293,8 @@
         <td class="border">{{v.visitDate | date:'yyyy-MM-ddTHH:mm:ss'}}</td>
         <td class="border" style="white-space: pre-line">{{v.description}}</td>
         <!--        <td style="white-space: pre-line">{{$ctrl.getPractitionerName(v.practitionerId)}}</td>-->
-        <td class="border" style="white-space: pre-line">{{v.practitionerId}}</td>
-        <td class="border" style="white-space: pre-line">{{v.petId}}</td>
+        <td class="border" style="white-space: pre-line">{{v.vetFirstName}} {{v.vetLastName}}</td>
+        <td class="border" style="white-space: pre-line">{{v.petName}}</td>
         <td class="status-text" style="white-space: pre-line"></td>
         <td class="status-text border" style="white-space: pre-line">{{v.status}}</td>
         <td class="border">


### PR DESCRIPTION
JIRA: [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-925)
## Context:
The list displayed many non user friendly data such as the vetId and petId that are UUIDS. By displaying the vet's and pet's names instead of their Id, our website becomes more user-friendly.
## Changes
Changed the front-end to display vet name and pet name instead of their Ids
This can be bullet point or sentence format.

UI CHANGES

**BEFORE**
![image](https://github.com/cgerard321/champlain_petclinic/assets/92550620/c0bdef35-b61b-43a8-b55d-82c74a6bb2f9)

**AFTER**
![image](https://github.com/cgerard321/champlain_petclinic/assets/92550620/488f53d5-fef8-4c5d-853d-f708c93f00f1)

