### PR TITLE
feat/(CUST-CPC-1134): Render pages based on user roles

### DIFF
--- a/petclinic-frontend/src/context/UserContext.tsx
+++ b/petclinic-frontend/src/context/UserContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext, useState, ReactNode } from 'react';
 import { UserResponseModel } from '@/shared/models/UserResponseModel';
 import router from '@/router';
 import { AppRoutePaths } from '@/shared/models/path.routes.ts';
+import { Role } from '@/shared/models/Role.ts';
 
 interface UserContextType {
   user: UserResponseModel;
@@ -25,7 +26,7 @@ export const UserProvider = ({
       ? JSON.parse(storedUser)
       : {
           email: '',
-          roles: '',
+          roles: new Set<Role>(),
           userId: '',
           username: '',
         };
@@ -49,7 +50,7 @@ export const useUser = (): UserContextType => {
   if (!context) {
     router.navigate(AppRoutePaths.login);
     return {
-      user: { email: '', roles: '', userId: '', username: '' },
+      user: { email: '', roles: new Set<Role>(), userId: '', username: '' },
       setUser: () => {},
     };
   }
@@ -71,6 +72,15 @@ export const useSetUser = (): ((user: UserResponseModel) => void) => {
 export const IsAdmin = (): boolean => {
   const context = useUser();
   return (
-    context.user?.roles !== undefined && context.user.roles.includes('admin')
+    context.user?.roles !== undefined &&
+    Array.from(context.user.roles).some((role: Role) => role.name === 'ADMIN')
+  );
+};
+
+export const IsOwner = (): boolean => {
+  const context = useUser();
+  return (
+    context.user?.roles !== undefined &&
+    Array.from(context.user.roles).some((role: Role) => role.name === 'OWNER')
   );
 };

--- a/petclinic-frontend/src/context/UserContext.tsx
+++ b/petclinic-frontend/src/context/UserContext.tsx
@@ -84,3 +84,21 @@ export const IsOwner = (): boolean => {
     Array.from(context.user.roles).some((role: Role) => role.name === 'OWNER')
   );
 };
+
+export const IsVet = (): boolean => {
+  const context = useUser();
+  return (
+    context.user?.roles !== undefined &&
+    Array.from(context.user.roles).some((role: Role) => role.name === 'VET')
+  );
+};
+
+export const IsInventoryManager = (): boolean => {
+  const context = useUser();
+  return (
+    context.user?.roles !== undefined &&
+    Array.from(context.user.roles).some(
+      (role: Role) => role.name === 'INVENTORY_MANAGER'
+    )
+  );
+};

--- a/petclinic-frontend/src/features/customers/components/UpdateCustomerForm.css
+++ b/petclinic-frontend/src/features/customers/components/UpdateCustomerForm.css
@@ -1,4 +1,4 @@
-.profile-edit {
+.update-customer-form {
     max-width: 600px;
     margin: 50px auto;
     padding: 20px;
@@ -8,25 +8,25 @@
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
-.profile-edit h1 {
+.update-customer-form h1 {
     text-align: center;
     margin-bottom: 20px;
     color: #333;
     font-family: 'Arial', sans-serif;
 }
 
-.profile-edit form {
+.update-customer-form form {
     display: flex;
     flex-direction: column;
 }
 
-.profile-edit label {
+.update-customer-form label {
     margin-bottom: 15px;
     font-family: 'Arial', sans-serif;
     color: #555;
 }
 
-.profile-edit input {
+.update-customer-form input {
     padding: 10px;
     margin-top: 5px;
     border: 1px solid #ccc;
@@ -35,7 +35,7 @@
     font-size: 16px;
 }
 
-.profile-edit button {
+.update-customer-form button {
     padding: 12px;
     background-color: #28a745;
     color: white;
@@ -48,7 +48,7 @@
     transition: background-color 0.3s ease;
 }
 
-.profile-edit button:hover {
+.update-customer-form button:hover {
     background-color: #218838;
 }
 
@@ -59,7 +59,7 @@
     font-family: 'Arial', sans-serif;
 }
 
-.profile-edit input:focus {
+.update-customer-form input:focus {
     border-color: #28a745;
     box-shadow: 0 0 5px rgba(40, 167, 69, 0.5);
     outline: none;

--- a/petclinic-frontend/src/features/customers/components/UpdateCustomerForm.tsx
+++ b/petclinic-frontend/src/features/customers/components/UpdateCustomerForm.tsx
@@ -1,24 +1,48 @@
 import * as React from 'react';
-import { FormEvent, useState } from 'react';
-import { addOwner } from '@/features/customers/api/addOwner.ts';
+import { FormEvent, useEffect, useState } from 'react';
+import { updateOwner, getOwner } from '@/features/customers/api/updateOwner.ts';
+import { OwnerRequestModel } from '@/features/customers/models/OwnerRequestModel.ts';
+import { OwnerResponseModel } from '@/features/customers/models/OwnerResponseModel.ts';
 import { useNavigate } from 'react-router-dom';
 import { AppRoutePaths } from '@/shared/models/path.routes';
-import '@/features/customers/components/UpdateCustomerForm.css';
-import { OwnerModel } from '@/features/customers/models/OwnerModel.ts';
+import { useUser } from '@/context/UserContext';
+import './UpdateCustomerForm.css';
 
-const AddingCustomer: React.FC = (): JSX.Element => {
+const UpdateCustomerForm: React.FC = (): JSX.Element => {
   const navigate = useNavigate();
-  const [owner, setOwner] = useState<OwnerModel>({
-    ownerId: '',
+  const { user } = useUser();
+  const [owner, setOwner] = useState<OwnerRequestModel>({
     firstName: '',
     lastName: '',
     address: '',
     city: '',
     province: '',
     telephone: '',
-    pets: [],
   });
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
+
+  useEffect(() => {
+    const fetchOwnerData = async (): Promise<void> => {
+      try {
+        const response = await getOwner(user.userId);
+        const ownerData: OwnerResponseModel = response.data;
+        setOwner({
+          firstName: ownerData.firstName,
+          lastName: ownerData.lastName,
+          address: ownerData.address,
+          city: ownerData.city,
+          province: ownerData.province,
+          telephone: ownerData.telephone,
+        });
+      } catch (error) {
+        console.error('Error fetching owner data:', error);
+      }
+    };
+
+    fetchOwnerData().catch(error =>
+      console.error('Error in fetchOwnerData:', error)
+    );
+  }, [user.userId]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const { name, value } = e.target;
@@ -44,11 +68,10 @@ const AddingCustomer: React.FC = (): JSX.Element => {
     if (!validate()) return;
 
     try {
-      const response = await addOwner(owner);
-      if (response.status === 201) {
+      const response = await updateOwner(user.userId, owner);
+      if (response.status === 200) {
         navigate(AppRoutePaths.Home);
       } else {
-        console.error('Failed to add owner');
       }
     } catch (error) {
       console.error('Error:', error);
@@ -57,7 +80,7 @@ const AddingCustomer: React.FC = (): JSX.Element => {
 
   return (
     <div className="update-customer-form">
-      <h1>Add Customer</h1>
+      <h1>Edit Profile</h1>
       <form onSubmit={handleSubmit}>
         <label>First Name: </label>
         <input
@@ -113,10 +136,10 @@ const AddingCustomer: React.FC = (): JSX.Element => {
         />
         {errors.telephone && <span className="error">{errors.telephone}</span>}
         <br />
-        <button type="submit">Add</button>
+        <button type="submit">Update</button>
       </form>
     </div>
   );
 };
 
-export default AddingCustomer;
+export default UpdateCustomerForm;

--- a/petclinic-frontend/src/layouts/AppNavBar.tsx
+++ b/petclinic-frontend/src/layouts/AppNavBar.tsx
@@ -61,13 +61,6 @@ export function NavBar(): JSX.Element {
                   </Link>
                 </div>
               </li>
-              {IsAdmin() && (
-                <li className="nav-item">
-                  <Link className="nav-link" to="">
-                    Bills
-                  </Link>
-                </li>
-              )}
               <li className="nav-item">
                 <Link className="nav-link" to={AppRoutePaths.CustomerBills}>
                   Bills

--- a/petclinic-frontend/src/pages/Customer/AddingCustomer.css
+++ b/petclinic-frontend/src/pages/Customer/AddingCustomer.css
@@ -1,0 +1,66 @@
+.add-customer-form {
+    max-width: 600px;
+    margin: 50px auto;
+    padding: 20px;
+    border: 1px solid #ccc;
+    border-radius: 10px;
+    background-color: #ffffff;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.add-customer-form h1 {
+    text-align: center;
+    margin-bottom: 20px;
+    color: #333;
+    font-family: 'Arial', sans-serif;
+}
+
+.add-customer-form form {
+    display: flex;
+    flex-direction: column;
+}
+
+.add-customer-form label {
+    margin-bottom: 15px;
+    font-family: 'Arial', sans-serif;
+    color: #555;
+}
+
+.add-customer-form input {
+    padding: 10px;
+    margin-top: 5px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    font-family: 'Arial', sans-serif;
+    font-size: 16px;
+}
+
+.add-customer-form button {
+    padding: 12px;
+    background-color: #28a745;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    margin-top: 20px;
+    font-family: 'Arial', sans-serif;
+    font-size: 16px;
+    transition: background-color 0.3s ease;
+}
+
+.add-customer-form button:hover {
+    background-color: #218838;
+}
+
+.error {
+    color: red;
+    font-size: 0.8em;
+    margin-top: 5px;
+    font-family: 'Arial', sans-serif;
+}
+
+.add-customer-form input:focus {
+    border-color: #28a745;
+    box-shadow: 0 0 5px rgba(40, 167, 69, 0.5);
+    outline: none;
+}

--- a/petclinic-frontend/src/pages/Customer/AddingCustomer.tsx
+++ b/petclinic-frontend/src/pages/Customer/AddingCustomer.tsx
@@ -56,7 +56,7 @@ const AddingCustomer: React.FC = (): JSX.Element => {
   };
 
   return (
-    <div className="update-customer-form">
+    <div className="add-customer-form">
       <h1>Add Customer</h1>
       <form onSubmit={handleSubmit}>
         <label>First Name: </label>

--- a/petclinic-frontend/src/pages/Customer/ProfileEdit.tsx
+++ b/petclinic-frontend/src/pages/Customer/ProfileEdit.tsx
@@ -1,143 +1,26 @@
 import * as React from 'react';
-import { FormEvent, useEffect, useState } from 'react';
-import { updateOwner, getOwner } from '@/features/customers/api/updateOwner.ts';
-import { OwnerRequestModel } from '@/features/customers/models/OwnerRequestModel.ts';
-import { OwnerResponseModel } from '@/features/customers/models/OwnerResponseModel.ts';
+import UpdateCustomerForm from '@/features/customers/components/UpdateCustomerForm.tsx';
+import { IsOwner } from '@/context/UserContext.tsx';
+import { AppRoutePaths } from '@/shared/models/path.routes.ts';
 import { useNavigate } from 'react-router-dom';
-import { AppRoutePaths } from '@/shared/models/path.routes';
-import { useUser } from '@/context/UserContext';
-import './ProfileEdit.css';
+import { useEffect } from 'react';
 
 const ProfileEdit: React.FC = (): JSX.Element => {
   const navigate = useNavigate();
-  const { user } = useUser();
-  const [owner, setOwner] = useState<OwnerRequestModel>({
-    firstName: '',
-    lastName: '',
-    address: '',
-    city: '',
-    province: '',
-    telephone: '',
-  });
-  const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
   useEffect(() => {
-    const fetchOwnerData = async (): Promise<void> => {
-      try {
-        const response = await getOwner(user.userId);
-        const ownerData: OwnerResponseModel = response.data;
-        setOwner({
-          firstName: ownerData.firstName,
-          lastName: ownerData.lastName,
-          address: ownerData.address,
-          city: ownerData.city,
-          province: ownerData.province,
-          telephone: ownerData.telephone,
-        });
-      } catch (error) {
-        console.error('Error fetching owner data:', error);
-      }
-    };
-
-    fetchOwnerData().catch(error =>
-      console.error('Error in fetchOwnerData:', error)
-    );
-  }, [user.userId]);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const { name, value } = e.target;
-    setOwner({ ...owner, [name]: value });
-  };
-
-  const validate = (): boolean => {
-    const newErrors: { [key: string]: string } = {};
-    if (!owner.firstName) newErrors.firstName = 'First name is required';
-    if (!owner.lastName) newErrors.lastName = 'Last name is required';
-    if (!owner.address) newErrors.address = 'Address is required';
-    if (!owner.city) newErrors.city = 'City is required';
-    if (!owner.province) newErrors.province = 'Province is required';
-    if (!owner.telephone) newErrors.telephone = 'Telephone is required';
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  const handleSubmit = async (
-    event: FormEvent<HTMLFormElement>
-  ): Promise<void> => {
-    event.preventDefault();
-    if (!validate()) return;
-
-    try {
-      const response = await updateOwner(user.userId, owner);
-      if (response.status === 200) {
-        navigate(AppRoutePaths.Home);
-      } else {
-      }
-    } catch (error) {
-      console.error('Error:', error);
+    if (!IsOwner()) {
+      navigate(AppRoutePaths.Forbidden);
     }
-  };
+  }, [navigate]);
+
+  if (!IsOwner()) {
+    return <></>; // Return an empty fragment while navigating
+  }
 
   return (
-    <div className="profile-edit">
-      <h1>Edit Profile</h1>
-      <form onSubmit={handleSubmit}>
-        <label>First Name: </label>
-        <input
-          type="text"
-          name="firstName"
-          value={owner.firstName}
-          onChange={handleChange}
-        />
-        {errors.firstName && <span className="error">{errors.firstName}</span>}
-        <br />
-        <label>Last Name: </label>
-        <input
-          type="text"
-          name="lastName"
-          value={owner.lastName}
-          onChange={handleChange}
-        />
-        {errors.lastName && <span className="error">{errors.lastName}</span>}
-        <br />
-        <label>Address: </label>
-        <input
-          type="text"
-          name="address"
-          value={owner.address}
-          onChange={handleChange}
-        />
-        {errors.address && <span className="error">{errors.address}</span>}
-        <br />
-        <label>City: </label>
-        <input
-          type="text"
-          name="city"
-          value={owner.city}
-          onChange={handleChange}
-        />
-        {errors.city && <span className="error">{errors.city}</span>}
-        <br />
-        <label>Province: </label>
-        <input
-          type="text"
-          name="province"
-          value={owner.province}
-          onChange={handleChange}
-        />
-        {errors.province && <span className="error">{errors.province}</span>}
-        <br />
-        <label>Telephone: </label>
-        <input
-          type="text"
-          name="telephone"
-          value={owner.telephone}
-          onChange={handleChange}
-        />
-        {errors.telephone && <span className="error">{errors.telephone}</span>}
-        <br />
-        <button type="submit">Update</button>
-      </form>
+    <div>
+      <UpdateCustomerForm />
     </div>
   );
 };

--- a/petclinic-frontend/src/pages/Customer/ProfileEdit.tsx
+++ b/petclinic-frontend/src/pages/Customer/ProfileEdit.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import UpdateCustomerForm from '@/features/customers/components/UpdateCustomerForm.tsx';
+import { NavBar } from '@/layouts/AppNavBar.tsx';
 
 const ProfileEdit: React.FC = (): JSX.Element => {
   return (
     <div>
+      <NavBar />
       <UpdateCustomerForm />
     </div>
   );

--- a/petclinic-frontend/src/pages/Customer/ProfileEdit.tsx
+++ b/petclinic-frontend/src/pages/Customer/ProfileEdit.tsx
@@ -1,23 +1,7 @@
 import * as React from 'react';
 import UpdateCustomerForm from '@/features/customers/components/UpdateCustomerForm.tsx';
-import { IsOwner } from '@/context/UserContext.tsx';
-import { AppRoutePaths } from '@/shared/models/path.routes.ts';
-import { useNavigate } from 'react-router-dom';
-import { useEffect } from 'react';
 
 const ProfileEdit: React.FC = (): JSX.Element => {
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!IsOwner()) {
-      navigate(AppRoutePaths.Forbidden);
-    }
-  }, [navigate]);
-
-  if (!IsOwner()) {
-    return <></>; // Return an empty fragment while navigating
-  }
-
   return (
     <div>
       <UpdateCustomerForm />

--- a/petclinic-frontend/src/router.tsx
+++ b/petclinic-frontend/src/router.tsx
@@ -59,7 +59,7 @@ const router = createBrowserRouter([
       {
         path: AppRoutePaths.CustomerProfileEdit,
         element: (
-          <ProtectedRoute>
+          <ProtectedRoute roles={['OWNER', 'ADMIN']}>
             <ProfileEdit />
           </ProtectedRoute>
         ),
@@ -67,7 +67,7 @@ const router = createBrowserRouter([
       {
         path: AppRoutePaths.AddingCustomer,
         element: (
-          <ProtectedRoute>
+          <ProtectedRoute roles={['ADMIN']}>
             <AddingCustomer />
           </ProtectedRoute>
         ),
@@ -83,7 +83,7 @@ const router = createBrowserRouter([
       {
         path: AppRoutePaths.AllCustomers,
         element: (
-          <ProtectedRoute>
+          <ProtectedRoute roles={['ADMIN', 'VET']}>
             <AllOwners />
           </ProtectedRoute>
         ),
@@ -160,26 +160,6 @@ const router = createBrowserRouter([
           </ProtectedRoute>
         ),
       },
-      //   {
-      //       path: AppRoutePaths.PageNotFound,
-      //       element: /* PageNotFoundComponent */
-      //   },
-      //   {
-      //       path: AppRoutePaths.InternalServer,
-      //       element: /* InternalServerErrorComponent */
-      //   },
-      //   {
-      //       path: AppRoutePaths.ServiceTimeout,
-      //       element: /* ServiceTimeoutComponent */
-      //   },
-      //   {
-      //       path: AppRoutePaths.ServiceUnavailable,
-      //       element: /* ServiceUnavailableComponent */
-      //   },
-      //   {
-      //       path: AppRoutePaths.Unauthorized,
-      //       element: /* UnauthorizedComponent */
-      //   }
     ],
   },
   { path: AppRoutePaths.login, element: <Login /> },

--- a/petclinic-frontend/src/router.tsx
+++ b/petclinic-frontend/src/router.tsx
@@ -59,7 +59,7 @@ const router = createBrowserRouter([
       {
         path: AppRoutePaths.CustomerProfileEdit,
         element: (
-          <ProtectedRoute roles={['OWNER', 'ADMIN']}>
+          <ProtectedRoute roles={['OWNER']}>
             <ProfileEdit />
           </ProtectedRoute>
         ),

--- a/petclinic-frontend/src/shared/components/ProtectedRouteProps.tsx
+++ b/petclinic-frontend/src/shared/components/ProtectedRouteProps.tsx
@@ -1,14 +1,28 @@
 // src/components/ProtectedRoute.tsx
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { useAuthRedirect } from '@/shared/hooks/useAuthRedirect';
+import { useHasRequiredRole } from '@/shared/hooks/useHasRequiredRole';
+import { AppRoutePaths } from '@/shared/models/path.routes.ts';
+import { useNavigate } from 'react-router-dom';
 
 interface ProtectedRouteProps {
   children: ReactNode;
+  roles?: string[];
 }
 
 export const ProtectedRoute = ({
   children,
+  roles,
 }: ProtectedRouteProps): JSX.Element => {
   useAuthRedirect();
+  const navigate = useNavigate();
+  const hasRequiredRole = useHasRequiredRole(roles);
+
+  useEffect(() => {
+    if (!hasRequiredRole) {
+      navigate(AppRoutePaths.Forbidden);
+    }
+  }, [hasRequiredRole, navigate]);
+
   return <>{children}</>;
 };

--- a/petclinic-frontend/src/shared/hooks/useHasRequiredRole.ts
+++ b/petclinic-frontend/src/shared/hooks/useHasRequiredRole.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+import { useUser } from '@/context/UserContext.tsx';
+
+export const useHasRequiredRole = (roles?: string[]): boolean => {
+  const { user } = useUser();
+
+  const hasRequiredRole = useCallback((): boolean => {
+    if (!roles) return true; // If no role is specified, everyone can access it
+    return roles.some(role =>
+      Array.from(user.roles).some(userRole => userRole.name === role)
+    );
+  }, [roles, user.roles]);
+
+  return hasRequiredRole();
+};

--- a/petclinic-frontend/src/shared/models/Role.ts
+++ b/petclinic-frontend/src/shared/models/Role.ts
@@ -1,0 +1,4 @@
+export interface Role {
+  id: number;
+  name: string;
+}

--- a/petclinic-frontend/src/shared/models/UserResponseModel.ts
+++ b/petclinic-frontend/src/shared/models/UserResponseModel.ts
@@ -1,6 +1,8 @@
+import { Role } from '@/shared/models/Role.ts';
+
 export interface UserResponseModel {
   username: string;
   email: string;
   userId: string;
-  roles: string;
+  roles: Set<Role>;
 }


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1134
## Context:
Currently, users can access every page that the axiosErrorResponseHandler doesn't handle. This means that an admin or vet is able to access the customer profile edit page which only a customer should be able to see.
## Does this PR change the .vscode folder in petclinic-frontend?:
Absolutely not. I hope.
## Changes
- Created a hook to validate user roles (useHasRequiredRole.ts). Implemented it in the ProtectedRouteProps.tsx
- Added the roles that are authorized to access ProfileEdit, AddingCustomer, and AllOwners. Other teams can implement it to their pages as well (see dev notes).
- Created 4 additional functions that people can use in the UserContext.tsx
- Refactored and reorganized the ProfileEdit.tsx. The update form is now a component in the newly created components folder in features/customers
## Before and After UI (Required for UI-impacting PRs)
No change to the UI. Users will just be redirected to 403 Forbidden when they access pages they shouldn't see
## Dev notes (Optional)
If you want to make a page accessible by roles, just take a look at router.tsx. Pages that trigger the axiosErrorResponseHandler will automatically redirect users to an error page. If you want to be consistent, then add roles to each page that would require it.
## Linked pull requests (Optional)
Update Customer https://github.com/cgerard321/champlain_petclinic/pull/622
Add Customer https://github.com/cgerard321/champlain_petclinic/pull/632
Show all customers https://github.com/cgerard321/champlain_petclinic/pull/634