### PR TITLE
Added get by id for v2 positive test and not found negative test for …

### DIFF
--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigCustomersService.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigCustomersService.java
@@ -94,6 +94,32 @@ public class MockServerConfigCustomersService {
                 );
     }
 
+    public void registerGetOwnerByIdEndpoint() {
+        String ownerResponseJson = "{"
+                + "\"ownerId\":\"e6c7398e-8ac4-4e10-9ee0-03ef33f0361a\","
+                + "\"firstName\":\"Betty\","
+                + "\"lastName\":\"Davis\","
+                + "\"address\":\"638 Cardinal Ave.\","
+                + "\"city\":\"Sun Prairie\","
+                + "\"province\":\"Quebec\","
+                + "\"telephone\":\"6085551749\","
+                + "\"pets\":null"
+                + "}";
+
+        mockServerClient_CustomersService
+                .when(
+                        request()
+                                .withMethod("GET")
+                                .withPath("/owners/e6c7398e-8ac4-4e10-9ee0-03ef33f0361a")
+                )
+                .respond(
+                        response()
+                                .withStatusCode(200)
+                                .withBody(json(ownerResponseJson))
+                                .withHeader("Content-Type", "application/json")
+                );
+    }
+
 
 
     public void stopMockServer() {


### PR DESCRIPTION

**JIRA:** [link to jira ticket](https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/15/backlog?selectedIssue=CPC-1061&text=CUST)

## Context:
Added some testing since it wasn't done yet for the v2 endpoint
## Does this PR change the .vscode folder in petclinic-frontend?:
No

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
- MockServerConfigCustomersService, added mocking of get by id endpoint
- OwnerControllerIntegrationTest, Added a positive and negative test for v2 get owner by id
## Before and After UI (Required for UI-impacting PRs)
No UI change