### PR TITLE
conf(CONF-CPC-1137): re-add VSCode extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,7 @@ out/
 .vs/champlain_petclinic/v16/.suo
 .vs/slnx.sqlite
 .vs/ProjectSettings.json
-### Include the plugin and project configuration ###
-!/.vscode/settings.json
-!/.vscode/extensions.json
+
 
 # Created by https://www.toptal.com/developers/gitignore/api/go
 # Edit at https://www.toptal.com/developers/gitignore?templates=go

--- a/petclinic-frontend/.gitignore
+++ b/petclinic-frontend/.gitignore
@@ -20,3 +20,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Include the plugin and project configuration
+!/.vscode/settings.json
+!/.vscode/extensions.json
+.vscode/

--- a/petclinic-frontend/.vscode/.editorconfig
+++ b/petclinic-frontend/.vscode/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/petclinic-frontend/.vscode/extensions.json
+++ b/petclinic-frontend/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+         "dbaeumer.vscode-eslint"
+    ]
+}

--- a/petclinic-frontend/.vscode/extensions.json
+++ b/petclinic-frontend/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "esbenp.prettier-vscode",
-         "dbaeumer.vscode-eslint"
+         "dbaeumer.vscode-eslint",
+         "rafapaulin.try-material-icon-theme"
     ]
 }

--- a/petclinic-frontend/.vscode/settings.json
+++ b/petclinic-frontend/.vscode/settings.json
@@ -1,0 +1,27 @@
+{
+    "editor.formatOnSave": true,
+    "prettier.configPath": "./.prettierrc.json",
+    "window.zoomLevel": -1,
+    "files.autoSave": "afterDelay",
+    "workbench.iconTheme": "material-icon-theme",
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "typescript.updateImportsOnFileMove.enabled": "always",
+    "files.autoSaveWorkspaceFilesOnly": true,
+    "github.copilot.preferredAccount": "nimar",
+    "notebook.formatOnSave.enabled": true,
+    "[typescript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": "explicit"
+        },
+        "eslint.validate": [
+          "javascript",
+          "javascriptreact",
+          "typescript",
+          "typescriptreact"
+        ]
+      
+}

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,13 +1,20 @@
-JIRA: link to jira ticket
+**JIRA:** link to jira ticket
 ## Context:
 What is the ticket about and why are we doing this change.
+## Does this PR change the .vscode folder in petclinic-frontend?:
+If the PR changes the .vscode folder, explain why in detail because it should not. 
+Be sure to include cgerard321 as a reviewer.
+
+<span style="color:red">**Reviewers need to check for any changes to the 
+.vscode folder and add a comment about it to their review comments.**</span>
+
 ## Changes
-What are the various changes and what other modules do those changes effect.
+What are the various changes and what other modules do those changes affect.
 This can be bullet point or sentence format.
 ## Before and After UI (Required for UI-impacting PRs)
 If this is a change to the UI, include before and after screenshots to show the differences.
 If this is a new UI feature, include screenshots to show reviewers what it looks like. 
 ## Dev notes (Optional)
-- Specific technical changes that should be noted
+Specific technical changes that should be noted
 ## Linked pull requests (Optional)
-- pull request link
+Pull request links


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-1137
## Context:
VSCode configuration and extensions for esLint and Prettier were removed. 
## Changes
- updated global .gitignore
- updated petclinic-frontend .gitignore
- added .vscode folder in petclinic-frontend
- added three configuration files in .vscode folder


## Before and After UI (Required for UI-impacting PRs)
N/A

## Dev notes (Optional)
N/A

## Linked pull requests (Optional)
https://github.com/cgerard321/champlain_petclinic/pull/619
https://github.com/cgerard321/champlain_petclinic/pull/631
