### PR TITLE
feat/(AUTH-CPC-1129): Create error pages for 4xx and 5xx status codes

### DIFF
--- a/petclinic-frontend/src/pages/Error/ErrorPage.css
+++ b/petclinic-frontend/src/pages/Error/ErrorPage.css
@@ -1,0 +1,63 @@
+.not-found-wrapper {
+    background-color: #f0f0f0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.not-found-container {
+    text-align: center;
+    background-color: #fff;
+    padding: 40px;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    max-width: 500px;
+    width: 100%;
+}
+
+.not-found-container h1 {
+    font-size: 6em;
+    margin: 0;
+    color: #ff6f61;
+    animation: pulse 1.5s infinite;
+}
+
+.not-found-container p {
+    font-size: 1.5em;
+    color: #333;
+    margin: 20px 0;
+}
+
+.not-found-container button {
+    display: inline-block;
+    margin-top: 20px;
+    padding: 10px 20px;
+    background-color: #ff6f61;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 5px;
+    transition: background-color 0.3s, transform 0.3s;
+    border: none;
+    outline: none;
+    cursor: pointer;
+}
+
+.not-found-container button:hover {
+    background-color: #ff3b2f;
+    transform: scale(1.05);
+}
+
+@keyframes pulse {
+    0% {
+        transform: scale(1);
+    }
+    50% {
+        transform: scale(1.05);
+    }
+    100% {
+        transform: scale(1);
+    }
+}

