### PR TITLE
bug(PROD-CPC-1142): revert products getall

### DIFF
--- a/petclinic-frontend/src/features/products/api/getAllProducts.ts
+++ b/petclinic-frontend/src/features/products/api/getAllProducts.ts
@@ -2,11 +2,16 @@ import axiosInstance from '@/shared/api/axiosInstance.ts';
 import { ProductModel } from '@/features/inventories/models/ProductModels/ProductModel.ts';
 
 export async function getAllProducts(): Promise<ProductModel[]> {
-  try {
-    const res = await axiosInstance.get<ProductModel[]>('/products');
-    return res.data;
-  } catch (err) {
-    console.error('Error fetching products:', err);
-    return [];
-  }
+  const res = await axiosInstance.get('/products', { responseType: 'stream' });
+  return res.data
+    .split('data:')
+    .map((dataChunk: string) => {
+      try {
+        if (dataChunk == '') return null;
+        return JSON.parse(dataChunk);
+      } catch (err) {
+        console.error('Could not parse JSON: ' + err);
+      }
+    })
+    .filter((data?: JSON) => data !== null);
 }


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1142
## Context:
After the following [commit](https://github.com/cgerard321/champlain_petclinic/commit/a2c737d0810c795f601678aaf9df4303ee92f896), the Products page was broken due to getAll being changed to a fetcher that expects a APPLICATION_JSON format but the backend returns an EVENT_STREAM.

## Does this PR change the .vscode folder in petclinic-frontend?: No
If the PR changes the .vscode folder, explain why in detail because it should not. 
Be sure to include cgerard321 as a reviewer.

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
- Revert getAllProducts to previous version (event-stream implementation)
## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://github.com/user-attachments/assets/d415cc94-b588-492a-a2f6-756ae68fa80e)

After:
![image](https://github.com/user-attachments/assets/6caf028a-17d0-4304-b231-dc96b90d9aaf)

## Dev notes (Optional)
Please don't change getAllProducts implementation, this one is fine.
Thank you.
## Linked pull requests (Optional)
https://github.com/cgerard321/champlain_petclinic/pull/655