### PR TITLE
feat/(VIST-CPC-1167): Update UI for visits section

### DIFF
--- a/petclinic-frontend/src/features/visits/VisitListTable.css
+++ b/petclinic-frontend/src/features/visits/VisitListTable.css
@@ -1,12 +1,43 @@
-table {
-  margin-left: auto;
-  margin-right: auto;
+.visit-actions {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 20px;
 }
 
-td,
-th {
-  padding: 10px;
-  background-color: #f1f1f1;
-  border: 1px solid black;
-  text-align: center;
+.visit-table-section {
+  margin-top: 40px;
 }
+
+.btn {
+  padding: 10px 20px;
+  margin: 5px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+table th, table td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid #ddd;
+}
+
+table th {
+  background-color: #f2f2f2;
+}
+
+table tr:hover {
+  background-color: #f5f5f5;
+}
+
+h1, h2 {
+  font-size: 24px;
+  margin-bottom: 15px;
+}
+
+

--- a/petclinic-frontend/src/features/visits/VisitListTable.tsx
+++ b/petclinic-frontend/src/features/visits/VisitListTable.tsx
@@ -8,7 +8,6 @@ export default function VisitListTable(): JSX.Element {
   const [visitsList, setVisitsList] = useState<Visit[]>([]);
   const navigate = useNavigate();
 
-  // Real-time updates (SEE)
   useEffect(() => {
     const eventSource = new EventSource(
       'http://localhost:8080/api/v2/gateway/visits',
@@ -21,7 +20,6 @@ export default function VisitListTable(): JSX.Element {
       try {
         const newVisit: Visit = JSON.parse(event.data);
         setVisitsList(oldVisits => {
-          // Check to see if the new visit is already in the list
           if (!oldVisits.some(visit => visit.visitId === newVisit.visitId)) {
             return [...oldVisits, newVisit];
           }
@@ -32,7 +30,6 @@ export default function VisitListTable(): JSX.Element {
       }
     };
 
-    // Handle errors
     eventSource.onerror = error => {
       console.error('EventSource error:', error);
       eventSource.close();
@@ -43,32 +40,19 @@ export default function VisitListTable(): JSX.Element {
     };
   }, []);
 
-  return (
-    <div>
-      <button
-        className="btn btn-warning"
-        onClick={() => navigate('/forms')}
-        title="Let a review"
-      >
-        Leave a Review
-      </button>
-      <p></p>
-      <button
-        className="btn btn-dark"
-        onClick={() => navigate('/reviews')}
-        title="View review"
-      >
-        View Reviews
-      </button>
+  const confirmedVisits = visitsList.filter(
+    visit => visit.status === 'CONFIRMED'
+  );
+  const upcomingVisits = visitsList.filter(
+    visit => visit.status === 'UPCOMING'
+  );
+  const completedVisits = visitsList.filter(
+    visit => visit.status === 'COMPLETED'
+  );
 
-      <button
-        className="btn btn-warning"
-        onClick={() => navigate(AppRoutePaths.AddVisit)}
-        title="Make a visit"
-      >
-        Make a visit
-      </button>
-      <h1>Visits List</h1>
+  const renderTable = (title: string, visits: Visit[]): JSX.Element => (
+    <div className="visit-table-section">
+      <h2>{title}</h2>
       <table>
         <thead>
           <tr>
@@ -80,10 +64,11 @@ export default function VisitListTable(): JSX.Element {
             <th>Vet Last Name</th>
             <th>Vet Email</th>
             <th>Status</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
-          {visitsList.map(visit => (
+          {visits.map(visit => (
             <tr key={visit.visitId}>
               <td>{visit.visitId}</td>
               <td>{new Date(visit.visitDate).toLocaleString()}</td>
@@ -119,6 +104,38 @@ export default function VisitListTable(): JSX.Element {
           ))}
         </tbody>
       </table>
+    </div>
+  );
+
+  return (
+    <div>
+      <div className="visit-actions">
+        <button
+          className="btn btn-warning"
+          onClick={() => navigate('/forms')}
+          title="Leave a Review"
+        >
+          Leave a Review
+        </button>
+        <button
+          className="btn btn-dark"
+          onClick={() => navigate('/reviews')}
+          title="View Reviews"
+        >
+          View Reviews
+        </button>
+        <button
+          className="btn btn-warning"
+          onClick={() => navigate(AppRoutePaths.AddVisit)}
+          title="Make a Visit"
+        >
+          Make a Visit
+        </button>
+      </div>
+
+      {renderTable('Confirmed Visits', confirmedVisits)}
+      {renderTable('Upcoming Visits', upcomingVisits)}
+      {renderTable('Completed Visits', completedVisits)}
     </div>
   );
 }

--- a/petclinic-frontend/src/pages/Visit/Visit.tsx
+++ b/petclinic-frontend/src/pages/Visit/Visit.tsx
@@ -1,12 +1,15 @@
 import VisitListTable from '@/features/visits/VisitListTable';
 import { NavBar } from '@/layouts/AppNavBar';
+import './Visits.css';
 
 export default function Visits(): JSX.Element {
   return (
-    <div>
+    <>
       <NavBar />
-      <h2>This is the Visits Page</h2>
-      <VisitListTable />
-    </div>
+      <div className="page-container">
+        <h2>This is the Visits Page</h2>
+        <VisitListTable />
+      </div>
+    </>
   );
 }

--- a/petclinic-frontend/src/pages/Visit/Visits.css
+++ b/petclinic-frontend/src/pages/Visit/Visits.css
@@ -1,0 +1,3 @@
+.page-container {
+    padding: 20px;
+}


### PR DESCRIPTION
**JIRA:** [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1167)
## Context:
What is the ticket about and why are we doing this change.
Implementing a cleaner and organized UI design to the visits section. Now the visits will be displayed in different tables based on their status.
## Does this PR change the .vscode folder in petclinic-frontend?:
No, it doesn't change the .vscode.

## Changes
What are the various changes and what other modules do those changes affect.
The buttons are now separated from one another.
The visits table are separated by upcoming, completed and confirmed visits.
Added padding to the page container. 
## Before and After UI (Required for UI-impacting PRs)
Before:
![{819D8A82-C7BD-40C3-B8AA-3A4C568CE1F6}](https://github.com/user-attachments/assets/0e453c34-1f0d-4ac3-91ac-0d9ecb0052c0)

After:
![{802DC349-4732-4DDC-8B23-A0A9F07A8C54}](https://github.com/user-attachments/assets/3c94f613-0bc7-4dde-b0b4-9f42610c4a6e)
