### PR TITLE
bug(PROD-CPC-1263): product description too long

### DIFF
--- a/petclinic-frontend/src/features/products/TrendlingList.tsx
+++ b/petclinic-frontend/src/features/products/TrendlingList.tsx
@@ -22,24 +22,32 @@ export default function TrendingList(): JSX.Element {
   return (
     <div>
       <div className="grid">
-        {topFourTrending.map((product: ProductModel) => (
-          <div
-            className={`card ${product.productQuantity < 10 ? 'low-quantity' : ''}`}
-            key={product.productId}
-          >
-            <ImageContainer imageId={product.imageId} />
-            <h2>{product.productName}</h2>
-            <p>{product.productDescription}</p>
-            <p>Rating: {product.averageRating.toFixed(1)}</p>
-            <p>Price: ${product.productSalePrice.toFixed(2)}</p>
-            {/* Conditionally display the "Out of Stock" or "Low Stock" message */}
-            {product.productQuantity === 0 ? (
-              <p className="out-of-stock">Out of Stock</p>
-            ) : product.productQuantity < 10 ? (
-              <p className="low-stock">Low Stock</p>
-            ) : null}
-          </div>
-        ))}
+        {topFourTrending.map((product: ProductModel) => {
+          const isTooLong = product.productDescription.length > 100;
+
+          return (
+            <div
+              className={`card ${product.productQuantity < 10 ? 'low-quantity' : ''}`}
+              key={product.productId}
+            >
+              <ImageContainer imageId={product.imageId} />
+              <h2>{product.productName}</h2>
+              <p>
+                {!isTooLong
+                  ? product.productDescription
+                  : `${product.productDescription.substring(0, 100)}...`}
+              </p>
+              <p>Rating: {product.averageRating.toFixed(1)}</p>
+              <p>Price: ${product.productSalePrice.toFixed(2)}</p>
+              {/* Conditionally display the "Out of Stock" or "Low Stock" message */}
+              {product.productQuantity === 0 ? (
+                <p className="out-of-stock">Out of Stock</p>
+              ) : product.productQuantity < 10 ? (
+                <p className="low-stock">Low Stock</p>
+              ) : null}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/petclinic-frontend/src/features/products/components/Product.tsx
+++ b/petclinic-frontend/src/features/products/components/Product.tsx
@@ -24,6 +24,7 @@ export default function Product({
   const [selectedProductForQuantity, setSelectedProductForQuantity] =
     useState<ProductModel | null>(null);
   const [quantity, setQuantity] = useState<number>(0);
+  const [tooLong, setTooLong] = useState<boolean>(false);
 
   const navigate = useNavigate();
 
@@ -35,6 +36,14 @@ export default function Product({
     fetchRating();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (product.productDescription.length > 100) {
+      setTooLong(true);
+    } else {
+      setTooLong(false);
+    }
+  }, [product.productDescription]);
 
   const fetchRating = async (): Promise<void> => {
     try {
@@ -168,8 +177,11 @@ export default function Product({
       >
         {currentProduct.productName}
       </h2>
-
-      <p>{currentProduct.productDescription}</p>
+      <p>
+        {!tooLong
+          ? currentProduct.productDescription
+          : `${currentProduct.productDescription.substring(0, 100)}...`}
+      </p>
       <p>Price: ${currentProduct.productSalePrice.toFixed(2)}</p>
       <p>Rating: {currentProduct.averageRating}</p>
       <p>Your Rating:</p>


### PR DESCRIPTION
**JIRA:** [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1263)
## Context:
In the main shop page it would list all of the product information even if it would take the whole page, so we decided to cut the description if it's too long and keep the description untouched in the details page.
## Does this PR change the .vscode folder in petclinic-frontend?:
Nope😉

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes

- Made changes to the Product.tsx and TrendingList.tsx to know which descriptions to cut

## Before and After UI (Required for UI-impacting PRs)
**BEFORE**
![image](https://github.com/user-attachments/assets/9f513090-f333-4ec4-9c79-0a53a743997e)
![image](https://github.com/user-attachments/assets/66c8a013-ace1-4a97-a9e7-5c113cde135f)

**AFTER**
![image](https://github.com/user-attachments/assets/450910af-c7a3-4a74-89ff-0c1e500a125f)
![image](https://github.com/user-attachments/assets/be1c7df6-a3a7-441f-9298-164fa9e5ef07)
