### PR TITLE
Bug(CUST-CPC-1188): Fixed lost UUID when creating an owner account as an admin

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/CustomersServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/CustomersServiceClient.java
@@ -162,12 +162,18 @@ public class CustomersServiceClient {
     }
 
     public Mono<OwnerResponseDTO> addOwner(Mono<OwnerRequestDTO> model) {
-        return model.flatMap(requestDTO -> webClientBuilder.build()
-                .post()
-                .uri(customersServiceUrl + "/owners")
-                .body(BodyInserters.fromValue(requestDTO))
-                .retrieve()
-                .bodyToMono(OwnerResponseDTO.class));
+        String ownerId = UUID.randomUUID().toString();
+        return model.flatMap(requestDTO -> {
+            if(requestDTO.getOwnerId() == null || requestDTO.getOwnerId().isEmpty()){
+                requestDTO.setOwnerId(ownerId);
+            }
+            return webClientBuilder.build()
+                    .post()
+                    .uri(customersServiceUrl + "/owners")
+                    .body(BodyInserters.fromValue(requestDTO))
+                    .retrieve()
+                    .bodyToMono(OwnerResponseDTO.class);
+        });
     }
 
     public Flux<PetType> getPetTypes() {


### PR DESCRIPTION
**JIRA:** link to jira ticket
https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/15/backlog?selectedIssue=CPC-1188
## Context:
My previous pull request broke the add owner and I recently found out so I fixed it
## Does this PR change the .vscode folder in petclinic-frontend?:
It doesn't go NEAR the .vscode foler :)

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
Changed the CustomersServiceClient to set a UUID if when sending a request it is null or empty. It does not reset it if it is not.
## Before and After UI (Required for UI-impacting PRs)
Didn't affect front end, but here was the issue: 
![image](https://github.com/user-attachments/assets/a37e38d1-d0a7-4d07-90f2-bea940424862)
It is now fixed