### PR TITLE
bug(VIST-CPC-817): add missing tests for entityDtoUtil and visitsServiceClient

### DIFF
--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
@@ -623,4 +623,20 @@ class VisitsServiceClientIntegrationTest {
                 .verifyComplete();
     }
 
+    @Test
+    void deleteVisitByVisitId_shouldSucceed() {
+        // Declare a testUUID to pass
+        String testUUID = UUID.randomUUID().toString();
+
+        // Enqueue mock respons of delete
+        server.enqueue(new MockResponse()
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setResponseCode(204)); // No Content
+
+        Mono<Void> result = visitsServiceClient.deleteVisitByVisitId(testUUID);
+
+        StepVerifier.create(result)
+                .verifyComplete();
+    }
+
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
@@ -257,7 +257,6 @@ class VisitServiceImplTest {
         Status status = Status.UPCOMING;
 
         VisitRequestDTO visitRequestDTO = new VisitRequestDTO();
-        // Assuming VisitRequestDTO has setters if the constructor is not available
         visitRequestDTO.setVisitDate(visitDate);
         visitRequestDTO.setDescription(description);
         visitRequestDTO.setPetId(petId);
@@ -276,7 +275,6 @@ class VisitServiceImplTest {
         when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
         when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
         when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
-        //when(EntityDtoUtil.toVisitResponseDTO(any(Visit.class))).thenReturn(visitResponseDTO); // Correct this line if toVisitResponseDTO is not a static method or if there's a compilation issue
 
         // Act
         Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(visitRequestDTO));
@@ -314,17 +312,14 @@ class VisitServiceImplTest {
         PetResponseDTO mockPetResponse = new PetResponseDTO(); // Adjust as necessary
         VetDTO mockVetResponse = new VetDTO(); // Create a mock VetDTO, set any necessary fields if required
 
-        // Mock the behavior of the repository and clients
         when(petsClient.getPetById(anyString())).thenReturn(Mono.just(mockPetResponse));
         when(vetsClient.getVetByVetId(anyString())).thenReturn(Mono.just(mockVetResponse)); // This ensures a non-null Mono is returned
-        // Mock the behavior of the repository and clients
         when(visitRepo.findByVisitDateAndPractitionerId(any(), any()))
-                .thenReturn(Flux.just(existingVisit)); // Return the existingVisit in case of conflict
+                .thenReturn(Flux.just(existingVisit)); // Return existingVisit in case of conflict
         when(entityDtoUtil.toVisitEntity(any())).thenReturn(visit1);
         when(entityDtoUtil.generateVisitIdString()).thenReturn("yourVisitId");
         when(visitRepo.insert(visit1)).thenReturn(Mono.just(visit1));
-        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));// This simulates finding a conflicting visit
-        // Other mocks remain the same if they are needed for this test scenario
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO)); // This simulates finding a conflicting visit
 
         // Act
         Mono<VisitResponseDTO> result = visitService.addVisit(Mono.just(visitRequestDTO));

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtilTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtilTest.java
@@ -1,19 +1,29 @@
 package com.petclinic.visits.visitsservicenew.Utils;
 
 import com.petclinic.visits.visitsservicenew.DataLayer.Visit;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.PetResponseDTO;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.PetsClient;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetDTO;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetsClient;
 import com.petclinic.visits.visitsservicenew.PresentationLayer.VisitRequestDTO;
 
+import com.petclinic.visits.visitsservicenew.PresentationLayer.VisitResponseDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 
 @SpringBootTest
@@ -28,6 +38,10 @@ public class EntityDtoUtilTest {
     @MockBean
     private PetsClient petsClient;
 
+
+    String testVetUUID = UUID.randomUUID().toString();
+    String testPetUUID = UUID.randomUUID().toString();
+
     @Test
     public void testGenerateVisitIdString() {
         String visitId = entityDtoUtil.generateVisitIdString();
@@ -41,28 +55,60 @@ public class EntityDtoUtilTest {
 
     @Test
     public void testToVisitEntity() {
-        // Create a sample VisitRequestDTO
+
         VisitRequestDTO requestDTO = new VisitRequestDTO();
         requestDTO.setVisitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
         requestDTO.setDescription("Sample description");
-        // Set other properties as needed
-
 
         Visit visit = entityDtoUtil.toVisitEntity(requestDTO);
 
-        // Assert that the properties are correctly copied
         assertEquals(requestDTO.getVisitDate(), visit.getVisitDate());
         assertEquals(requestDTO.getDescription(), visit.getDescription());
-        // Add more assertions for other properties
     }
 
-
-/*
     @Test
-    public void testToVisitEntity_makeCallToVet
+    public void testToVisitResponseDTO() {
+        // Mock responses for petsClient and vetsClient
+        when(petsClient.getPetById(eq(testPetUUID)))
+                .thenReturn(Mono.just(new PetResponseDTO("ownerId", "petName", new Date(2023, 2, 21), "petType", "newPhoto")));
+        when(vetsClient.getVetByVetId(eq(testVetUUID)))
+                .thenReturn(Mono.just(
+                        VetDTO.builder()
+                                .vetId("vetId")
+                                .vetBillId("billId")
+                                .firstName("Cristiano")
+                                .lastName("Ronaldo")
+                                .email("cr7@gmail.com")
+                                .phoneNumber("5149950205")
+                                .imageId("image123")
+                                .resume("Resume")
+                                .workday(new HashSet<>())
+                                .active(true)
+                                .specialties(new HashSet<>())
+                                .build()
+                ));
 
+        // Create visit
+        Visit visit = new Visit();
+        visit.setVisitId(UUID.randomUUID().toString());
+        visit.setVisitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
 
+        visit.setDescription("Test description");
+        visit.setPetId(testPetUUID); // passing pre-defined testPetUUID
+        visit.setPractitionerId(testVetUUID); // passing pre-defined testVetUUID
 
-*/
+        // Call the toVisitResponseDTO method
+        Mono<VisitResponseDTO> resultMono = entityDtoUtil.toVisitResponseDTO(visit);
 
+        // Use Step verifier to ensure matching responses
+        StepVerifier.create(resultMono)
+                .expectNextMatches(dto -> {
+                    return dto.getVisitId().equals(visit.getVisitId()) &&
+                            dto.getPetName().equals("petName") &&
+                            dto.getPetBirthDate().equals(new Date(2023, 2, 21)) &&
+                            dto.getVetFirstName().equals("Cristiano") &&
+                            dto.getVetLastName().equals("Ronaldo");
+                })
+                .verifyComplete();
+    }
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtilTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtilTest.java
@@ -55,4 +55,14 @@ public class EntityDtoUtilTest {
         assertEquals(requestDTO.getDescription(), visit.getDescription());
         // Add more assertions for other properties
     }
+
+
+/*
+    @Test
+    public void testToVisitEntity_makeCallToVet
+
+
+
+*/
+
 }


### PR DESCRIPTION
link to jira ticket:
https://champlainsaintlambert.atlassian.net/browse/CPC-817
## Context:
This ticket pertains to adding some missing tests for the EntityDTOUtils class in the visits-serivce as well as a missed method in the VisitsServiceClient.
## Changes
- Added testToVisitEntity
- Added test deleteVisitByVisitIdShouldSucceed

![image](https://github.com/cgerard321/champlain_petclinic/assets/77695020/51485b96-3437-43e2-87cd-fe4c5f49bab0)

![image](https://github.com/cgerard321/champlain_petclinic/assets/77695020/ec09deb1-1595-484e-9dc9-14108f5728bc)


## Dev notes (Optional)
Teammate will be making a pr shortly adding more tests for coverage