--- a/petclinic-frontend/src/pages/Error/ErrorPage.css
+++ b/petclinic-frontend/src/pages/Error/ErrorPage.css
@@ -1,4 +1,4 @@
-.not-found-wrapper {
+.error-wrapper {
     background-color: #f0f0f0;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     display: flex;
@@ -8,30 +8,30 @@
     margin: 0;
 }
 
-.not-found-container {
+.error-container {
     text-align: center;
     background-color: #fff;
     padding: 40px;
     border-radius: 10px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    max-width: 500px;
+    max-width: 700px;
     width: 100%;
 }
 
-.not-found-container h1 {
+.error-container h1 {
     font-size: 6em;
     margin: 0;
     color: #ff6f61;
     animation: pulse 1.5s infinite;
 }
 
-.not-found-container p {
+.error-container p {
     font-size: 1.5em;
     color: #333;
     margin: 20px 0;
 }
 
-.not-found-container button {
+.error-container button {
     display: inline-block;
     margin-top: 20px;
     padding: 10px 20px;
@@ -45,7 +45,7 @@
     cursor: pointer;
 }
 
-.not-found-container button:hover {
+.error-container button:hover {
     background-color: #ff3b2f;
     transform: scale(1.05);
 }

--- a/petclinic-frontend/src/pages/Error/ErrorPage.css
+++ b/petclinic-frontend/src/pages/Error/ErrorPage.css
@@ -6,16 +6,18 @@
     align-items: center;
     height: 100vh;
     margin: 0;
+    padding: 20px;
 }
 
 .error-container {
     text-align: center;
     background-color: #fff;
     padding: 40px;
-    border-radius: 10px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    border-radius: 15px;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
     max-width: 700px;
     width: 100%;
+    transition: transform 0.3s;
 }
 
 .error-container h1 {

--- a/petclinic-frontend/src/pages/Error/Forbidden.tsx
+++ b/petclinic-frontend/src/pages/Error/Forbidden.tsx
@@ -14,7 +14,9 @@ const Forbidden: React.FC = () => {
     <div className="error-wrapper">
       <div className="error-container">
         <h1>403</h1>
-        <p>Sorry, you do not have permission to access this page or resource.</p>
+        <p>
+          Sorry, you do not have permission to access this page or resource.
+        </p>
         <button onClick={handleGoHome}>Go Back Home</button>
       </div>
     </div>

--- a/petclinic-frontend/src/pages/Error/Forbidden.tsx
+++ b/petclinic-frontend/src/pages/Error/Forbidden.tsx
@@ -14,7 +14,7 @@ const Forbidden: React.FC = () => {
     <div className="error-wrapper">
       <div className="error-container">
         <h1>403</h1>
-        <p>Sorry, you do not have permission to access this page.</p>
+        <p>Sorry, you do not have permission to access this page or resource.</p>
         <button onClick={handleGoHome}>Go Back Home</button>
       </div>
     </div>

--- a/petclinic-frontend/src/pages/Error/Forbidden.tsx
+++ b/petclinic-frontend/src/pages/Error/Forbidden.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import './ErrorPage.css';
 import { AppRoutePaths } from '@/shared/models/path.routes.ts';
@@ -6,7 +6,7 @@ import { AppRoutePaths } from '@/shared/models/path.routes.ts';
 const Forbidden: React.FC = () => {
   const navigate = useNavigate();
 
-  const handleGoHome = () => {
+  const handleGoHome = (): void => {
     navigate(AppRoutePaths.Home);
   };
 
@@ -14,7 +14,7 @@ const Forbidden: React.FC = () => {
     <div className="error-wrapper">
       <div className="error-container">
         <h1>403</h1>
-        <p>Sorry, you don't have permission to access this page.</p>
+        <p>Sorry, you do not have permission to access this page.</p>
         <button onClick={handleGoHome}>Go Back Home</button>
       </div>
     </div>

--- a/petclinic-frontend/src/pages/Error/Forbidden.tsx
+++ b/petclinic-frontend/src/pages/Error/Forbidden.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './ErrorPage.css';
+import { AppRoutePaths } from '@/shared/models/path.routes.ts';
+
+const Forbidden: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleGoHome = () => {
+    navigate(AppRoutePaths.Home);
+  };
+
+  return (
+    <div className="error-wrapper">
+      <div className="error-container">
+        <h1>403</h1>
+        <p>Sorry, you don't have permission to access this page.</p>
+        <button onClick={handleGoHome}>Go Back Home</button>
+      </div>
+    </div>
+  );
+};
+
+export default Forbidden;

--- a/petclinic-frontend/src/pages/Error/InternalServerError.tsx
+++ b/petclinic-frontend/src/pages/Error/InternalServerError.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import './ErrorPage.css';
 import { AppRoutePaths } from '@/shared/models/path.routes.ts';
@@ -6,7 +6,7 @@ import { AppRoutePaths } from '@/shared/models/path.routes.ts';
 const InternalServerError: React.FC = () => {
   const navigate = useNavigate();
 
-  const handleGoHome = () => {
+  const handleGoHome = (): void => {
     navigate(AppRoutePaths.Home);
   };
 

--- a/petclinic-frontend/src/pages/Error/InternalServerError.tsx
+++ b/petclinic-frontend/src/pages/Error/InternalServerError.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './ErrorPage.css';
+import { AppRoutePaths } from '@/shared/models/path.routes.ts';
+
+const InternalServerError: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleGoHome = () => {
+    navigate(AppRoutePaths.Home);
+  };
+
+  return (
+    <div className="error-wrapper">
+      <div className="error-container">
+        <h1>500</h1>
+        <p>Something went wrong on our end. Please try again later.</p>
+        <button onClick={handleGoHome}>Go Back Home</button>
+      </div>
+    </div>
+  );
+};
+
+export default InternalServerError;

--- a/petclinic-frontend/src/pages/Error/PageNotFound.tsx
+++ b/petclinic-frontend/src/pages/Error/PageNotFound.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './PageNotFound.css'
+import { AppRoutePaths } from '@/shared/models/path.routes.ts';
+
+const NotFound: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleGoHome = () => {
+    navigate(AppRoutePaths.Home);
+  };
+
+  return (
+    <div className="not-found-wrapper">
+      <div className="not-found-container">
+        <h1>404</h1>
+        <p>Oops! The page you're looking for doesn't exist.</p>
+        <button onClick={handleGoHome}>Go Back Home</button>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/petclinic-frontend/src/pages/Error/PageNotFound.tsx
+++ b/petclinic-frontend/src/pages/Error/PageNotFound.tsx
@@ -1,20 +1,20 @@
-import React from 'react';
+import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-import './ErrorPage.css'
+import './ErrorPage.css';
 import { AppRoutePaths } from '@/shared/models/path.routes.ts';
 
 const NotFound: React.FC = () => {
   const navigate = useNavigate();
 
-  const handleGoHome = () => {
+  const handleGoHome = (): void => {
     navigate(AppRoutePaths.Home);
   };
 
   return (
-    <div className='error-wrapper'>
-      <div className='error-container'>
+    <div className="error-wrapper">
+      <div className="error-container">
         <h1>404</h1>
-        <p>Oops! The page you're looking for doesn't exist.</p>
+        <p>Oops! The page you are looking for does not exist.</p>
         <button onClick={handleGoHome}>Go Back Home</button>
       </div>
     </div>

--- a/petclinic-frontend/src/pages/Error/PageNotFound.tsx
+++ b/petclinic-frontend/src/pages/Error/PageNotFound.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import './PageNotFound.css'
+import './ErrorPage.css'
 import { AppRoutePaths } from '@/shared/models/path.routes.ts';
 
 const NotFound: React.FC = () => {
@@ -11,8 +11,8 @@ const NotFound: React.FC = () => {
   };
 
   return (
-    <div className="not-found-wrapper">
-      <div className="not-found-container">
+    <div className='error-wrapper'>
+      <div className='error-container'>
         <h1>404</h1>
         <p>Oops! The page you're looking for doesn't exist.</p>
         <button onClick={handleGoHome}>Go Back Home</button>

--- a/petclinic-frontend/src/pages/Error/RequestTimeout.tsx
+++ b/petclinic-frontend/src/pages/Error/RequestTimeout.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './ErrorPage.css';
+import { AppRoutePaths } from '@/shared/models/path.routes.ts';
+
+const RequestTimeout: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleGoHome = () => {
+    navigate(AppRoutePaths.Home);
+  };
+
+  return (
+    <div className="error-wrapper">
+      <div className="error-container">
+        <h1>408</h1>
+        <p>The server timed out waiting for the request.</p>
+        <button onClick={handleGoHome}>Go Back Home</button>
+      </div>
+    </div>
+  );
+};
+
+export default RequestTimeout;

--- a/petclinic-frontend/src/pages/Error/RequestTimeout.tsx
+++ b/petclinic-frontend/src/pages/Error/RequestTimeout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import './ErrorPage.css';
 import { AppRoutePaths } from '@/shared/models/path.routes.ts';
@@ -6,7 +6,7 @@ import { AppRoutePaths } from '@/shared/models/path.routes.ts';
 const RequestTimeout: React.FC = () => {
   const navigate = useNavigate();
 
-  const handleGoHome = () => {
+  const handleGoHome = (): void => {
     navigate(AppRoutePaths.Home);
   };
 

--- a/petclinic-frontend/src/pages/Error/ServiceUnavailable.tsx
+++ b/petclinic-frontend/src/pages/Error/ServiceUnavailable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import './ErrorPage.css';
 import { AppRoutePaths } from '@/shared/models/path.routes.ts';
@@ -6,7 +6,7 @@ import { AppRoutePaths } from '@/shared/models/path.routes.ts';
 const ServiceUnavailable: React.FC = () => {
   const navigate = useNavigate();
 
-  const handleGoHome = () => {
+  const handleGoHome = (): void => {
     navigate(AppRoutePaths.Home);
   };
 

--- a/petclinic-frontend/src/pages/Error/ServiceUnavailable.tsx
+++ b/petclinic-frontend/src/pages/Error/ServiceUnavailable.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './ErrorPage.css';
+import { AppRoutePaths } from '@/shared/models/path.routes.ts';
+
+const ServiceUnavailable: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleGoHome = () => {
+    navigate(AppRoutePaths.Home);
+  };
+
+  return (
+    <div className="error-wrapper">
+      <div className="error-container">
+        <h1>503</h1>
+        <p>The server is currently unavailable. Please try again later.</p>
+        <button onClick={handleGoHome}>Go Back Home</button>
+      </div>
+    </div>
+  );
+};
+
+export default ServiceUnavailable;

--- a/petclinic-frontend/src/pages/Error/Unauthorized.tsx
+++ b/petclinic-frontend/src/pages/Error/Unauthorized.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import './ErrorPage.css';
 import { AppRoutePaths } from '@/shared/models/path.routes.ts';
@@ -6,7 +6,7 @@ import { AppRoutePaths } from '@/shared/models/path.routes.ts';
 const Unauthorized: React.FC = () => {
   const navigate = useNavigate();
 
-  const handleGoHome = () => {
+  const handleGoHome = (): void => {
     navigate(AppRoutePaths.Home);
   };
 

--- a/petclinic-frontend/src/pages/Error/Unauthorized.tsx
+++ b/petclinic-frontend/src/pages/Error/Unauthorized.tsx
@@ -14,7 +14,7 @@ const Unauthorized: React.FC = () => {
     <div className="error-wrapper">
       <div className="error-container">
         <h1>401</h1>
-        <p>You are not authorized to view this page.</p>
+        <p>You are not authorized to access this page or resource.</p>
         <button onClick={handleGoHome}>Go Back Home</button>
       </div>
     </div>

--- a/petclinic-frontend/src/pages/Error/Unauthorized.tsx
+++ b/petclinic-frontend/src/pages/Error/Unauthorized.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './ErrorPage.css';
+import { AppRoutePaths } from '@/shared/models/path.routes.ts';
+
+const Unauthorized: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleGoHome = () => {
+    navigate(AppRoutePaths.Home);
+  };
+
+  return (
+    <div className="error-wrapper">
+      <div className="error-container">
+        <h1>401</h1>
+        <p>You are not authorized to view this page.</p>
+        <button onClick={handleGoHome}>Go Back Home</button>
+      </div>
+    </div>
+  );
+};
+
+export default Unauthorized;

--- a/petclinic-frontend/src/router.tsx
+++ b/petclinic-frontend/src/router.tsx
@@ -9,6 +9,12 @@ import ProfileEdit from '@/pages/Customer/ProfileEdit.tsx';
 import AddingCustomer from '@/pages/Customer/AddingCustomer.tsx';
 import CustomerBillingPage from '@/pages/Bills/CostumerBills.tsx';
 import AllOwners from '@/pages/Customer/AllOwners.tsx';
+import PageNotFound from '@/pages/Error/PageNotFound.tsx';
+import Forbidden from '@/pages/Error/Forbidden.tsx';
+import Unauthorized from '@/pages/Error/Unauthorized.tsx';
+import InternalServerError from '@/pages/Error/InternalServerError.tsx';
+import RequestTimeout from '@/pages/Error/RequestTimeout.tsx';
+import ServiceUnavailable from '@/pages/Error/ServiceUnavailable.tsx';
 
 const router = createBrowserRouter([
   {
@@ -67,6 +73,62 @@ const router = createBrowserRouter([
         element: (
           <ProtectedRoute>
             <AllOwners />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: AppRoutePaths.PageNotFound,
+        element: (
+          <ProtectedRoute>
+            <PageNotFound />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: AppRoutePaths.Forbidden,
+        element: (
+          <ProtectedRoute>
+            <Forbidden />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: AppRoutePaths.Unauthorized,
+        element: (
+          <ProtectedRoute>
+            <Unauthorized />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: AppRoutePaths.InternalServerError,
+        element: (
+          <ProtectedRoute>
+            <InternalServerError />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: AppRoutePaths.RequestTimeout,
+        element: (
+          <ProtectedRoute>
+            <RequestTimeout />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: AppRoutePaths.ServiceUnavailable,
+        element: (
+          <ProtectedRoute>
+            <ServiceUnavailable />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: '*',
+        element: (
+          <ProtectedRoute>
+            <PageNotFound />
           </ProtectedRoute>
         ),
       },

--- a/petclinic-frontend/src/shared/api/axiosErrorResponseHandler.ts
+++ b/petclinic-frontend/src/shared/api/axiosErrorResponseHandler.ts
@@ -7,23 +7,23 @@ export default function axiosErrorResponseHandler(
 ): void {
   switch (statusCode) {
     case 401:
-      // redirrect to the unauthorized page
+      // redirect to the unauthorized page
       router.navigate('/unauthorized');
       break;
     case 403:
-      // redirrect to the forbidden page
-      router.navigate('/unauthorized');
+      // redirect to the forbidden page
+      router.navigate('/forbidden');
       break;
     case 408:
-      // redirrect to the request timeout page
+      // redirect to the request timeout page
       router.navigate('/request-timeout');
       break;
     case 500:
-      // redirrect to the internal server error page
+      // redirect to the internal server error page
       router.navigate('/internal-server-error');
       break;
     case 503:
-      // redirrect to the service unavailable page
+      // redirect to the service unavailable page
       router.navigate('/service-unavailable');
       break;
     default:

--- a/petclinic-frontend/src/shared/models/path.routes.ts
+++ b/petclinic-frontend/src/shared/models/path.routes.ts
@@ -13,5 +13,5 @@ export enum AppRoutePaths {
   AddingCustomer = '/customer/add',
   AllCustomers = '/customers',
   Home = '/home',
-  Forbidden = '/forbidden'
+  Forbidden = '/forbidden',
 }

--- a/petclinic-frontend/src/shared/models/path.routes.ts
+++ b/petclinic-frontend/src/shared/models/path.routes.ts
@@ -5,12 +5,13 @@ export enum AppRoutePaths {
   CustomerBills = '/bills/customer',
   PageNotFound = '/page-not-found',
   Unauthorized = '/unauthorized',
-  ServiceTimeout = '/service-timeout',
-  InternalServer = '/internal-server',
+  RequestTimeout = '/request-timeout',
+  InternalServerError = '/internal-server-error',
   ServiceUnavailable = '/service-unavailable',
   login = '/users/login',
   CustomerProfileEdit = '/customer/profile/edit',
   AddingCustomer = '/customer/add',
   AllCustomers = '/customers',
   Home = '/home',
+  Forbidden = '/forbidden'
 }


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-1129
## Context:
We currently do not have custom error pages.
## Changes
- Created error pages for status code: 401, 403, 404, 408, 500, and 503.
- Button to go back home.
- Added some styling (might change in future). All pages use the same design.
- Routed all the pages accordingly.
## Before and After UI (Required for UI-impacting PRs)
**Before**
![image](https://github.com/user-attachments/assets/ed69762e-da37-4937-85c6-a44ce7672c2b)

**After**
![image](https://github.com/user-attachments/assets/ab5a21f0-fa90-4fd9-8cd4-0292e6121d3f)

![image](https://github.com/user-attachments/assets/a2eeb6d5-7bf8-42e3-9d5e-57801b6a1a70)
The other error pages look the same with their corresponding messages.