### PR TITLE
feat(BILL-CPC-1234): Admin Can Create Bill

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/BillController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/BillController.java
@@ -1,13 +1,16 @@
 package com.petclinic.bffapigateway.presentationlayer.v2;
 
 import com.petclinic.bffapigateway.domainclientlayer.BillServiceClient;
+import com.petclinic.bffapigateway.dtos.Bills.BillRequestDTO;
 import com.petclinic.bffapigateway.dtos.Bills.BillResponseDTO;
 import com.petclinic.bffapigateway.utils.Security.Annotations.IsUserSpecific;
 import com.petclinic.bffapigateway.utils.Security.Variables.Roles;
 import com.petclinic.bffapigateway.utils.Security.Annotations.SecuredEndpoint;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
@@ -27,6 +30,15 @@ public class BillController {
     public Flux<BillResponseDTO> getBillsByOwnerId(final @PathVariable String customerId)
     {
         return billService.getBillsByOwnerId(customerId);
+    }
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
+    @PostMapping(value = "/admin",
+            consumes = "application/json",
+            produces = "application/json")
+    public Mono<ResponseEntity<BillResponseDTO>> createBill(@RequestBody BillRequestDTO model) {
+        return billService.createBill(model).map(s -> ResponseEntity.status(HttpStatus.CREATED).body(s))
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN})

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -42,7 +42,7 @@ public class VetController {
 
 
     @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS})
-    @GetMapping()
+    @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<VetResponseDTO> getVets(){
         return vetsServiceClient.getVets();
     }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/BillControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/BillControllerIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.petclinic.bffapigateway.presentationlayer.v2;
 
+import com.petclinic.bffapigateway.dtos.Bills.BillRequestDTO;
 import com.petclinic.bffapigateway.dtos.Bills.BillResponseDTO;
 import com.petclinic.bffapigateway.dtos.Bills.BillStatus;
 import com.petclinic.bffapigateway.presentationlayer.v2.mockservers.MockServerConfigAuthService;
@@ -15,11 +16,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDate;
 
 import static com.petclinic.bffapigateway.presentationlayer.v2.mockservers.MockServerConfigAuthService.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 @SpringBootTest
