### PR TITLE
added negative test and added invalidinputexception inside the global…

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/config/GlobalExceptionHandler.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/config/GlobalExceptionHandler.java
@@ -129,4 +129,11 @@ public class GlobalExceptionHandler {
                 .body(new HttpErrorInfo(HttpStatus.FORBIDDEN.value(),ex.getMessage()));
     }
 
+    @ExceptionHandler(value = InvalidInputException.class)
+    public ResponseEntity<HttpErrorInfo> handleInvalidInputException(InvalidInputException ex){
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(new HttpErrorInfo(HttpStatus.UNPROCESSABLE_ENTITY.value(), ex.getMessage()));
+    }
+
+
 }


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-1139 
## Context:
Had to add a negative test for the new GetAllBillsByCustomerid endpoint in the bills v2 controller so that the test would be fully covered. 

## Changes
- Made changes inside the controller unit test so that the exception handling would work during tests.
- Added InvalidInputException to GlobalExceptionHandler so it could handle the exception.
- Made the negative test for GetAllBillsByCustomerid when it is given an invalid customer id. 
