### PR TITLE
Feat/INVT-CPC-1040/Display_Low_Stock_Supplies_On_Click

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/InventoryServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/InventoryServiceClient.java
@@ -264,4 +264,16 @@ public class InventoryServiceClient {
                 .bodyToMono(Void.class);
     }
 
+    public Flux<ProductResponseDTO> getLowStockProducts(String inventoryId, int stockThreshold) {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(inventoryServiceUrl + "/{inventoryId}/products/lowstock")
+                .queryParam("threshold", stockThreshold);
+
+        return webClient.get()
+                .uri(uriBuilder.buildAndExpand(inventoryId).toUri())
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError,
+                        resp -> Mono.error(new NotFoundException("No products below threshold in inventory: " + inventoryId)))
+                .bodyToFlux(ProductResponseDTO.class);
+    }
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -1059,6 +1059,12 @@ public class BFFApiGatewayController {
         return inventoryServiceClient.deleteInventoryByInventoryId(inventoryId);
     }
 
+    @GetMapping(value="inventory/{inventoryId}/products/lowstock")
+    public Flux<ProductResponseDTO>getLowStockProducts(@PathVariable String inventoryId, @RequestParam Optional<Integer> threshold){
+        int stockThreshold = threshold.orElse(16);
+        return inventoryServiceClient.getLowStockProducts(inventoryId, stockThreshold);
+    }
+
     @SecuredEndpoint(allowedRoles = {Roles.ALL})
     @GetMapping(value = "owners/petTypes")//, produces= MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<PetTypeResponseDTO> getAllPetTypes() {

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryService.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryService.java
@@ -29,5 +29,8 @@ public interface ProductInventoryService {
 
     Mono<ProductResponseDTO> getProductByProductIdInInventory(String inventoryId, String productId);
 
+    Flux<ProductResponseDTO> getLowStockProducts(String inventoryId, int stockThreshold);
 
-}
+
+
+    }

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryServiceImpl.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryServiceImpl.java
@@ -409,6 +409,14 @@ public class ProductInventoryServiceImpl implements ProductInventoryService {
                 .switchIfEmpty(Mono.error(new NotFoundException("Inventory id:" + inventoryId + "and product:" + productId + "are not found")));
     }
 
+    @Override
+    public Flux<ProductResponseDTO> getLowStockProducts(String inventoryId, int stockThreshold) {
+        return productRepository
+                .findAllByInventoryIdAndProductQuantityLessThan(inventoryId, stockThreshold)
+                .map(EntityDTOUtil::toProductResponseDTO)
+                .switchIfEmpty(Mono.error(new NotFoundException("No products below threshold in inventory: " + inventoryId)));
+    }
+
     //delete all products and delete all inventory
     @Override
     public Mono<Void> deleteAllProductInventory (String inventoryId){
@@ -440,5 +448,7 @@ public class ProductInventoryServiceImpl implements ProductInventoryService {
         return inventoryTypeRepository.findAll()
                 .map(EntityDTOUtil::toInventoryTypeResponseDTO);
     }
+
+
 }
 

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/datalayer/Product/ProductRepository.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/datalayer/Product/ProductRepository.java
@@ -23,4 +23,5 @@ public interface ProductRepository extends ReactiveMongoRepository<Product, Stri
    //Regex
     Flux<Product> findAllProductsByInventoryIdAndProductNameRegex(String inventoryId, String regex);
 
+    Flux<Product> findAllByInventoryIdAndProductQuantityLessThan(String inventoryId, int productQuantity);
 }

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/presentationlayer/InventoryController.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/presentationlayer/InventoryController.java
@@ -154,5 +154,11 @@ public Flux<InventoryResponseDTO> searchInventories(
     return productInventoryService.getAllInventoryTypes();
     }
 
+    @GetMapping("/{inventoryId}/products/lowstock")
+    public Flux<ProductResponseDTO> getLowStockProducts(@PathVariable String inventoryId, @RequestParam Optional<Integer> threshold) {
+        int stockThreshold = threshold.orElse(16);
+        return productInventoryService.getLowStockProducts(inventoryId, stockThreshold);
+    }
+
 }
 

--- a/inventory-service/src/test/java/com/petclinic/inventoryservice/datalayer/Product/ProductRepositoryTest.java
+++ b/inventory-service/src/test/java/com/petclinic/inventoryservice/datalayer/Product/ProductRepositoryTest.java
@@ -240,6 +240,22 @@ class ProductRepositoryTest {
                 .verifyComplete();
     }
 
