### PR TITLE
bug(INVT-1149) Fix inventory pages

### DIFF
--- a/petclinic-frontend/src/features/inventories/InventoriesListTable.tsx
+++ b/petclinic-frontend/src/features/inventories/InventoriesListTable.tsx
@@ -65,10 +65,14 @@ export default function InventoriesListTable(): JSX.Element {
   };
 
   const pageBefore = (): void => {
-    setCurrentPage(prevPage => Math.max(prevPage - 1, 0));
+    if (currentPage > 0) {
+      setCurrentPage(prevPage => prevPage - 1);
+    }
   };
   const pageAfter = (): void => {
-    setCurrentPage(prevPage => prevPage + 1);
+    if (inventoryList.length > 0) {
+      setCurrentPage(prevPage => prevPage + 1);
+    }
   };
 
   const deleteInventoryHandler = (inventoryToDelete: Inventory): void => {
@@ -343,27 +347,38 @@ export default function InventoriesListTable(): JSX.Element {
           ))}
         </tbody>
       </table>
-      <div className="text-center">
-        <table className="mx-auto">
-          <tbody>
-            <tr>
-              <td>
-                <button className="btn btn-success btn-sm" onClick={pageBefore}>
-                  &lt;
-                </button>
-              </td>
-              <td>
-                <span>{realPage}</span>
-              </td>
-              <td>
-                <button className="btn btn-success btn-sm" onClick={pageAfter}>
-                  &gt;
-                </button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      <div className="d-flex justify-content-center">
+        <div className="text-center">
+          <table>
+            <tbody>
+              <tr>
+                <td>
+                  <button
+                    className="btn btn-success btn-sm"
+                    onClick={pageBefore}
+                  >
+                    &lt;
+                  </button>
+                </td>
+                <td>
+                  <span className="mx-2">{realPage}</span>{' '}
+                  {/* Added margin for space */}
+                </td>
+                <td>
+                  <button
+                    className="btn btn-success btn-sm"
+                    onClick={pageAfter}
+                    disabled={inventoryList.length === 0}
+                  >
+                    &gt;
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
+
       <div id="loadingObject" style={{ display: 'none' }}>
         Loading...
       </div>


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1149
## Context:
Fixed the inventory pages going on infinitely, as well as their ugly CSS.
## Does this PR change the .vscode folder in petclinic-frontend?:
No, it does not
## Changes
- Fixed the prevPage and nextPage buttons CSS by adding a different styling to the current bootstrap buttons
- Added contraints to block the nextPage button if there are no inventories on it.
## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://github.com/user-attachments/assets/81d48877-b527-435a-ba2f-1af89da50d4d)
After:
![Screenshot 2024-10-01 at 3 17 45 AM](https://github.com/user-attachments/assets/290f4472-18ba-4bba-a8a8-62604fb27e40)