### PR TITLE
bug/CART-CPC-1111_Parallel_CI_Workflow_Update_Cart_Service

### DIFF
--- a/.github/workflows/parallel_microservice_build.yml
+++ b/.github/workflows/parallel_microservice_build.yml
@@ -164,6 +164,26 @@ jobs:
         run: ./gradlew clean build
         working-directory: ./products-service
 
+
+  cart_service_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./cart-service
+      - name: Build with Gradle
+        run: ./gradlew clean build
+        working-directory: ./cart-service
+
     
   dependency-submission:
 


### PR DESCRIPTION
Added the cart service in the parallel_microservice_build.yml to fix the bug

JIRA: https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/15/backlog?selectedIssue=CPC-1111
## Context:
Cart-service has not been added to parallel CI testing file which could cause bugs
## Changes
Added the cart-service to the parallel CI file to fix the bug
## Dev notes (Optional)
Please verify this pull request