+    @Test
+    public void shouldFindNoProductsWhenNoneAreBelowThreshold() {
+        // Act & Assert
+        StepVerifier
+                .create(productRepository.findAllByInventoryIdAndProductQuantityLessThan("inventoryId_1", 3))  // No product with stock less than 3
+                .verifyComplete();  // Expect no results
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenInventoryDoesNotExist() {
+        // Act & Assert
+        StepVerifier
+                .create(productRepository.findAllByInventoryIdAndProductQuantityLessThan("nonExistingInventoryId", 50))
+                .verifyComplete();
+    }
+
 
     private Product buildProduct(String inventoryId, String productId, String productName, String productDescription, Double productPrice, Integer productQuantity, Double productSalePrice) {
         return Product.builder()

--- a/inventory-service/src/test/java/com/petclinic/inventoryservice/presentationlayer/InventoryControllerIntegrationTest.java
+++ b/inventory-service/src/test/java/com/petclinic/inventoryservice/presentationlayer/InventoryControllerIntegrationTest.java
@@ -1059,9 +1059,4 @@ class InventoryControllerIntegrationTest {
     }
 
  */
-
-
-
-
-
 }

--- a/inventory-service/src/test/java/com/petclinic/inventoryservice/presentationlayer/InventoryControllerUnitTest.java
+++ b/inventory-service/src/test/java/com/petclinic/inventoryservice/presentationlayer/InventoryControllerUnitTest.java
@@ -78,6 +78,17 @@ class InventoryControllerUnitTest {
                     .build()
     );
 
+    ProductResponseDTO lowStockProduct = ProductResponseDTO.builder()
+            .id("1")
+            .inventoryId("inventoryId_1")
+            .productId("productId_1")
+            .productName("Low Stock Product")
+            .productQuantity(5)
+            .productPrice(100.00)
+            .build();
+
+    List<ProductResponseDTO> lowStockProducts = List.of(lowStockProduct);
+
     @Test
     void updateInventory_ValidRequest_ShouldReturnOk() {
         // Arrange
@@ -1291,26 +1302,100 @@ class InventoryControllerUnitTest {
                 .updateProductInInventory(any(), eq(inventoryId), eq(productId));
 
 
-
     }
 
+    @Test
+    void getLowStockProducts_WithDefaultThreshold_ShouldReturnLowStockProducts() {
+        // Arrange
+        String inventoryId = "inventoryId_1";
+        int defaultThreshold = 16;
 
+        when(productInventoryService.getLowStockProducts(inventoryId, defaultThreshold))
+                .thenReturn(Flux.fromIterable(lowStockProducts));
 
+        // Act & Assert
+        webTestClient.get()
+                .uri("/inventory/{inventoryId}/products/lowstock", inventoryId)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBodyList(ProductResponseDTO.class)
+                .value(products -> {
+                    assertNotNull(products);
+                    assertEquals(1, products.size());
+                    assertEquals(lowStockProduct.getProductName(), products.get(0).getProductName());
+                    assertEquals(lowStockProduct.getProductQuantity(), products.get(0).getProductQuantity());
+                });
 
+        verify(productInventoryService, times(1)).getLowStockProducts(inventoryId, defaultThreshold);
+    }
 
+    @Test
+    void getLowStockProducts_WithCustomThreshold_ShouldReturnLowStockProducts() {
+        // Arrange
+        String inventoryId = "inventoryId_1";
+        int customThreshold = 10;
 
+        when(productInventoryService.getLowStockProducts(inventoryId, customThreshold))
+                .thenReturn(Flux.fromIterable(lowStockProducts));
 
+        // Act & Assert
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/inventory/{inventoryId}/products/lowstock")
+                        .queryParam("threshold", String.valueOf(customThreshold))
+                        .build(inventoryId))
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBodyList(ProductResponseDTO.class)
+                .value(products -> {
+                    assertNotNull(products);
+                    assertEquals(1, products.size());
+                    assertEquals(lowStockProduct.getProductName(), products.get(0).getProductName());
+                    assertEquals(lowStockProduct.getProductQuantity(), products.get(0).getProductQuantity());
+                });
+
+        verify(productInventoryService, times(1)).getLowStockProducts(inventoryId, customThreshold);
+    }
+
+//    @Test
+//    void getLowStockProducts_WithInvalidInventoryId_ShouldReturnNotFound() {
+//        // Arrange
+//        String invalidInventoryId = "nonExistentInventory";
+//        int threshold = 16;
+//
+//        when(productInventoryService.getLowStockProducts(invalidInventoryId, threshold))
+//                .thenReturn(Flux.empty());
+//
+//        // Act & Assert
+//        webTestClient.get()
+//                .uri("/inventory/{inventoryId}/products/lowstock", invalidInventoryId)
+//                .accept(MediaType.APPLICATION_JSON)
+//                .exchange()
+//                .expectStatus().isNotFound();
+//
+//        verify(productInventoryService, times(1)).getLowStockProducts(invalidInventoryId, threshold);
+//    }
+
+//    @Test
+//    void getLowStockProducts_WithEmptyResult_ShouldReturnNoContent() {
+//        // Arrange
+//        String inventoryId = "inventoryId_2";
+//        int threshold = 16;
+//
+//        when(productInventoryService.getLowStockProducts(inventoryId, threshold))
+//                .thenReturn(Flux.empty());
+//
+//        // Act & Assert
+//        webTestClient.get()
+//                .uri("/inventory/{inventoryId}/products/lowstock", inventoryId)
+//                .accept(MediaType.APPLICATION_JSON)
+//                .exchange()
+//                .expectStatus().isNoContent();
+//
+//        verify(productInventoryService, times(1)).getLowStockProducts(inventoryId, threshold);
+//    }
 
 }
