### PR TITLE
feat(VIST-CPC-810): Create Cancel Visit Button for Admin

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
@@ -360,12 +360,20 @@ public class VisitsServiceClient {
                 .bodyToMono(EmergencyResponseDTO.class);
     }
 
-    public Mono<EmergencyResponseDTO> deleteEmergency(String emergencyId){
+    public Mono<EmergencyResponseDTO> deleteEmergency(String emergencyId) {
         return webClient
                 .delete()
                 .uri(reviewUrl + "/emergency/" + emergencyId)
                 .retrieve()
                 .bodyToMono(EmergencyResponseDTO.class);
+    }
+
+    public Mono<VisitResponseDTO> patchVisitStatus(String visitId, String status) {
+        return webClient.patch()
+                .uri(reviewUrl + "/" + visitId + "/" + status) // Adjust URI based on visit-service
+                .retrieve()
+                .bodyToMono(VisitResponseDTO.class); // Parse response into VisitResponseDTO
+
     }
 }
 

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
@@ -164,6 +164,14 @@ public class VisitController {
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
-
+    @SecuredEndpoint(allowedRoles = Roles.ADMIN)
+    @IsUserSpecific(idToMatch = {"visitId"})
+    @PatchMapping(value = "/{visitId}/{status}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<VisitResponseDTO>> updateVisitStatus(
+            @PathVariable String visitId, @PathVariable String status) {
+        return visitsServiceClient.patchVisitStatus(visitId, status) // Forward to the client
+                .map(visitResponseDTO -> new ResponseEntity<>(visitResponseDTO, HttpStatus.OK))
+                .defaultIfEmpty(new ResponseEntity<>(HttpStatus.NOT_FOUND)); // Handle empty responses
+    }
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.webjars.NotFoundException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -909,7 +910,6 @@ class VisitsServiceClientIntegrationTest {
     }
 
 
-
     //Emergency
     private static final String EMERGENCY_ID = UUID.randomUUID().toString();
 
@@ -1043,5 +1043,45 @@ class VisitsServiceClientIntegrationTest {
                 .verifyComplete();
     }
 
+    @Test
+    void updateVisitStatus_ShouldSucceed_WhenStatusUpdatedToCancelled() {
+        String visitId = "12345";
+        String status = "CANCELLED";
 
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId(visitId)
+                .status(Status.CANCELLED)
+                .description("Test visit with cancelled status")
+                .build();
+
+        // Mocking the service client to return the expected response
+        server.enqueue(new MockResponse()
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody("{ \"visitId\": \"" + visitId + "\", \"status\": \"CANCELLED\", \"description\": \"Test visit with cancelled status\" }")
+                .setResponseCode(200));
+
+        Mono<VisitResponseDTO> result = visitsServiceClient.patchVisitStatus(visitId, status);
+
+        StepVerifier.create(result)
+                .expectNextMatches(response -> response.getVisitId().equals(visitId) && response.getStatus().equals(Status.CANCELLED))
+                .verifyComplete();
+    }
+
+    // Test for the NOT_FOUND scenario (when visit does not exist)
+    @Test
+    void updateVisitStatus_ShouldReturnNotFound_WhenVisitDoesNotExist() {
+        String visitId = "nonExistentVisitId";
+        String status = "CANCELLED";
+
+        // Mocking the service client to simulate a 404 Not Found response
+        server.enqueue(new MockResponse()
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setResponseCode(404));
+
+        Mono<VisitResponseDTO> result = visitsServiceClient.patchVisitStatus(visitId, status);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof WebClientResponseException.NotFound)
+                .verify();
+    }
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
@@ -583,4 +583,50 @@ public class VisitControllerUnitTest {
         verify(bffApiGatewayController, times(1)).getVisitsByOwnerId(ownerId);
     }
 
+    @Test
+    void updateVisitStatus_ShouldReturnOK_WhenStatusUpdatedToCancelled() {
+        String visitId = "12345";
+        String status = "CANCELLED";
+
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId(visitId)
+                .status(Status.CANCELLED)
+                .description("Test visit with cancelled status")
+                .build();
+
+        // Mocking the service layer to return the expected response
+        when(visitsServiceClient.patchVisitStatus(eq(visitId), eq(status)))
+                .thenReturn(Mono.just(visitResponseDTO));
+
+        webTestClient.patch()
+                .uri(BASE_VISIT_URL + "/{visitId}/{status}", visitId, status)
+                .exchange()
+                .expectStatus().isOk() // Expect 200 OK
+                .expectBody(VisitResponseDTO.class)
+                .value(response -> {
+                    assertEquals(response.getVisitId(), visitId);
+                    assertEquals(response.getStatus(), Status.CANCELLED);
+                });
+
+        // Verify that the service was called with the correct parameters
+        verify(visitsServiceClient, times(1)).patchVisitStatus(eq(visitId), eq(status));
+    }
+
+    @Test
+    void updateVisitStatus_ShouldReturnNotFound_WhenVisitDoesNotExist() {
+        String visitId = "nonExistentVisitId";
+        String status = "CANCELLED";
+
+        // Mocking the service to return an empty Mono, simulating a not found scenario
+        when(visitsServiceClient.patchVisitStatus(eq(visitId), eq(status)))
+                .thenReturn(Mono.empty());
+
+        webTestClient.patch()
+                .uri(BASE_VISIT_URL + "/{visitId}/{status}", visitId, status)
+                .exchange()
+                .expectStatus().isNotFound(); // Expect 404 NOT_FOUND
+
+        // Verify that the service was called
+        verify(visitsServiceClient, times(1)).patchVisitStatus(eq(visitId), eq(status));
+    }
 }

