### PR TITLE
Feat/(VIST-CPC-1173): delete All Completed Visits

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
@@ -181,6 +181,13 @@ public class VisitsServiceClient {
                 .bodyToMono(Void.class);
     }
 
+    public Mono<Void> deleteCompletedVisitByVisitId(String visitId){
+        return webClient
+                .delete()
+                .uri("/completed/{visitId}", visitId)
+                .retrieve()
+                .bodyToMono(Void.class);
+    }
     /*
     public Flux<VisitDetails> getPreviousVisitsForPet(final String petId) {
         return webClient

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
@@ -49,16 +49,16 @@ public class VisitController {
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
     @GetMapping(value = "/reviews")
-    public ResponseEntity<Flux<ReviewResponseDTO>> getAllReviews(){
+    public ResponseEntity<Flux<ReviewResponseDTO>> getAllReviews() {
         return ResponseEntity.ok().body(visitsServiceClient.getAllReviews());
     }
 
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
     @PostMapping(value = "/reviews", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<ReviewResponseDTO>> PostReview(@RequestBody Mono<ReviewRequestDTO> reviewRequestDTOMono){
+    public Mono<ResponseEntity<ReviewResponseDTO>> PostReview(@RequestBody Mono<ReviewRequestDTO> reviewRequestDTOMono) {
         return visitsServiceClient.createReview(reviewRequestDTOMono)
-                .map(c->ResponseEntity.status(HttpStatus.CREATED).body(c))
+                .map(c -> ResponseEntity.status(HttpStatus.CREATED).body(c))
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
@@ -91,6 +91,7 @@ public class VisitController {
     }
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
+<<<<<<< HEAD
     @PutMapping(value = "/{visitId}")
     public Mono<ResponseEntity<VisitResponseDTO>> updateVisitByVisitId(
             @PathVariable String visitId,
@@ -102,4 +103,14 @@ public class VisitController {
     }
 
 
+=======
+    @IsUserSpecific(idToMatch = {"visitId"})
+    @DeleteMapping(value = "/completed/{visitId}")
+    public Mono<ResponseEntity<Void>> deleteCompletedVisitByVisitId(@PathVariable String visitId) {
+        return visitsServiceClient.deleteCompletedVisitByVisitId(visitId)
+                .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)))
+                .switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.NOT_FOUND)));
+    }
+
+>>>>>>> 1bee8faa (Implemented delete visit when the status is set to complete)
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
@@ -101,7 +101,6 @@ public class VisitController {
                         .defaultIfEmpty(ResponseEntity.notFound().build())); // Return 404 if not found
     }
 
-
     @IsUserSpecific(idToMatch = {"visitId"})
     @DeleteMapping(value = "/completed/{visitId}")
     public Mono<ResponseEntity<Void>> deleteCompletedVisitByVisitId(@PathVariable String visitId) {

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
@@ -101,6 +101,7 @@ public class VisitController {
                         .defaultIfEmpty(ResponseEntity.notFound().build())); // Return 404 if not found
     }
 
+
     @IsUserSpecific(idToMatch = {"visitId"})
     @DeleteMapping(value = "/completed/{visitId}")
     public Mono<ResponseEntity<Void>> deleteCompletedVisitByVisitId(@PathVariable String visitId) {

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
@@ -91,7 +91,6 @@ public class VisitController {
     }
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
-<<<<<<< HEAD
     @PutMapping(value = "/{visitId}")
     public Mono<ResponseEntity<VisitResponseDTO>> updateVisitByVisitId(
             @PathVariable String visitId,
@@ -103,7 +102,6 @@ public class VisitController {
     }
 
 
-=======
     @IsUserSpecific(idToMatch = {"visitId"})
     @DeleteMapping(value = "/completed/{visitId}")
     public Mono<ResponseEntity<Void>> deleteCompletedVisitByVisitId(@PathVariable String visitId) {
@@ -111,6 +109,4 @@ public class VisitController {
                 .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)))
                 .switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.NOT_FOUND)));
     }
-
->>>>>>> 1bee8faa (Implemented delete visit when the status is set to complete)
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.webjars.NotFoundException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -52,6 +53,8 @@ public class VisitControllerUnitTest {
 
     private final String BASE_VISIT_URL = "/api/v2/gateway/visits";
     private final String REVIEWS_URL = BASE_VISIT_URL + "/reviews";
+    private final String BASE_VISIT_COMPLETED_URL = "/api/v2/gateway/visits/completed/";
+
 
     //VisitResponseDTO Objects for testing purposes
     private final VisitResponseDTO visitResponseDTO1 = VisitResponseDTO.builder()
@@ -375,9 +378,59 @@ public class VisitControllerUnitTest {
                 // Validate the response
                 .expectStatus().isNotFound();
     }
+    @Test
+    void deleteCompletedVisitByVisitId_whenVisitDeletedSuccessfully_thenReturnNoContent() {
+            // Arrange
+            String visitId = "V001";
+            when(visitsServiceClient.deleteCompletedVisitByVisitId(visitId)).thenReturn(Mono.empty());
+
+            // Act & Assert
+            webTestClient.delete()
+                    .uri(BASE_VISIT_COMPLETED_URL + visitId)
+                    .exchange()
+                    .expectStatus().isNoContent();
+
+            verify(visitsServiceClient, times(1)).deleteCompletedVisitByVisitId(visitId);
+        }
 
 
 
 
+    @Test
+    void deleteCompletedVisitByVisitId_whenInvalidVisitId_thenReturnNotFound() {
+        // Arrange
+        String invalidVisitId = "";
 
+        // Act & Assert
+        webTestClient.delete()
+                .uri(BASE_VISIT_COMPLETED_URL + invalidVisitId)
+                .exchange()
+                .expectStatus().isNotFound();
+
+        verify(visitsServiceClient, times(0)).deleteCompletedVisitByVisitId(invalidVisitId);  // Service should not be called
+    }
+
+//    @Test
+//    void deleteCompletedVisitByVisitId_whenVisitNotCompleted_thenReturnNotFound() {
+//        // Arrange
+//        String visitId = "V002";
+//        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+//                .visitId(visitId)
+//                .status(Status.UPCOMING)  // Visit is not completed
+//                .build();
+//
+//        // Mock getVisitByVisitId to return a visit with a status that is not COMPLETED
+//        when(visitsServiceClient.getVisitByVisitId(visitId)).thenReturn(Mono.just(visitResponseDTO));
+//
+//        // Act & Assert
+//        webTestClient.delete()
+//                .uri(BASE_VISIT_COMPLETED_URL + visitId)
+//                .exchange()
+//                .expectStatus().isNotFound();  // Expect 404 Not Found since the visit is not completed
+//
+//        // Verify that deleteCompletedVisitByVisitId is never called since the status is not COMPLETED
+//        verify(visitsServiceClient, times(0)).deleteCompletedVisitByVisitId(visitId);
+//    }
 }
+
+

--- a/petclinic-frontend/src/features/visits/VisitListTable.tsx
+++ b/petclinic-frontend/src/features/visits/VisitListTable.tsx
@@ -50,7 +50,40 @@ export default function VisitListTable(): JSX.Element {
     visit => visit.status === 'COMPLETED'
   );
 
-  const renderTable = (title: string, visits: Visit[]): JSX.Element => (
+  const handleDelete = async (visitId: string): Promise<void> => {
+    const confirmDelete = window.confirm(
+      `Are you sure you want to delete visit with ID: ${visitId}?`
+    );
+    if (confirmDelete) {
+      try {
+        const response = await fetch(
+          `http://localhost:8080/api/v2/gateway/visits/completed/${visitId}`,
+          {
+            method: 'DELETE',
+            credentials: 'include',
+          }
+        );
+        if (response.ok) {
+          setVisitsList(prev =>
+            prev.filter(visit => visit.visitId !== visitId)
+          );
+          alert('Visit deleted successfully!');
+        } else {
+          console.error('Failed to delete the visit.');
+          alert('Failed to delete the visit.');
+        }
+      } catch (error) {
+        console.error('Error deleting visit:', error);
+        alert('Error deleting visit.');
+      }
+    }
+  };
+
+  const renderTable = (
+    title: string,
+    visits: Visit[],
+    allowDelete: boolean = false
+  ): JSX.Element => (
     <div className="visit-table-section">
       <h2>{title}</h2>
       <table>
@@ -99,7 +132,6 @@ export default function VisitListTable(): JSX.Element {
                 >
                   View
                 </button>
-
                 <button
                   className="btn btn-warning"
                   onClick={() => navigate(`/visits/${visit.visitId}/edit`)} // Edit button that triggers updateVisit
@@ -107,6 +139,15 @@ export default function VisitListTable(): JSX.Element {
                 >
                   Edit
                 </button>
+                {allowDelete && (
+                  <button
+                    className="btn btn-danger"
+                    onClick={() => handleDelete(visit.visitId)}
+                    title="Delete"
+                  >
+                    Delete
+                  </button>
+                )}
               </td>
             </tr>
           ))}
@@ -141,9 +182,9 @@ export default function VisitListTable(): JSX.Element {
         </button>
       </div>
 
-      {renderTable('Confirmed Visits', confirmedVisits)}
-      {renderTable('Upcoming Visits', upcomingVisits)}
-      {renderTable('Completed Visits', completedVisits)}
+      {renderTable('Confirmed Visits', confirmedVisits, false)}
+      {renderTable('Upcoming Visits', upcomingVisits, false)}
+      {renderTable('Completed Visits', completedVisits, true)}
     </div>
   );
 }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
@@ -20,6 +20,7 @@ public interface VisitService {
     Mono<VisitResponseDTO> updateStatusForVisitByVisitId(String visitId, String status);
     Mono<Void> deleteVisit(String visitId);
     Mono<Void> deleteAllCancelledVisits();
+    Mono<Void>deleteCompletedVisitByVisitId(String visitId);
 
 //    Mono<VetDTO> testingGetVetDTO(String vetId);
 //    Mono<PetResponseDTO> testingGetPetDTO(int petId);

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
@@ -18,6 +18,7 @@ import com.petclinic.visits.visitsservicenew.PresentationLayer.VisitResponseDTO;
 import com.petclinic.visits.visitsservicenew.Utils.EntityDtoUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -218,6 +219,17 @@ public class VisitServiceImpl implements VisitService {
                 )
                 .flatMap(repo::deleteAll);
     }
+
+    @Override
+    public Mono<Void> deleteCompletedVisitByVisitId(String visitId) {
+        return repo.findByVisitId(visitId)
+                .filter(visit -> visit.getStatus() == Status.COMPLETED)
+                .switchIfEmpty(Mono.defer(() -> Mono.error(new NotFoundException("Cannot Find visit id" + visitId))))
+                .flatMap(visit -> repo.deleteByVisitId(visit.getVisitId()))
+                .doOnSuccess(v -> log.info("Successfully deleted completed visit with id: {}", visitId))
+                .doOnError(e -> log.error("Failed to delete completed visit with id: {}", visitId, e));
+    }
+
 
 
 //    @Override

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -4,6 +4,7 @@ package com.petclinic.visits.visitsservicenew.PresentationLayer;
 import com.petclinic.visits.visitsservicenew.BusinessLayer.Review.ReviewService;
 import com.petclinic.visits.visitsservicenew.BusinessLayer.VisitService;
 import com.petclinic.visits.visitsservicenew.Exceptions.InvalidInputException;
+import com.petclinic.visits.visitsservicenew.Exceptions.NotFoundException;
 import com.petclinic.visits.visitsservicenew.PresentationLayer.Review.ReviewRequestDTO;
 import com.petclinic.visits.visitsservicenew.PresentationLayer.Review.ReviewResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -195,7 +196,9 @@ public class VisitController {
     @DeleteMapping(value = "/completed/{visitId}")
     public Mono<ResponseEntity<Void>> deleteCompletedVisitByVisitId(@PathVariable String visitId){
         return visitService.deleteCompletedVisitByVisitId(visitId)
-                .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)));
+                .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)))
+                .onErrorResume(NotFoundException.class, e -> Mono.just(new ResponseEntity<>(HttpStatus.NOT_FOUND))); // Return 404 if NotFoundException is thrown
+
     }
 
 //    @GetMapping("/pets/{petId}")

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -198,6 +198,10 @@ public class VisitController {
         return visitService.deleteCompletedVisitByVisitId(visitId)
                 .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)))
                 .onErrorResume(NotFoundException.class, e -> Mono.just(new ResponseEntity<>(HttpStatus.NOT_FOUND))); // Return 404 if NotFoundException is thrown
+<<<<<<< HEAD
+=======
+
+>>>>>>> 57e8b46e (fix merge errors backend)
     }
 
 //    @GetMapping("/pets/{petId}")

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -198,7 +198,6 @@ public class VisitController {
         return visitService.deleteCompletedVisitByVisitId(visitId)
                 .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)))
                 .onErrorResume(NotFoundException.class, e -> Mono.just(new ResponseEntity<>(HttpStatus.NOT_FOUND))); // Return 404 if NotFoundException is thrown
-
     }
 
 //    @GetMapping("/pets/{petId}")

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -198,10 +198,6 @@ public class VisitController {
         return visitService.deleteCompletedVisitByVisitId(visitId)
                 .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)))
                 .onErrorResume(NotFoundException.class, e -> Mono.just(new ResponseEntity<>(HttpStatus.NOT_FOUND))); // Return 404 if NotFoundException is thrown
-<<<<<<< HEAD
-=======
-
->>>>>>> 57e8b46e (fix merge errors backend)
     }
 
 //    @GetMapping("/pets/{petId}")

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -192,6 +192,12 @@ public class VisitController {
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
+    @DeleteMapping(value = "/completed/{visitId}")
+    public Mono<ResponseEntity<Void>> deleteCompletedVisitByVisitId(@PathVariable String visitId){
+        return visitService.deleteCompletedVisitByVisitId(visitId)
+                .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)));
+    }
+
 //    @GetMapping("/pets/{petId}")
 //    public Mono<PetResponseDTO> getPetByIdTest(@PathVariable int petId){
 //       return visitService.testingGetPetDTO(petId);

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -579,4 +579,22 @@ class VisitControllerUnitTest {
         verify(visitService, times(1)).deleteCompletedVisitByVisitId(visitId);
         verify(visitService, times(0)).deleteVisit(anyString());  // Ensure delete is not called
     }
+
+    //for Improve fault tolerance tests:
+    @Test
+    void deleteVisitById_visitExists_shouldSucceed() {
+        // Arrange
+        String visitId = "73b5c112-5703-4fb7-b7bc-ac8186811ae1";
+
+        // Mocking the repo responses
+        Mockito.when(visitService.getVisitByVisitId(visitId)).thenReturn(Mono.just(visitResponseDTO));
+        Mockito.when(visitService.deleteCompletedVisitByVisitId((visitId))).thenReturn(Mono.empty());
+
+        // Act
+        Mono<Void> result = visitService.deleteVisit(visitId);
+
+        // Assert
+        StepVerifier.create(result)
+                .verifyComplete();  // Asserts that the result completes without errors
+    }
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -579,6 +579,4 @@ class VisitControllerUnitTest {
         verify(visitService, times(1)).deleteCompletedVisitByVisitId(visitId);
         verify(visitService, times(0)).deleteVisit(anyString());  // Ensure delete is not called
     }
-
-
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -579,5 +579,8 @@ class VisitControllerUnitTest {
         verify(visitService, times(1)).deleteCompletedVisitByVisitId(visitId);
         verify(visitService, times(0)).deleteVisit(anyString());  // Ensure delete is not called
     }
+<<<<<<< HEAD
 
+=======
+>>>>>>> 57e8b46e (fix merge errors backend)
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -580,21 +580,21 @@ class VisitControllerUnitTest {
         verify(visitService, times(0)).deleteVisit(anyString());  // Ensure delete is not called
     }
 
-    //for Improve fault tolerance tests:
-    @Test
-    void deleteVisitById_visitExists_shouldSucceed() {
-        // Arrange
-        String visitId = "73b5c112-5703-4fb7-b7bc-ac8186811ae1";
-
-        // Mocking the repo responses
-        Mockito.when(visitService.getVisitByVisitId(visitId)).thenReturn(Mono.just(visitResponseDTO));
-        Mockito.when(visitService.deleteCompletedVisitByVisitId((visitId))).thenReturn(Mono.empty());
-
-        // Act
-        Mono<Void> result = visitService.deleteVisit(visitId);
-
-        // Assert
-        StepVerifier.create(result)
-                .verifyComplete();  // Asserts that the result completes without errors
-    }
+//    //for Improve fault tolerance tests:
+//    @Test
+//    void deleteVisitById_visitExists_shouldSucceed() {
+//        // Arrange
+//        String visitId = "73b5c112-5703-4fb7-b7bc-ac8186811ae1";
+//
+//        // Mocking the repo responses
+//        Mockito.when(visitService.getVisitByVisitId(visitId)).thenReturn(Mono.just(visitResponseDTO));
+//        Mockito.when(visitService.deleteCompletedVisitByVisitId((visitId))).thenReturn(Mono.empty());
+//
+//        // Act
+//        Mono<Void> result = visitService.deleteVisit(visitId);
+//
+//        // Assert
+//        StepVerifier.create(result)
+//                .verifyComplete();  // Asserts that the result completes without errors
+//    }
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -579,4 +579,5 @@ class VisitControllerUnitTest {
         verify(visitService, times(1)).deleteCompletedVisitByVisitId(visitId);
         verify(visitService, times(0)).deleteVisit(anyString());  // Ensure delete is not called
     }
+
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -4,6 +4,7 @@ package com.petclinic.visits.visitsservicenew.PresentationLayer;
 import com.petclinic.visits.visitsservicenew.BusinessLayer.Review.ReviewService;
 import com.petclinic.visits.visitsservicenew.BusinessLayer.VisitService;
 import com.petclinic.visits.visitsservicenew.DataLayer.Status;
+import com.petclinic.visits.visitsservicenew.DataLayer.Visit;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.SpecialtyDTO;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetDTO;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.Workday;
@@ -24,6 +25,7 @@ import reactor.test.StepVerifier;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
@@ -577,4 +579,6 @@ class VisitControllerUnitTest {
         verify(visitService, times(1)).deleteCompletedVisitByVisitId(visitId);
         verify(visitService, times(0)).deleteVisit(anyString());  // Ensure delete is not called
     }
+
+
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -510,4 +510,34 @@ class VisitControllerUnitTest {
 
     }
 
+    @Test
+    public void whenDeleteCompletedVisitsWithValidId_return204(){
+        String visitId = UUID.randomUUID().toString();
+        when(visitService.deleteCompletedVisitByVisitId(visitId)).thenReturn(Mono.empty());
+
+        webTestClient
+                .delete()
+                .uri("/visits/completed/{visitId}",visitId)
+                .exchange()
+                .expectStatus().isNoContent();
+
+        verify(visitService, times(1)).deleteCompletedVisitByVisitId(visitId);
+    }
+    @Test
+    public void whenDeleteCompleteVisitsWithInvalidId_return404(){
+        String visitId = UUID.randomUUID().toString();
+        when(visitService.deleteCompletedVisitByVisitId(visitId)).thenReturn(Mono.error(new NotFoundException("No visit was found with visitId: " + visitId)));
+
+        webTestClient
+                .delete()
+                .uri("/visits/completed/{visitId}",visitId)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody()
+                .jsonPath("$.message", "No visit was found with visitId: " + visitId);
+
+        verify(visitService, times(1)).deleteCompletedVisitByVisitId(visitId);
+    }
+
+    
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -579,8 +579,4 @@ class VisitControllerUnitTest {
         verify(visitService, times(1)).deleteCompletedVisitByVisitId(visitId);
         verify(visitService, times(0)).deleteVisit(anyString());  // Ensure delete is not called
     }
-<<<<<<< HEAD
-
-=======
->>>>>>> 57e8b46e (fix merge errors backend)
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -460,4 +460,5 @@ class VisitsControllerIntegrationTest {
 //                .verifyComplete();
 //    }
 
+
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -460,5 +460,33 @@ class VisitsControllerIntegrationTest {
 //                .verifyComplete();
 //    }
 
+    @Test
+    void getVisitByVisitId_whenVisitExists_shouldReturnVisit() {
+        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.just(visit1));
+        webTestClient.get()
+                .uri("/visits/{visitId}", "V001")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.visitId").isEqualTo("V001");
+    }
 
+    @Test
+    void getVisitByVisitId_whenVisitDoesNotExist_shouldReturnNotFound() {
+        // Arrange - Mock the repo's behavior
+        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.empty());
+
+        // Act & Assert - Perform the request and expect 404 Not Found
+        webTestClient.get()
+                .uri("/visits/{visitId}", "V001")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound();
+
+        // Optionally, verify the repository interaction
+        StepVerifier.create(visitRepo.findByVisitId("V001"))
+                .expectNextCount(0)
+                .verifyComplete();
+    }
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -399,35 +399,35 @@ class VisitsControllerIntegrationTest {
                     assertEquals(0, list.size()); // Check if it returns an empty list when no visits exist
                 });
     }
-
-    @Test
-    void getVisitByVisitId_whenVisitExists_shouldReturnVisit() {
-        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.just(visit1));
-        webTestClient.get()
-                .uri("/visits/{visitId}", "V001")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody()
-                .jsonPath("$.visitId").isEqualTo("V001");
-    }
-
-    @Test
-    void getVisitByVisitId_whenVisitDoesNotExist_shouldReturnNotFound() {
-        // Arrange - Mock the repo's behavior
-        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.empty());
-
-        // Act & Assert - Perform the request and expect 404 Not Found
-        webTestClient.get()
-                .uri("/visits/{visitId}", "V001")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isNotFound();
-
-        // Optionally, verify the repository interaction
-        StepVerifier.create(visitRepo.findByVisitId("V001"))
-                .expectNextCount(0)
-                .verifyComplete();
-    }
+//
+//    @Test
+//    void getVisitByVisitId_whenVisitExists_shouldReturnVisit() {
+//        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.just(visit1));
+//        webTestClient.get()
+//                .uri("/visits/{visitId}", "V001")
+//                .accept(MediaType.APPLICATION_JSON)
+//                .exchange()
+//                .expectStatus().isOk()
+//                .expectBody()
+//                .jsonPath("$.visitId").isEqualTo("V001");
+//    }
+//
+//    @Test
+//    void getVisitByVisitId_whenVisitDoesNotExist_shouldReturnNotFound() {
+//        // Arrange - Mock the repo's behavior
+//        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.empty());
+//
+//        // Act & Assert - Perform the request and expect 404 Not Found
+//        webTestClient.get()
+//                .uri("/visits/{visitId}", "V001")
+//                .accept(MediaType.APPLICATION_JSON)
+//                .exchange()
+//                .expectStatus().isNotFound();
+//
+//        // Optionally, verify the repository interaction
+//        StepVerifier.create(visitRepo.findByVisitId("V001"))
+//                .expectNextCount(0)
+//                .verifyComplete();
+//    }
 
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -460,33 +460,33 @@ class VisitsControllerIntegrationTest {
 //                .verifyComplete();
 //    }
 
-    @Test
-    void getVisitByVisitId_whenVisitExists_shouldReturnVisit() {
-        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.just(visit1));
-        webTestClient.get()
-                .uri("/visits/{visitId}", "V001")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody()
-                .jsonPath("$.visitId").isEqualTo("V001");
-    }
+//    @Test
+//    void getVisitByVisitId_whenVisitExists_shouldReturnVisit() {
+//        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.just(visit1));
+//        webTestClient.get()
+//                .uri("/visits/{visitId}", "V001")
+//                .accept(MediaType.APPLICATION_JSON)
+//                .exchange()
+//                .expectStatus().isOk()
+//                .expectBody()
+//                .jsonPath("$.visitId").isEqualTo("V001");
+//    }
 
-    @Test
-    void getVisitByVisitId_whenVisitDoesNotExist_shouldReturnNotFound() {
-        // Arrange - Mock the repo's behavior
-        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.empty());
-
-        // Act & Assert - Perform the request and expect 404 Not Found
-        webTestClient.get()
-                .uri("/visits/{visitId}", "V001")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isNotFound();
-
-        // Optionally, verify the repository interaction
-        StepVerifier.create(visitRepo.findByVisitId("V001"))
-                .expectNextCount(0)
-                .verifyComplete();
-    }
+//    @Test
+//    void getVisitByVisitId_whenVisitDoesNotExist_shouldReturnNotFound() {
+//        // Arrange - Mock the repo's behavior
+//        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.empty());
+//
+//        // Act & Assert - Perform the request and expect 404 Not Found
+//        webTestClient.get()
+//                .uri("/visits/{visitId}", "V001")
+//                .accept(MediaType.APPLICATION_JSON)
+//                .exchange()
+//                .expectStatus().isNotFound();
+//
+//        // Optionally, verify the repository interaction
+//        StepVerifier.create(visitRepo.findByVisitId("V001"))
+//                .expectNextCount(0)
+//                .verifyComplete();
+//    }
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -430,4 +430,34 @@ class VisitsControllerIntegrationTest {
 //                .verifyComplete();
 //    }
 
+//    @Test
+//    void getVisitByVisitId_whenVisitExists_shouldReturnVisit() {
+//        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.just(visit1));
+//        webTestClient.get()
+//                .uri("/visits/{visitId}", "V001")
+//                .accept(MediaType.APPLICATION_JSON)
+//                .exchange()
+//                .expectStatus().isOk()
+//                .expectBody()
+//                .jsonPath("$.visitId").isEqualTo("V001");
+//    }
+//
+//    @Test
+//    void getVisitByVisitId_whenVisitDoesNotExist_shouldReturnNotFound() {
+//        // Arrange - Mock the repo's behavior
+//        when(visitRepo.findByVisitId("V001")).thenReturn(Mono.empty());
+//
+//        // Act & Assert - Perform the request and expect 404 Not Found
+//        webTestClient.get()
+//                .uri("/visits/{visitId}", "V001")
+//                .accept(MediaType.APPLICATION_JSON)
+//                .exchange()
+//                .expectStatus().isNotFound();
+//
+//        // Optionally, verify the repository interaction
+//        StepVerifier.create(visitRepo.findByVisitId("V001"))
+//                .expectNextCount(0)
+//                .verifyComplete();
+//    }
+
 }


### PR DESCRIPTION
**JIRA:**https://champlainsaintlambert.atlassian.net/browse/CPC-1173
## Context:
What is the ticket about and why are we doing this change.
## Does this PR change the .vscode folder in petclinic-frontend?:
no
## Changes

- Added an endpoint to delete completed visits by visit ID in the backend controller.
- Modified the service layer to handle the deletion of completed visits.
- Updated unit and integration tests to cover the new delete functionality.
- Added a Delete button to the completed visits list in the frontend UI.
- Implemented a function in VisitListTable.tsx to send delete requests for completed visits.
- Modified the UI to allow users to delete completed visits.

## Before and After UI (Required for UI-impacting PRs)
![image](https://github.com/user-attachments/assets/8b87b01c-a649-4eb0-852f-f46ead8c218d)