-
-
-
-
-
-
-
-
-
-
-
-

--- a/petclinic-frontend/src/features/inventories/InventoriesListTable.tsx
+++ b/petclinic-frontend/src/features/inventories/InventoriesListTable.tsx
@@ -8,6 +8,7 @@ import deleteAllInventories from '@/features/inventories/api/deleteAllInventorie
 import './InventoriesListTable.css';
 import deleteInventory from '@/features/inventories/api/deleteInventory.ts';
 import AddInventoryType from '@/features/inventories/AddInventoryType.tsx';
+import { ProductModel } from '@/features/inventories/models/ProductModels/ProductModel.ts';
 
 //TODO: create add inventory form component and change the component being shown on the inventories page on the onClick event of the add inventory button
 export default function InventoriesListTable(): JSX.Element {
@@ -23,6 +24,9 @@ export default function InventoriesListTable(): JSX.Element {
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [showAddTypeForm, setShowAddTypeForm] = useState(false); // Add state to control the form visibility
   const navigate = useNavigate();
+  const [lowStockProductsByInventory, setLowStockProductsByInventory] =
+    useState<{ [inventoryName: string]: ProductModel[] }>({});
+  const [showLowStock, setShowLowStock] = useState(false);
 
   const {
     inventoryList,
@@ -76,6 +80,41 @@ export default function InventoriesListTable(): JSX.Element {
         return;
       }
       setShowConfirmDialog(true);
+    }
+  };
+
+  const getAllLowStockProducts = async (
+    inventory: Inventory
+  ): Promise<void> => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/gateway/inventory/${inventory.inventoryId}/products/lowstock`,
+        {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            Accept: 'application/json',
+          },
+        }
+      );
+
+      if (response.status === 404) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `No products below threshold in inventory: ${inventory.inventoryName}`
+        );
+      }
+
+      const data = await response.json();
+      if (data && data.length > 0) {
+        setLowStockProductsByInventory(prevState => ({
+          ...prevState,
+          [inventory.inventoryName]: data, //Group products by inventory name
+        }));
+        setShowLowStock(true);
+      }
+    } catch (error) {
+      console.error('Error fetching low stock products:', error);
     }
   };
 
@@ -353,6 +392,47 @@ export default function InventoriesListTable(): JSX.Element {
       >
         Add Inventory
       </button>
+      <button
+        className="low-stock-button btn btn-warning mx-1"
+        onClick={async () => {
+          if (inventoryList.length > 0) {
+            setLowStockProductsByInventory({});
+            try {
+              for (const inventory of inventoryList) {
+                await getAllLowStockProducts(inventory);
+              }
+            } catch (error) {
+              console.error('Error fetching low stock products:', error);
+            }
+          } else {
+            console.error('No inventories found');
+          }
+        }}
+      >
+        Check Low Stock for All Inventories
+      </button>
+
+      {showLowStock && Object.keys(lowStockProductsByInventory).length > 0 && (
+        <div>
+          <h3>Low Stock Products</h3>
+          {Object.entries(lowStockProductsByInventory).map(
+            ([inventoryName, products]) => (
+              <div key={inventoryName}>
+                <h4>Inventory: {inventoryName}</h4>
+                <ul>
+                  {products.map(product => (
+                    <li key={product.productId}>
+                      {product.productName}: {product.productQuantity} units
+                      left
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )
+          )}
+        </div>
+      )}
+
       <button
         className="add-inventorytype-button btn btn-primary"
         onClick={() => setShowAddTypeForm(true)} // Show the form when clicked


### PR DESCRIPTION
[**JIRA:** link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1040)
What is the ticket about and why are we doing this change.
The ticket is about adding a button that displays every supplies that is considered to have low stocks. It displays the supplies that will need to be ordered. 

What are the various changes and what other modules do those changes affect.
It adds a check low stock for all inventory button and when you click on it a list of supplies that are low stocks are displayed.  Those changes don't affect any other modules only the inventory. 

![CPCChangesLowStock](https://github.com/user-attachments/assets/15ccf7cf-0502-4d2d-9b2a-bf8b78f6b457)