--- a/petclinic-frontend/src/features/visits/VisitListTable.tsx
+++ b/petclinic-frontend/src/features/visits/VisitListTable.tsx
@@ -87,6 +87,9 @@ export default function VisitListTable(): JSX.Element {
   const completedVisits = visitsList.filter(
     visit => visit.status === 'COMPLETED'
   );
+  const cancelledVisits = visitsList.filter(
+    visit => visit.status === 'CANCELLED'
+  );
   const handleDelete = async (visitId: string): Promise<void> => {
     const confirmDelete = window.confirm(
       `Are you sure you want to delete visit with ID: ${visitId}?`
@@ -112,6 +115,44 @@ export default function VisitListTable(): JSX.Element {
       } catch (error) {
         console.error('Error deleting visit:', error);
         alert('Error deleting visit.');
+      }
+    }
+  };
+
+  // Handle canceling the visit
+  const handleCancel = async (visitId: string): Promise<void> => {
+    const confirmCancel = window.confirm(
+      'Do you confirm you want to cancel the reservation?'
+    );
+
+    if (confirmCancel) {
+      try {
+        const response = await fetch(
+          `http://localhost:8080/api/v2/gateway/visits/${visitId}/CANCELLED`,
+          {
+            method: 'PATCH',
+            credentials: 'include',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error('Failed to cancel the visit');
+        }
+
+        // Update the visit list after cancellation
+        setVisitsList(prevVisits =>
+          prevVisits.map(visit =>
+            visit.visitId === visitId
+              ? { ...visit, status: 'CANCELLED' }
+              : visit
+          )
+        );
+      } catch (error) {
+        console.error('Error canceling visit:', error);
+        alert('Error canceling visit.');
       }
     }
   };
@@ -210,9 +251,11 @@ export default function VisitListTable(): JSX.Element {
                       ? 'green'
                       : visit.status === 'UPCOMING'
                         ? 'orange'
-                        : visit.status === 'COMPLETED'
-                          ? 'blue'
-                          : 'inherit',
+                        : visit.status === 'CANCELLED'
+                          ? 'red'
+                          : visit.status === 'COMPLETED'
+                            ? 'blue'
+                            : 'inherit',
                 }}
               >
                 {visit.status}
@@ -241,6 +284,16 @@ export default function VisitListTable(): JSX.Element {
                     Delete
                   </button>
                 )}
+
+                {visit.status !== 'CANCELLED' &&
+                  visit.status !== 'COMPLETED' && (
+                    <button
+                      className="btn btn-danger"
+                      onClick={() => handleCancel(visit.visitId)}
+                    >
+                      Cancel Visit
+                    </button>
+                  )}
               </td>
             </tr>
           ))}
@@ -287,6 +340,7 @@ export default function VisitListTable(): JSX.Element {
 
       {renderTable('Confirmed Visits', confirmedVisits)}
       {renderTable('Upcoming Visits', upcomingVisits)}
+      {renderTable('Cancelled Visits', cancelledVisits)}
       {renderTable('Completed Visits', completedVisits, true)}
     </div>
   );

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
@@ -22,6 +22,7 @@ public interface VisitService {
     Mono<Void> deleteVisit(String visitId);
     Mono<Void> deleteAllCancelledVisits();
     Mono<Void>deleteCompletedVisitByVisitId(String visitId);
+    Mono<VisitResponseDTO> patchVisitStatusInVisit(String visitId, String status);
 
 //    Mono<VetDTO> testingGetVetDTO(String vetId);
 //    Mono<PetResponseDTO> testingGetPetDTO(int petId);

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
@@ -415,4 +415,21 @@ public class VisitServiceImpl implements VisitService {
                 .to(user.getEmail())
                 .build();
     }
+
+
+    @Override
+    public Mono<VisitResponseDTO> patchVisitStatusInVisit(String visitId, String status) {
+        // Find the visit by the ID
+        return repo.findByVisitId(visitId)
+                .switchIfEmpty(Mono.defer(() ->
+                        Mono.error(new NotFoundException("Cannot find visit with id: " + visitId))
+                ))
+                // Update the status of the found Visit entity
+                .doOnNext(visit -> visit.setStatus(Status.valueOf(status))) // Update status reactively
+                // Save the updated visit
+                .flatMap(repo::save)
+                // Convert to VisitResponseDTO
+                .flatMap(entityDtoUtil::toVisitResponseDTO);
+    }
+
 }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