@@ -38,6 +42,7 @@ public class BillControllerIntegrationTest {
     public void startMockServer() {
         mockServerConfigBillService = new MockServerConfigBillService();
         mockServerConfigBillService.registerGetAllBillsEndpoint();
+        mockServerConfigBillService.registerCreateBillEndpoint();
 
         mockServerConfigAuthService = new MockServerConfigAuthService();
         mockServerConfigAuthService.registerValidateTokenForAdminEndpoint();
@@ -50,6 +55,16 @@ public class BillControllerIntegrationTest {
         mockServerConfigBillService.stopMockServer();
         mockServerConfigAuthService.stopMockServer();
     }
+
+    private BillRequestDTO billRequestDTO = BillRequestDTO.builder()
+            .customerId("e6c7398e-8ac4-4e10-9ee0-03ef33f0361a")
+            .visitType("general")
+            .vetId("3")
+            .date(LocalDate.parse("2024-10-11"))
+            .amount(100.0)
+            .billStatus(BillStatus.UNPAID)
+            .dueDate(LocalDate.parse("2024-10-13"))
+            .build();
 
 
     private BillResponseDTO billresponse = BillResponseDTO.builder()
@@ -94,6 +109,37 @@ public class BillControllerIntegrationTest {
         StepVerifier
                 .create(result)
                 .expectNextCount(2)
+                .verifyComplete();
+    }
+
+    @Test
+    void whenCreateBill_thenReturnCreatedBill() {
+            Mono<BillResponseDTO> result = webTestClient
+                .post()
+                .uri("/api/v2/gateway/bills/admin")
+                .cookie("Bearer", jwtTokenForValidAdmin)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(billRequestDTO), BillRequestDTO.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .returnResult(BillResponseDTO.class)
+                .getResponseBody()
+                .single();
+
+        StepVerifier
+                .create(result)
+                .expectNextMatches(response -> {
+                    assertNotNull(response);
+                    assertEquals(billRequestDTO.getCustomerId(), response.getCustomerId());
+                    assertEquals(billRequestDTO.getVisitType(), response.getVisitType());
+                    assertEquals(billRequestDTO.getVetId(), response.getVetId());
+                    assertEquals(billRequestDTO.getDate(), response.getDate());
+                    assertEquals(billRequestDTO.getAmount(), response.getAmount());
+                    assertEquals(billRequestDTO.getBillStatus(), response.getBillStatus());
+                    assertEquals(billRequestDTO.getDueDate(), response.getDueDate());
+                    return true;})
                 .verifyComplete();
     }
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/BillControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/BillControllerUnitTest.java
@@ -2,6 +2,7 @@ package com.petclinic.bffapigateway.presentationlayer.v2;
 
 import com.petclinic.bffapigateway.config.GlobalExceptionHandler;
 import com.petclinic.bffapigateway.domainclientlayer.BillServiceClient;
+import com.petclinic.bffapigateway.dtos.Bills.BillRequestDTO;
 import com.petclinic.bffapigateway.dtos.Bills.BillResponseDTO;
 import com.petclinic.bffapigateway.dtos.Bills.BillStatus;
 import com.petclinic.bffapigateway.exceptions.InvalidInputException;
@@ -17,6 +18,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 
@@ -63,6 +65,16 @@ private final String baseBillURL = "/api/v2/gateway/bills";
             .dueDate(LocalDate.parse("2024-10-13"))
             .build();
 
+    private BillRequestDTO billRequestDTO = BillRequestDTO.builder()
+            .customerId("e6c7398e-8ac4-4e10-9ee0-03ef33f0361a")
+            .visitType("general")
+            .vetId("3")
+            .date(LocalDate.parse("2024-10-11"))
+            .amount(100.0)
+            .billStatus(BillStatus.UNPAID)
+            .dueDate(LocalDate.parse("2024-10-13"))
+            .build();
+
 
    @Test
     public void whenGetAllBillsByCustomerId_ThenReturnCustomerBills() {
@@ -104,6 +116,18 @@ private final String baseBillURL = "/api/v2/gateway/bills";
 
        verify(billServiceClient, times(1))
                .getAllBilling();
+    }
+
+    @Test
+    public void AddBill_thenReturnBill(){
+        when(billServiceClient.createBill(billRequestDTO)).thenReturn(Mono.just(billresponse));
+        webTestClient.post()
+                .uri(baseBillURL + "/admin")
+                .bodyValue(billRequestDTO)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(BillResponseDTO.class)
+                .isEqualTo(billresponse);
     }
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
@@ -104,10 +104,10 @@ class VetControllerIntegrationTest {
         webTestClient.get()
                 .uri(VET_ENDPOINT)
                 .cookie("Bearer", jwtTokenForValidAdmin)
-                .accept(MediaType.APPLICATION_JSON)
+                .accept(MediaType.valueOf(MediaType.TEXT_EVENT_STREAM_VALUE))
                 .exchange()
                 .expectStatus().isOk()
-                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectHeader().contentType("text/event-stream;charset=UTF-8")
                 .expectBodyList(VetResponseDTO.class)
                 .hasSize(2);
     }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigBillService.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigBillService.java
@@ -36,6 +36,22 @@ public class MockServerConfigBillService {
                 );
     }
 
+    public void registerCreateBillEndpoint() {
+        String response = "{\"billId\":\"e6c7398e-8ac4-4e10-9ee0-03ef33f0361b\",\"customerId\":\"e6c7398e-8ac4-4e10-9ee0-03ef33f0361a\",\"visitType\":\"general\",\"vetId\":\"3\",\"date\":\"2024-10-11\",\"amount\":\"100\",\"taxedAmount\":\"0.0\", \"billStatus\":\"UNPAID\", \"dueDate\":\"2024-10-13\"}";
+
+        mockServerClient_BillService
+                .when(
+                    request()
+                            .withMethod("POST")
+                            .withPath("/bills")
+                )
+                .respond(
+                        response()
+                                .withStatusCode(201)
+                                .withBody(json(response))
+                );
+    }
+
     public void stopMockServer() {
         if(clientAndServer != null)
             this.clientAndServer.stop();

--- a/petclinic-frontend/src/features/bills/AdminBillsListTable.tsx
+++ b/petclinic-frontend/src/features/bills/AdminBillsListTable.tsx
@@ -40,9 +40,47 @@ export default function AdminBillsListTable(): JSX.Element {
     setVets(vetsList);
   };
 
+  const validateForm = (): boolean => {
+    if (
+      !newBill.customerId ||
+      !newBill.vetId ||
+      !newBill.visitType ||
+      !newBill.date ||
+      newBill.amount <= 0 ||
+      !newBill.billStatus ||
+      !newBill.dueDate
+    ) {
+      setError(
+        'All fields are required and the amount must be greater than zero.'
+      );
+      return false;
+    }
+
+    const billDate = new Date(newBill.date);
+    const dueDate = new Date(newBill.dueDate);
+
+    if (billDate > dueDate) {
+      setError('The bill date cannot be after the due date.');
+      return false;
+    }
+
+    setError(null);
+    return true;
+  };
+
   const handleCreateBill = async (): Promise<void> => {
+    const isValid = validateForm();
+    if (!isValid) {
+      return;
+    }
+
+    const formattedBill = {
+      ...newBill,
+      billStatus: newBill.billStatus.toUpperCase(),
+    };
+
     try {
-      await addBill(newBill);
+      await addBill(formattedBill);
       setCreateForm(false);
       fetchBills();
     } catch (err) {
@@ -98,84 +136,10 @@ export default function AdminBillsListTable(): JSX.Element {
         {showCreateForm ? 'Cancel' : 'Create New Bill'}
       </button>
 
-      {searchedBill ? (
-        <div>
-          <h3>Searched Bill Details:</h3>
-          <p>
-            <strong>Bill ID:</strong> {searchedBill.billId}
-          </p>
-          <p>
-            <strong>Owner Name:</strong> {searchedBill.ownerFirstName}{' '}
-            {searchedBill.ownerLastName}
-          </p>
-          <p>
-            <strong>Visit Type:</strong> {searchedBill.visitType}
-          </p>
-          <p>
-            <strong>Vet Name:</strong> {searchedBill.vetFirstName}{' '}
-            {searchedBill.vetLastName}
-          </p>
-          <p>
-            <strong>Date:</strong> {searchedBill.date}
-          </p>
-          <p>
-            <strong>Amount:</strong> {searchedBill.amount}
-          </p>
-          <p>
-            <strong>Taxed Amount:</strong> {searchedBill.taxedAmount}
-          </p>
-          <p>
-            <strong>Status:</strong> {searchedBill.billStatus}
-          </p>
-          <p>
-            <strong>Due Date:</strong> {searchedBill.dueDate}
-          </p>
-        </div>
-      ) : (
-        <div>
-          <h3>All Bills:</h3>
-          <table className="table table-striped">
-            <thead>
-              <tr>
-                <th>Bill ID</th>
-                <th>Owner Name</th>
-                <th>Visit Type</th>
-                <th>Vet Name</th>
-                <th>Date</th>
-                <th>Amount</th>
-                <th>Taxed Amount</th>
-                <th>Status</th>
-                <th>Due Date</th>
-              </tr>
-            </thead>
-            <tbody>
-              {bills
-                .filter(data => data != null)
-                .map((bill: Bill) => (
-                  <tr key={bill.billId}>
-                    <td>{bill.billId}</td>
-                    <td>
-                      {bill.ownerFirstName} {bill.ownerLastName}
-                    </td>
-                    <td>{bill.visitType}</td>
-                    <td>
-                      {bill.vetFirstName} {bill.vetLastName}
-                    </td>
-                    <td>{bill.date}</td>
-                    <td>{bill.amount}</td>
-                    <td>{bill.taxedAmount}</td>
-                    <td>{bill.billStatus}</td>
-                    <td>{bill.dueDate}</td>
-                  </tr>
-                ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
       {showCreateForm && (
         <div>
           <h3>Create New Bill</h3>
+          {error && <p style={{ color: 'red' }}>{error}</p>}
           <form
             onSubmit={e => {
               e.preventDefault();
@@ -251,7 +215,7 @@ export default function AdminBillsListTable(): JSX.Element {
               <label>Status</label>
               <input
                 type="text"
-                value={newBill.billStatus}
+                value={newBill.billStatus.toUpperCase()}
                 onChange={e =>
                   setNewBill({ ...newBill, billStatus: e.target.value })
                 }
@@ -271,6 +235,81 @@ export default function AdminBillsListTable(): JSX.Element {
 
             <button type="submit">Create Bill</button>
           </form>
+        </div>
+      )}
+
+      {searchedBill ? (
+        <div>
+          <h3>Searched Bill Details:</h3>
+          <p>
+            <strong>Bill ID:</strong> {searchedBill.billId}
+          </p>
+          <p>
+            <strong>Owner Name:</strong> {searchedBill.ownerFirstName}{' '}
+            {searchedBill.ownerLastName}
+          </p>
+          <p>
+            <strong>Visit Type:</strong> {searchedBill.visitType}
+          </p>
+          <p>
+            <strong>Vet Name:</strong> {searchedBill.vetFirstName}{' '}
+            {searchedBill.vetLastName}
+          </p>
+          <p>
+            <strong>Date:</strong> {searchedBill.date}
+          </p>
+          <p>
+            <strong>Amount:</strong> {searchedBill.amount}
+          </p>
+          <p>
+            <strong>Taxed Amount:</strong> {searchedBill.taxedAmount}
+          </p>
+          <p>
+            <strong>Status:</strong> {searchedBill.billStatus}
+          </p>
+          <p>
+            <strong>Due Date:</strong> {searchedBill.dueDate}
+          </p>
+        </div>
+      ) : (
+        <div>
+          <h3>All Bills:</h3>
+          <table className="table table-striped">
+            <thead>
+              <tr>
+                <th>Bill ID</th>
+                <th>Owner Name</th>
+                <th>Visit Type</th>
+                <th>Vet Name</th>
+                <th>Date</th>
+                <th>Amount</th>
+                <th>Taxed Amount</th>
+                <th>Status</th>
+                <th>Due Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {bills
+                .filter(data => data != null)
+                .map((bill: Bill) => (
+                  <tr key={bill.billId}>
+                    <td>{bill.billId}</td>
+                    <td>
+                      {bill.ownerFirstName} {bill.ownerLastName}
+                    </td>
+                    <td>{bill.visitType}</td>
+                    <td>
+                      {bill.vetFirstName} {bill.vetLastName}
+                    </td>
+                    <td>{bill.date}</td>
+                    <td>{bill.amount}</td>
+                    <td>{bill.taxedAmount}</td>
+                    <td>{bill.billStatus}</td>
+                    <td>{bill.dueDate}</td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
         </div>
       )}
     </div>

--- a/petclinic-frontend/src/features/bills/AdminBillsListTable.tsx
+++ b/petclinic-frontend/src/features/bills/AdminBillsListTable.tsx
@@ -93,6 +93,11 @@ export default function AdminBillsListTable(): JSX.Element {
         {searchedBill && <button onClick={handleGoBack}>Go Back</button>}
       </div>
 
+      {/* Create Bill Form */}
+      <button onClick={() => setCreateForm(!showCreateForm)}>
+        {showCreateForm ? 'Cancel' : 'Create New Bill'}
+      </button>
+
       {searchedBill ? (
         <div>
           <h3>Searched Bill Details:</h3>
@@ -167,11 +172,6 @@ export default function AdminBillsListTable(): JSX.Element {
           </table>
         </div>
       )}
-
-      {/* Create Bill Form */}
-      <button onClick={() => setCreateForm(!showCreateForm)}>
-        {showCreateForm ? 'Cancel' : 'Create New Bill'}
-      </button>
 
       {showCreateForm && (
         <div>

--- a/petclinic-frontend/src/features/bills/api/addBill.tsx
+++ b/petclinic-frontend/src/features/bills/api/addBill.tsx
@@ -1,0 +1,15 @@
+import axiosInstance from '@/shared/api/axiosInstance';
+import { BillRequestModel } from '../models/BillRequestModel';
+
+export async function addBill(newBill: BillRequestModel): Promise<void> {
+  try {
+    await axiosInstance.post('/bills/admin', newBill, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (err) {
+    console.error('Error creating bill:', err);
+    throw err;
+  }
+}

--- a/petclinic-frontend/src/features/bills/models/BillRequestModel.tsx
+++ b/petclinic-frontend/src/features/bills/models/BillRequestModel.tsx
@@ -1,0 +1,9 @@
+export interface BillRequestModel {
+  customerId: string;
+  visitType: string;
+  vetId: string;
+  date: string;
+  amount: number;
+  billStatus: string;
+  dueDate: string;
+}

--- a/petclinic-frontend/src/features/customers/api/getAllOwners.ts
+++ b/petclinic-frontend/src/features/customers/api/getAllOwners.ts
@@ -1,0 +1,19 @@
+import axiosInstance from '@/shared/api/axiosInstance.ts';
+import { OwnerResponseModel } from '../models/OwnerResponseModel';
+
+export async function getAllOwners(): Promise<OwnerResponseModel[]> {
+  const response = await axiosInstance.get('/owners', {
+    responseType: 'stream',
+  });
+  return response.data
+    .split('data:')
+    .map((payLoad: string) => {
+      try {
+        if (payLoad == '') return null;
+        return JSON.parse(payLoad);
+      } catch (err) {
+        console.error("Can't parse JSON: " + err);
+      }
+    })
+    .filter((data?: JSON) => data !== null);
+}

--- a/petclinic-frontend/src/features/veterinarians/api/getAllVets.ts
+++ b/petclinic-frontend/src/features/veterinarians/api/getAllVets.ts
@@ -1,0 +1,17 @@
+import axiosInstance from '@/shared/api/axiosInstance.ts';
+import { VetResponseModel } from '@/features/veterinarians/models/VetResponseModel';
+
+export async function getAllVets(): Promise<VetResponseModel[]> {
+  const response = await axiosInstance.get('/vets', { responseType: 'stream' });
+  return response.data
+    .split('data:')
+    .map((payLoad: string) => {
+      try {
+        if (payLoad == '') return null;
+        return JSON.parse(payLoad);
+      } catch (err) {
+        console.error("Can't parse JSON: " + err);
+      }
+    })
+    .filter((data?: JSON) => data !== null);
+}


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1234


## Context:
As an admin, I should be able to create a bill, in case of unforeseen problem, emergency  or manual entry is required. 

Acceptance Criteria:

1. Admin should have an option (a button of some kind) to start the bill creation process.
2. A form for creating the bill should be displayed.
3. Inserting incorrect information should return an error and shouldn’t create the bill
4. Putting in all the correct information, the bill should be created and the form should disappear.
5. The new bill can now be seen and is created.


## Does this PR change the .vscode folder in petclinic-frontend?:
It does not.


## Changes

- added 2 api function for a get all in vets and customers in the front-end.
- added a post function in the v2 controller.
- added testing for the post function
- modified the vets get all vets function in vets v2 controller to have it's content type be a text-event stream
- added a button and a form to the Admin bills page that lets you create a bill.


## Before and After UI (Required for UI-impacting PRs)

<h3> Before </h3>

![image](https://github.com/user-attachments/assets/8ee0804c-62c8-438c-b177-7bbf03bf9d2c)

<h3> After </h3>

![image](https://github.com/user-attachments/assets/c71a9e55-aa67-49fe-8084-6777d0798be7)

![image](https://github.com/user-attachments/assets/11864117-2fd6-40ab-87aa-42524eb9322e)


