### PR TITLE
Added the Products Service into the parrallel workflow, added at the …

### DIFF
--- a/.github/workflows/parallel_microservice_build.yml
+++ b/.github/workflows/parallel_microservice_build.yml
@@ -145,6 +145,25 @@ jobs:
       run: ./gradlew clean build
       working-directory: ./inventory-service
 
+  products_service_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./products-service
+      - name: Build with Gradle
+        run: ./gradlew clean build
+        working-directory: ./products-service
+
     
   dependency-submission:
 


### PR DESCRIPTION
…bottom of the file

JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-1109
## Context:
This ticket was about fixing a configuration where we forgot to add the new service we created (products-service) into the parallel workflow inside the .github folder. 

## Changes

Towards the bottom of the file I created a new profile called products-service-test. This has the same configurations as all the other tests produced in that section.