@@ -34,7 +34,7 @@ public class DataSetupService implements CommandLineRunner {
     }
 
     private void setupVisits() {
-        Visit visit1 = buildVisit("visitId1", "2022-11-24 13:00", "this is a dummy description", "ecb109cd-57ea-4b85-b51e-99751fd1c349", "69f852ca-625b-11ee-8c99-0242ac120002", Status.COMPLETED, LocalDateTime.parse("2022-11-24 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
+        Visit visit1 = buildVisit("visitId1", "2022-11-24 13:00", "this is a dummy description", "ecb109cd-57ea-4b85-b51e-99751fd1c349", "69f852ca-625b-11ee-8c99-0242ac120002", Status.UPCOMING, LocalDateTime.parse("2024-11-24 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
         Visit visit2 = buildVisit("visitId2", "2022-03-01 13:00", "Dog Needs Meds", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85766-625b-11ee-8c99-0242ac120002", Status.COMPLETED, LocalDateTime.parse("2022-03-01 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
         Visit visit3 = buildVisit("visitId3", "2020-07-19 13:00","Dog Needs Surgery After Meds", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85bda-625b-11ee-8c99-0242ac120002", Status.COMPLETED, LocalDateTime.parse("2020-07-19 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
         Visit visit4 = buildVisit("visitId4", "2022-12-24 13:00", "Dog Needs Physio-Therapy", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85d2e-625b-11ee-8c99-0242ac120002", Status.UPCOMING, LocalDateTime.parse("2022-12-24 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -259,4 +259,13 @@ public class VisitController {
 //    public Mono<VetDTO> getVetByIdTest(@PathVariable String vetId){
 //        return visitService.testingGetVetDTO(vetId);
 //    }
+
+    @PatchMapping("/{visitId}/{status}")
+    public Mono<ResponseEntity<VisitResponseDTO>> updateVisitStatus(
+            @PathVariable String visitId, @PathVariable String status) {
+        return visitService.patchVisitStatusInVisit(visitId, status)
+                .map(visitResponseDTO -> new ResponseEntity<>(visitResponseDTO, HttpStatus.OK))
+                .defaultIfEmpty(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -732,7 +733,52 @@ class VisitControllerUnitTest {
         verify(emergencyService, times(1)).DeleteEmergency(emergencyId);
     }
 
+    @Test
+    void updateVisitStatus_ShouldReturnOK_WhenStatusUpdatedToCancelled() {
+        String visitId = "12345";
+        String status = "CANCELLED";
 
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId(visitId)
+                .status(Status.CANCELLED)
+                .description("Test visit with cancelled status")
+                .build();
+
+        // Mocking the service layer to return the expected response
+        when(visitService.patchVisitStatusInVisit(eq(visitId), eq(status)))
+                .thenReturn(Mono.just(visitResponseDTO));
+
+        webTestClient.patch()
+                .uri("/visits/{visitId}/{status}", visitId, status)
+                .exchange()
+                .expectStatus().isOk() // Expect 200 OK
+                .expectBody(VisitResponseDTO.class)
+                .value(response -> {
+                    assertEquals(response.getVisitId(), visitId);
+                    assertEquals(response.getStatus(), Status.CANCELLED);
+                });
+
+        // Verify that the service was called with the correct parameters
+        verify(visitService, times(1)).patchVisitStatusInVisit(eq(visitId), eq(status));
+    }
+
+    @Test
+    void updateVisitStatus_ShouldReturnNotFound_WhenVisitDoesNotExist() {
+        String visitId = "nonExistentVisitId";
+        String status = "CANCELLED";
+
+        // Mocking the service to return an empty Mono, simulating a not found scenario
+        when(visitService.patchVisitStatusInVisit(eq(visitId), eq(status)))
+                .thenReturn(Mono.empty());
+
+        webTestClient.patch()
+                .uri("/visits/{visitId}/{status}", visitId, status)
+                .exchange()
+                .expectStatus().isNotFound(); // Expect 404 NOT_FOUND
+
+        // Verify that the service was called
+        verify(visitService, times(1)).patchVisitStatusInVisit(eq(visitId), eq(status));
+    }
 
 
 


### PR DESCRIPTION
**JIRA:** [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-810?atlOrigin=eyJpIjoiMTY4YWQyZTBmMzJiNGVlNGI4NjZlZmVkNDU5ZTZiOGIiLCJwIjoiaiJ9)

## Context:
Create Cancel Visit Button next to each visit for Admin. When user clicks on this button, it will pop out a window on the browser asking for confirmation. If the user confirms, the status of the visit will be set to "CANCELLED". For a visit that has been completed, there is no "Cancel Request" button.

## Does this PR change the .vscode folder in petclinic-frontend?:
NO

## Changes
BACKEND:
- Implemented a new patch request method in visits-service and api-gateway.
- Implemented tests for this new method.
FRONTEND:
- Implemented a button "Cancel Request" with method "handleCancel".
- Added a new status "Cancelled" with red color.

## Before and After UI (Required for UI-impacting PRs)
Before: 
![image](https://github.com/user-attachments/assets/a2c51e5a-7968-4736-9e2b-051975e32a7c)

After UI:
![image](https://github.com/user-attachments/assets/4c355a30-bc30-4da2-940b-a9a9ff1b7b04)
