### PR TITLE
bug/(CUST-CPC-1143): Add back roles for pages that were accidentally removed

### DIFF
--- a/petclinic-frontend/src/router.tsx
+++ b/petclinic-frontend/src/router.tsx
@@ -197,26 +197,6 @@ const router = createBrowserRouter([
           </ProtectedRoute>
         ),
       },
-      //   {
-      //       path: AppRoutePaths.PageNotFound,
-      //       element: /* PageNotFoundComponent */
-      //   },
-      //   {
-      //       path: AppRoutePaths.InternalServer,
-      //       element: /* InternalServerErrorComponent */
-      //   },
-      //   {
-      //       path: AppRoutePaths.ServiceTimeout,
-      //       element: /* ServiceTimeoutComponent */
-      //   },
-      //   {
-      //       path: AppRoutePaths.ServiceUnavailable,
-      //       element: /* ServiceUnavailableComponent */
-      //   },
-      //   {
-      //       path: AppRoutePaths.Unauthorized,
-      //       element: /* UnauthorizedComponent */
-      //   }
     ],
   },
   { path: AppRoutePaths.login, element: <Login /> },

--- a/petclinic-frontend/src/router.tsx
+++ b/petclinic-frontend/src/router.tsx
@@ -95,7 +95,7 @@ const router = createBrowserRouter([
       {
         path: AppRoutePaths.CustomerProfileEdit,
         element: (
-          <ProtectedRoute>
+          <ProtectedRoute roles={['OWNER']}>
             <ProfileEdit />
           </ProtectedRoute>
         ),
@@ -103,7 +103,7 @@ const router = createBrowserRouter([
       {
         path: AppRoutePaths.AddingCustomer,
         element: (
-          <ProtectedRoute>
+          <ProtectedRoute roles={['ADMIN']}>
             <AddingCustomer />
           </ProtectedRoute>
         ),
@@ -119,7 +119,7 @@ const router = createBrowserRouter([
       {
         path: AppRoutePaths.AllCustomers,
         element: (
-          <ProtectedRoute>
+          <ProtectedRoute roles={['ADMIN', 'VET']}>
             <AllOwners />
           </ProtectedRoute>
         ),

--- a/petclinic-frontend/src/router.tsx
+++ b/petclinic-frontend/src/router.tsx
@@ -84,7 +84,6 @@ const router = createBrowserRouter([
           </ProtectedRoute>
         ),
       },
-
       {
         path: AppRoutePaths.Vet,
         element: (
@@ -122,14 +121,6 @@ const router = createBrowserRouter([
         element: (
           <ProtectedRoute>
             <AllOwners />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: AppRoutePaths.PageNotFound,
-        element: (
-          <ProtectedRoute>
-            <PageNotFound />
           </ProtectedRoute>
         ),
       },
@@ -174,14 +165,6 @@ const router = createBrowserRouter([
         ),
       },
       {
-        path: '*',
-        element: (
-          <ProtectedRoute>
-            <PageNotFound />
-          </ProtectedRoute>
-        ),
-      },
-      {
         path: AppRoutePaths.Products,
         element: (
           <ProtectedRoute>
@@ -200,7 +183,10 @@ const router = createBrowserRouter([
     ],
   },
   { path: AppRoutePaths.login, element: <Login /> },
-  //   {path: '*', element: /* PageNotFoundComponent */},
+  {
+    path: '*',
+    element: <PageNotFound />,
+  },
 ]);
 
 export default router;


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1143
## Context:
The PR https://github.com/cgerard321/champlain_petclinic/pull/665 accidentally removed the roles for the pages that were added in PR https://github.com/cgerard321/champlain_petclinic/pull/656. This was done in the file router.tsx.
## Does this PR change the .vscode folder in petclinic-frontend?:
No
## Changes
- Reverted the change
- Moved PageNotFound to where it should be
## Linked pull requests (Optional)
https://github.com/cgerard321/champlain_petclinic/pull/656
https://github.com/cgerard321/champlain_petclinic/pull/665