### PR TITLE
Bug(CUST-CPC-1188): Fixed V2 endpoint for creating a user failing and reverted back to old emailing service

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/CustomersServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/CustomersServiceClient.java
@@ -162,16 +162,12 @@ public class CustomersServiceClient {
     }
 
     public Mono<OwnerResponseDTO> addOwner(Mono<OwnerRequestDTO> model) {
-        String ownerId = UUID.randomUUID().toString();
-        return model.flatMap(requestDTO -> {
-            requestDTO.setOwnerId(ownerId);
-            return webClientBuilder.build()
-                    .post()
-                    .uri(customersServiceUrl + "/owners")
-                    .body(BodyInserters.fromValue(requestDTO))
-                    .retrieve()
-                    .bodyToMono(OwnerResponseDTO.class);
-        });
+        return model.flatMap(requestDTO -> webClientBuilder.build()
+                .post()
+                .uri(customersServiceUrl + "/owners")
+                .body(BodyInserters.fromValue(requestDTO))
+                .retrieve()
+                .bodyToMono(OwnerResponseDTO.class));
     }
 
     public Flux<PetType> getPetTypes() {

--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -82,7 +82,7 @@ jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
-                minimum = 0.85
+                minimum = 0.90
             }
         }
     }

--- a/auth-service/src/main/java/com/petclinic/authservice/businesslayer/UserServiceImpl.java
+++ b/auth-service/src/main/java/com/petclinic/authservice/businesslayer/UserServiceImpl.java
@@ -111,8 +111,8 @@ public class UserServiceImpl implements UserService {
             log.info("Sending email to {}...", userIDLessDTO.getEmail());
 
             //Commented out the old emailing service and replaced it with the new emailing service
-            //log.info(mailService.sendMail(generateVerificationMail(user)));  //Old
-            generateVerificationMailWithNewEmailingService(user);              //New
+            log.info(mailService.sendMail(generateVerificationMail(user)));  //Old
+            //generateVerificationMailWithNewEmailingService(user);              //New
 
             log.info("Email sent to {}", userIDLessDTO.getEmail());
 

--- a/auth-service/src/main/java/com/petclinic/authservice/businesslayer/UserServiceImpl.java
+++ b/auth-service/src/main/java/com/petclinic/authservice/businesslayer/UserServiceImpl.java
@@ -110,9 +110,9 @@ public class UserServiceImpl implements UserService {
 
             log.info("Sending email to {}...", userIDLessDTO.getEmail());
 
-            //Commented out the old emailing service and replaced it with the new emailing service
+            //Commented out the New emailing service and replaced it with the old emailing service as I implemented the new one but was told by Christine to revert back to the old one
             log.info(mailService.sendMail(generateVerificationMail(user)));  //Old
-            //generateVerificationMailWithNewEmailingService(user);              //New
+            //generateVerificationMailWithNewEmailingService(user);          //New
 
             log.info("Email sent to {}", userIDLessDTO.getEmail());
 

--- a/auth-service/src/test/java/com/petclinic/authservice/presentationlayer/User/UserControllerIntegrationTest.java
+++ b/auth-service/src/test/java/com/petclinic/authservice/presentationlayer/User/UserControllerIntegrationTest.java
@@ -336,10 +336,6 @@ class UserControllerIntegrationTest {
 
     }
 
-    ////////////////////////////////////////////
-    // Removing the following tests as it is testing a function that is no longer in use (The old emailing service)
-    ////////////////////////////////////////////
-    /*
     @Test
     void createUser_ShouldSucceed() {
         UserIDLessRoleLessDTO userDTO = UserIDLessRoleLessDTO.builder()
@@ -418,8 +414,6 @@ class UserControllerIntegrationTest {
 
         userRepo.delete(userRepo.findByEmail(userDTO.getEmail()).get());
     }
-     */
-    ////////////////////////////////////////////
 
 
     @Test

--- a/petclinic-frontend/src/pages/User/SignUp.tsx
+++ b/petclinic-frontend/src/pages/User/SignUp.tsx
@@ -158,7 +158,7 @@ const SignUp: React.FC = (): JSX.Element => {
 
     try {
       const response = await axios.post<Register>(
-        'http://localhost:8080/api/gateway/users',
+        'http://localhost:8080/api/v2/gateway/users',
         requestData
       );
 


### PR DESCRIPTION
[**JIRA:** link to jira ticket](https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/15/backlog?selectedIssue=CPC-1188)
## Context:
We are doing this change because Christine requested the change to the older mailing service and because there was a small bug with the v2 endpoint for creating an owner account.
## Does this PR change the .vscode folder in petclinic-frontend?:
It doesn't do any changes to the vscode folder

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
- Reverted back to the old emailing service at Christine's request
- Fixed a small bug with the v2 endpoint for creating a customer as it was overwriting the UUID
- Upped Jacoco minimum % to 90
- Changed to v2 endpoint since the bug was fixed

## Before and After UI (Required for UI-impacting PRs)
Didn't Impact UI

## Dev notes
There should no longer be any problems caused by antiviruses or limits.