### PR TITLE
feat(VETS-CPC-1253): delete profile photo

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/InventoryServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/InventoryServiceClient.java
@@ -331,6 +331,17 @@ public class InventoryServiceClient {
                 .bodyToMono(ProductResponseDTO.class);
     }
 
+    public Mono<ProductResponseDTO> consumeProduct(String inventoryId, String productId) {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(inventoryServiceUrl + "/{inventoryId}/products/{productId}/consume");
+
+        return webClient.patch()
+                .uri(uriBuilder.buildAndExpand(inventoryId, productId).toUri())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError,
+                        resp -> Mono.error(new NotFoundException("Product not found in inventory: " + inventoryId)))
+                .bodyToMono(ProductResponseDTO.class);
+    }
+
     public Mono<Integer> getQuantityOfProductsInInventory(final String inventoryId) {
         return webClient.get()
                 .uri(inventoryServiceUrl + "/{inventoryId}/productquantity", inventoryId)

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -1003,6 +1003,20 @@ public class BFFApiGatewayController {
         return inventoryServiceClient.getProductsInInventoryByInventoryIdAndProductsField(inventoryId, productName, productPrice, productQuantity, productSalePrice);
     }
 
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.INVENTORY_MANAGER, Roles.VET})
+    @PatchMapping("inventory/{inventoryId}/products/{productId}/consume")
+    public Mono<ResponseEntity<ProductResponseDTO>> consumeProduct(
+            @PathVariable String inventoryId,
+            @PathVariable String productId) {
+
+        return inventoryServiceClient.consumeProduct(inventoryId, productId)
+                .map(s -> ResponseEntity.status(HttpStatus.OK).body(s))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+
+
+
+
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN,Roles.INVENTORY_MANAGER,Roles.VET})
     @GetMapping(value = "inventory")//, produces= MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<InventoryResponseDTO> searchInventory(@RequestParam Optional<Integer> page,

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/InventoryController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/InventoryController.java
@@ -188,6 +188,17 @@ public class InventoryController {
     }
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.INVENTORY_MANAGER})
+    @PatchMapping(value = "/{inventoryId}/products/{productId}/consume", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<Mono<ProductResponseDTO>>> consumeProduct(
+            @PathVariable String inventoryId,
+            @PathVariable String productId) {
+
+        return inventoryServiceClient.consumeProduct(inventoryId, productId)
+                .map(productResponseDTO -> ResponseEntity.ok(Mono.just(productResponseDTO)))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.INVENTORY_MANAGER})
     @GetMapping(value = "/{inventoryId}/products/{productId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Get a product by its ID in an inventory")
     @ApiResponses(value = {

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -138,9 +138,6 @@ public class VetController {
     public Mono<ResponseEntity<Void>> deletePhotoByVetId(@PathVariable String vetId) {
         return vetsServiceClient.deletePhotoByVetId(vetId)
                 .then(Mono.just(ResponseEntity.noContent().<Void>build()))
-                .onErrorResume(ExistingVetNotFoundException.class, ex ->
-                        Mono.just(ResponseEntity.notFound().build())
-                )
                 .doOnError(error -> log.error("Error deleting photo for vetId: {}", vetId, error));
     }
 

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -133,7 +133,7 @@ public class VetController {
     }
 
 
-    @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS, Roles.VET})
+    @SecuredEndpoint(allowedRoles = {Roles.VET, Roles.VET})
     @DeleteMapping("{vetId}/photo")
     public Mono<ResponseEntity<Void>> deletePhotoByVetId(@PathVariable String vetId) {
         return vetsServiceClient.deletePhotoByVetId(vetId)

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -133,7 +133,7 @@ public class VetController {
     }
 
 
-    @SecuredEndpoint(allowedRoles = {Roles.VET, Roles.VET})
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.VET})
     @DeleteMapping("{vetId}/photo")
     public Mono<ResponseEntity<Void>> deletePhotoByVetId(@PathVariable String vetId) {
         return vetsServiceClient.deletePhotoByVetId(vetId)

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -9,6 +9,7 @@ import com.petclinic.bffapigateway.dtos.Vets.Album;
 import com.petclinic.bffapigateway.dtos.Vets.SpecialtyDTO;
 import com.petclinic.bffapigateway.dtos.Vets.VetRequestDTO;
 import com.petclinic.bffapigateway.dtos.Vets.VetResponseDTO;
+import com.petclinic.bffapigateway.exceptions.ExistingVetNotFoundException;
 import com.petclinic.bffapigateway.exceptions.InvalidInputException;
 import com.petclinic.bffapigateway.utils.Security.Annotations.IsUserSpecific;
 import com.petclinic.bffapigateway.utils.Security.Annotations.SecuredEndpoint;
@@ -131,5 +132,16 @@ public class VetController {
                 .doOnError(error -> log.error("Error fetching photos for vet {}", vetId, error));
     }
 
+
+    @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS, Roles.VET})
+    @DeleteMapping("{vetId}/photo")
+    public Mono<ResponseEntity<Void>> deletePhotoByVetId(@PathVariable String vetId) {
+        return vetsServiceClient.deletePhotoByVetId(vetId)
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .onErrorResume(ExistingVetNotFoundException.class, ex ->
+                        Mono.just(ResponseEntity.notFound().build())
+                )
+                .doOnError(error -> log.error("Error deleting photo for vetId: {}", vetId, error));
+    }
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/InventoryControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/InventoryControllerTest.java
@@ -695,4 +695,60 @@ public class InventoryControllerTest {
     }
 
 
+    @Test
+    void consumeProduct_withValidData_shouldReturnUpdatedProduct() {
+        // Arrange
+        String inventoryId = "1";
+        String productId = "101";
+        ProductRequestDTO productRequestDTO = ProductRequestDTO.builder()
+                .productName("Product 101")
+                .productDescription("Description of Product 101")
+                .productPrice(99.99)
+                .build();
+
+        ProductResponseDTO updatedProductResponseDTO = ProductResponseDTO.builder()
+                .productId(productId)
+                .productName("Product 101")
+                .productDescription("Description of Product 101")
+                .productPrice(99.99)
+                .build();
+
+        when(inventoryServiceClient.consumeProduct(inventoryId, productId))
+                .thenReturn(Mono.just(updatedProductResponseDTO));
+
+        // Act
+        client.patch()
+                .uri(baseInventoryURL + "/" + inventoryId + "/products/" + productId + "/consume")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(productRequestDTO)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(ProductResponseDTO.class)
+                .isEqualTo(updatedProductResponseDTO);
+
+        // Assert
+        verify(inventoryServiceClient, times(1))
+                .consumeProduct(inventoryId, productId);
+    }
+
+    @Test
+    void consumeProduct_withInvalidData_shouldReturnNotFound() {
+        // Arrange
+        String inventoryId = "1";
+        String invalidProductId = "999";
+        when(inventoryServiceClient.consumeProduct(inventoryId, invalidProductId))
+                .thenReturn(Mono.empty());
+
+        // Act
+        client.patch()
+                .uri(baseInventoryURL + "/" + inventoryId + "/products/" + invalidProductId + "/consume")
+                .contentType(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound();
+
+        // Assert
+        verify(inventoryServiceClient, times(1))
+                .consumeProduct(inventoryId, invalidProductId);
+    }
+
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
@@ -384,4 +384,33 @@ class VetControllerIntegrationTest {
                 .expectStatus().isNotFound();
     }
 
+    @Test
+    void whenDeletePhotoByVetId_thenReturnNoContent() {
+        String vetId = "ac9adeb8-625b-11ee-8c99-0242ac120002";
+        mockServerConfigVetService.registerDeletePhotoByVetIdEndpoint(vetId);
+
+        webTestClient.delete()
+                .uri(VET_ENDPOINT + "/" + vetId + "/photo")
+                .cookie("Bearer", BEARER_TOKEN)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNoContent()
+                .expectBody().isEmpty();
+    }
+
+    @Test
+    void whenDeletePhotoByVetId_PhotoNotFound_thenReturnNotFound() {
+        String vetId = "in9beda9-526t-22gg-1a96-0672ac230007";
+        mockServerConfigVetService.registerDeletePhotoByVetIdEndpointNotFound(vetId);
+
+        webTestClient.delete()
+                .uri(VET_ENDPOINT + "/" + vetId + "/photo")
+                .cookie("Bearer", BEARER_TOKEN)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("Photo not found for vetId: " + vetId);
+    }
+
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigVetService.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigVetService.java
@@ -380,4 +380,29 @@ public void stopMockServer() {
                                 .withStatusCode(404));
     }
 
+    public void registerDeletePhotoByVetIdEndpoint(String vetId) {
+        mockServerClient_VetService
+                .when(
+                request()
+                        .withMethod("DELETE")
+                        .withPath("/vets/" + vetId + "/photo")
+        ).respond(
+                response()
+                        .withStatusCode(204)
+        );
+    }
+
+    public void registerDeletePhotoByVetIdEndpointNotFound(String vetId) {
+        mockServerClient_VetService
+                .when(
+                        request()
+                                .withMethod("DELETE")
+                                .withPath("/vets/" + vetId + "/photo")
+                ).respond(
+                        response()
+                                .withStatusCode(404)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(json("{\"message\":\"Photo not found for vetId: " + vetId + "\"}"))
+                );
+    }
 }

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryService.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryService.java
@@ -39,4 +39,6 @@ public interface ProductInventoryService {
     Mono<ProductResponseDTO> addSupplyToInventory(Mono<ProductRequestDTO> productRequestDTOMono, String inventoryId);
 
     Mono<Integer> getQuantityOfProductsInInventory(String inventoryId);
+    Mono<ProductResponseDTO> consumeProduct(String inventoryId, String productId);
+
     }

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryServiceImpl.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/businesslayer/ProductInventoryServiceImpl.java
@@ -559,6 +559,21 @@ public class ProductInventoryServiceImpl implements ProductInventoryService {
     }
 
     @Override
+    public Mono<ProductResponseDTO> consumeProduct(String inventoryId, String productId) {
+        return productRepository.findProductByInventoryIdAndProductId(inventoryId, productId)
+                .flatMap(product -> {
+                    if (product.getProductQuantity() - 1 < 0) {
+                        return Mono.error(new InvalidInputException("Not enough stock to consume."));
+                    } else {
+                        product.setProductQuantity(product.getProductQuantity() - 1);
+                        return productRepository.save(product)
+                                .map(EntityDTOUtil::toProductResponseDTO);
+                    }
+                })
+                .switchIfEmpty(Mono.error(new NotFoundException("Product not found with id: " + productId)));
+    }
+
+    @Override
     public Mono<Integer> getQuantityOfProductsInInventory(String inventoryId) {
         return inventoryRepository.findInventoryByInventoryId(inventoryId)
                 .switchIfEmpty(Mono.error(new NotFoundException("Inventory not found with id: " + inventoryId)))

--- a/inventory-service/src/main/java/com/petclinic/inventoryservice/presentationlayer/InventoryController.java
+++ b/inventory-service/src/main/java/com/petclinic/inventoryservice/presentationlayer/InventoryController.java
@@ -207,6 +207,14 @@ public Flux<InventoryResponseDTO> searchInventories(
     public Mono<Integer> getQuantityOfProductsInInventory (@PathVariable String inventoryId) {
         return productInventoryService.getQuantityOfProductsInInventory(inventoryId);
     }
+
+    @PatchMapping("/{inventoryId}/products/{productId}/consume")
+    public Mono<ResponseEntity<ProductResponseDTO>> consumeProduct(@PathVariable String inventoryId,
+                                                                   @PathVariable String productId) {
+        return productInventoryService.consumeProduct(inventoryId, productId)
+                .map(productResponseDTO -> ResponseEntity.ok().body(productResponseDTO))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
 }
 
 

--- a/petclinic-frontend/src/features/carts/components/CartItem.css
+++ b/petclinic-frontend/src/features/carts/components/CartItem.css
@@ -66,20 +66,21 @@
 .delete-button {
   background-color: #f44336;
   color: white;
-  padding: 16px 33px; 
+  padding: 16px 33px;
   border: none;
-  border-radius: 6px; 
+  border-radius: 6px;
   cursor: pointer;
-  transition: background-color 0.3s, transform 0.3s; 
-  font-size: 1em; 
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); 
+  transition:
+    background-color 0.3s,
+    transform 0.3s;
+  font-size: 1em;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .delete-button:hover {
   background-color: #d32f2f;
   transform: scale(1.05); /* Slightly increase size on hover for effect */
 }
-
 
 .low-stock-message {
   color: orange;
@@ -102,4 +103,3 @@
   color: red;
   font-weight: bold;
 }
-

--- a/petclinic-frontend/src/features/carts/components/UserCart.css
+++ b/petclinic-frontend/src/features/carts/components/UserCart.css
@@ -32,7 +32,9 @@
 .clear-cart-btn {
   background-color: #f44336;
   color: white;
-  transition: background-color 0.3s, transform 0.2s;
+  transition:
+    background-color 0.3s,
+    transform 0.2s;
 }
 
 .clear-cart-btn:hover {

--- a/petclinic-frontend/src/features/customers/components/AddPetForm.css
+++ b/petclinic-frontend/src/features/customers/components/AddPetForm.css
@@ -77,7 +77,7 @@
 }
 
 .cancel-form-button {
-  background-color: #007BFF !important;
+  background-color: #007bff !important;
 }
 
 .cancel-form-button:hover {

--- a/petclinic-frontend/src/features/customers/components/CustomerDetails.css
+++ b/petclinic-frontend/src/features/customers/components/CustomerDetails.css
@@ -66,7 +66,9 @@
   padding: 12px 20px;
   font-size: 1.1em;
   cursor: pointer;
-  transition: background-color 0.3s, transform 0.3s;
+  transition:
+    background-color 0.3s,
+    transform 0.3s;
 }
 
 .customer-details-button:hover,

--- a/petclinic-frontend/src/features/inventories/CardInventoryTeam.module.css
+++ b/petclinic-frontend/src/features/inventories/CardInventoryTeam.module.css
@@ -1,70 +1,72 @@
 .cardContainerCustom {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 40px;
-    width: 100%;
-    height: fit-content;
-    margin: 0 auto;
-    min-height: 100px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 40px;
+  width: 100%;
+  height: fit-content;
+  margin: 0 auto;
+  min-height: 100px;
 }
 
 .card {
-    overflow: hidden;
-    width: 300px;
-    height: 440px;
-    border-radius: 15px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    padding: 15px;
-    border: 1px solid #ccc;
-    background-color: white;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+  overflow: hidden;
+  width: 300px;
+  height: 440px;
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  padding: 15px;
+  border: 1px solid #ccc;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition:
+    transform 0.3s ease-in-out,
+    box-shadow 0.3s ease-in-out;
 }
 
 .imageContainer {
-    width: 100%;
-    height: 50%;
-    overflow: hidden;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  width: 100%;
+  height: 50%;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .cardImage {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: 10px 10px 0 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 10px 10px 0 0;
 }
 
 .card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+  transform: translateY(-10px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
 }
 
 .iconCustomized {
-    width: 28px;
-    height: 28px;
-    margin-left: auto;
+  width: 28px;
+  height: 28px;
+  margin-left: auto;
 }
 
 .inventoryNameSection {
-    margin-top: 8%;
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    width: 100%;
-    border-bottom: 1px solid black;
+  margin-top: 8%;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  width: 100%;
+  border-bottom: 1px solid black;
 }
 
 #cardTypeSection {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
-#cardDescriptionSection{
-    width: 100%;
+#cardDescriptionSection {
+  width: 100%;
 }

--- a/petclinic-frontend/src/features/inventories/InventoriesListTable.module.css
+++ b/petclinic-frontend/src/features/inventories/InventoriesListTable.module.css
@@ -31,4 +31,3 @@
   float: right;
   margin-right: 25px;
 }
-

--- a/petclinic-frontend/src/features/inventories/InventoryProducts.tsx
+++ b/petclinic-frontend/src/features/inventories/InventoryProducts.tsx
@@ -83,6 +83,35 @@ const InventoryProducts: React.FC = () => {
     setFilteredProducts(filtered); // Apply status filter immediately
   };
 
+  const reduceQuantity = async (
+    productId: string,
+    currentQuantity: number
+  ): Promise<void> => {
+    if (currentQuantity > 0) {
+      try {
+        // Send a PATCH/PUT request to update the quantity in the backend
+        const updatedQuantity = currentQuantity - 1;
+        await axios.patch(
+          `http://localhost:8080/api/gateway/inventory/${inventoryId}/products/${productId}`,
+          {
+            productQuantity: updatedQuantity,
+          }
+        );
+
+        // Update the product list in the frontend
+        const updatedProducts = products.map(product =>
+          product.productId === productId
+            ? { ...product, productQuantity: updatedQuantity }
+            : product
+        );
+        setProducts(updatedProducts);
+        setFilteredProducts(updatedProducts); // Update the filtered list if needed
+      } catch (err) {
+        setError('Failed to reduce product quantity.');
+      }
+    }
+  };
+
   // UseEffect to monitor changes in productList and apply filtering
   useEffect(() => {
     // Apply frontend status filtering on the updated productList from the backend
@@ -203,6 +232,17 @@ const InventoryProducts: React.FC = () => {
                     onClick={() => deleteProduct(product.productId)}
                   >
                     Delete
+                  </button>
+                </td>
+                <td>
+                  <button
+                    className="btn btn-primary"
+                    onClick={() =>
+                      reduceQuantity(product.productId, product.productQuantity)
+                    }
+                    disabled={product.productQuantity <= 0} // Disable if no more products
+                  >
+                    Consume
                   </button>
                 </td>
               </tr>

--- a/petclinic-frontend/src/features/products/ProductList.css
+++ b/petclinic-frontend/src/features/products/ProductList.css
@@ -51,6 +51,7 @@
   margin-bottom: 10px;
 }
 
-.apply-filter-button, .clear-filter-button {
+.apply-filter-button,
+.clear-filter-button {
   margin-top: 10px;
 }

--- a/petclinic-frontend/src/features/products/TrendlingList.tsx
+++ b/petclinic-frontend/src/features/products/TrendlingList.tsx
@@ -22,24 +22,32 @@ export default function TrendingList(): JSX.Element {
   return (
     <div>
       <div className="grid">
-        {topFourTrending.map((product: ProductModel) => (
-          <div
-            className={`card ${product.productQuantity < 10 ? 'low-quantity' : ''}`}
-            key={product.productId}
-          >
-            <ImageContainer imageId={product.imageId} />
-            <h2>{product.productName}</h2>
-            <p>{product.productDescription}</p>
-            <p>Rating: {product.averageRating.toFixed(1)}</p>
-            <p>Price: ${product.productSalePrice.toFixed(2)}</p>
-            {/* Conditionally display the "Out of Stock" or "Low Stock" message */}
-            {product.productQuantity === 0 ? (
-              <p className="out-of-stock">Out of Stock</p>
-            ) : product.productQuantity < 10 ? (
-              <p className="low-stock">Low Stock</p>
-            ) : null}
-          </div>
-        ))}
+        {topFourTrending.map((product: ProductModel) => {
+          const isTooLong = product.productDescription.length > 100;
+
+          return (
+            <div
+              className={`card ${product.productQuantity < 10 ? 'low-quantity' : ''}`}
+              key={product.productId}
+            >
+              <ImageContainer imageId={product.imageId} />
+              <h2>{product.productName}</h2>
+              <p>
+                {!isTooLong
+                  ? product.productDescription
+                  : `${product.productDescription.substring(0, 100)}...`}
+              </p>
+              <p>Rating: {product.averageRating.toFixed(1)}</p>
+              <p>Price: ${product.productSalePrice.toFixed(2)}</p>
+              {/* Conditionally display the "Out of Stock" or "Low Stock" message */}
+              {product.productQuantity === 0 ? (
+                <p className="out-of-stock">Out of Stock</p>
+              ) : product.productQuantity < 10 ? (
+                <p className="low-stock">Low Stock</p>
+              ) : null}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/petclinic-frontend/src/features/products/api/ProductDetails.css
+++ b/petclinic-frontend/src/features/products/api/ProductDetails.css
@@ -6,7 +6,9 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  transition: background-color 0.3s, transform 0.2s;
+  transition:
+    background-color 0.3s,
+    transform 0.2s;
 }
 
 .edit-button:hover {

--- a/petclinic-frontend/src/features/products/components/EditProduct.css
+++ b/petclinic-frontend/src/features/products/components/EditProduct.css
@@ -1,6 +1,6 @@
 :root {
-  --primary-color: #28a745; 
-  --primary-color-dark: #218838; 
+  --primary-color: #28a745;
+  --primary-color-dark: #218838;
   --input-border-color: #ccc;
   --input-focus-border-color: var(--primary-color);
   --background-color: #f9f9f9;
@@ -46,13 +46,15 @@
   border: 1px solid var(--input-border-color);
   border-radius: 4px;
   font-size: 16px;
-  transition: border-color 0.3s, box-shadow 0.3s;
+  transition:
+    border-color 0.3s,
+    box-shadow 0.3s;
 }
 
 .form-input:focus {
   border-color: var(--input-focus-border-color);
   outline: none;
-  box-shadow: 0 0 5px rgba(40, 167, 69, 0.5); 
+  box-shadow: 0 0 5px rgba(40, 167, 69, 0.5);
 }
 
 .submit-button {
@@ -63,7 +65,9 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  transition: background-color 0.3s, transform 0.2s;
+  transition:
+    background-color 0.3s,
+    transform 0.2s;
 }
 
 .submit-button:hover {
@@ -93,7 +97,7 @@
 
 .form-input:focus {
   border-color: var(--input-focus-border-color);
-  box-shadow: 0 0 5px rgba(40, 167, 69, 0.5); 
+  box-shadow: 0 0 5px rgba(40, 167, 69, 0.5);
 }
 
 .submit-button:focus {

--- a/petclinic-frontend/src/features/products/components/Image.css
+++ b/petclinic-frontend/src/features/products/components/Image.css
@@ -1,10 +1,9 @@
 .card {
-    text-align: center;
-  }
-  
-  .card img {
-    width: 35%;
-    border-radius: 4px;
-    margin-bottom: 12px;
-  }
-  
+  text-align: center;
+}
+
+.card img {
+  width: 35%;
+  border-radius: 4px;
+  margin-bottom: 12px;
+}

--- a/petclinic-frontend/src/features/products/components/Product.tsx
+++ b/petclinic-frontend/src/features/products/components/Product.tsx
@@ -24,6 +24,7 @@ export default function Product({
   const [selectedProductForQuantity, setSelectedProductForQuantity] =
     useState<ProductModel | null>(null);
   const [quantity, setQuantity] = useState<number>(0);
+  const [tooLong, setTooLong] = useState<boolean>(false);
 
   const navigate = useNavigate();
 
@@ -35,6 +36,14 @@ export default function Product({
     fetchRating();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (product.productDescription.length > 100) {
+      setTooLong(true);
+    } else {
+      setTooLong(false);
+    }
+  }, [product.productDescription]);
 
   const fetchRating = async (): Promise<void> => {
     try {
@@ -168,8 +177,11 @@ export default function Product({
       >
         {currentProduct.productName}
       </h2>
-
-      <p>{currentProduct.productDescription}</p>
+      <p>
+        {!tooLong
+          ? currentProduct.productDescription
+          : `${currentProduct.productDescription.substring(0, 100)}...`}
+      </p>
       <p>Price: ${currentProduct.productSalePrice.toFixed(2)}</p>
       <p>Rating: {currentProduct.averageRating}</p>
       <p>Your Rating:</p>

--- a/petclinic-frontend/src/features/veterinarians/api/deleteVetPhoto.ts
+++ b/petclinic-frontend/src/features/veterinarians/api/deleteVetPhoto.ts
@@ -1,0 +1,5 @@
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export const deleteVetPhoto = async (vetId: string): Promise<void> => {
+    await axiosInstance.delete(`/vets/${vetId}/photo`);
+};

--- a/petclinic-frontend/src/features/veterinarians/api/deleteVetPhoto.ts
+++ b/petclinic-frontend/src/features/veterinarians/api/deleteVetPhoto.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '@/shared/api/axiosInstance';
 
 export const deleteVetPhoto = async (vetId: string): Promise<void> => {
-    await axiosInstance.delete(`/vets/${vetId}/photo`);
+  await axiosInstance.delete(`/vets/${vetId}/photo`);
 };

--- a/petclinic-frontend/src/features/visits/Emergency.css
+++ b/petclinic-frontend/src/features/visits/Emergency.css
@@ -1,61 +1,61 @@
 .visit-table-section-red {
-    margin-bottom: 20px;
-    border: 2px solid #d9534f;
-    border-radius: 8px;
-    background-color: #f2dede; 
-    padding: 20px;
+  margin-bottom: 20px;
+  border: 2px solid #d9534f;
+  border-radius: 8px;
+  background-color: #f2dede;
+  padding: 20px;
 }
 
 .visit-table-section-red h2 {
-    color: #c9302c; 
-    text-align: center;
-    margin-bottom: 15px;
-    font-weight: bold;
+  color: #c9302c;
+  text-align: center;
+  margin-bottom: 15px;
+  font-weight: bold;
 }
 
 .visit-table-section-red table {
-    width: 100%;
-    border-collapse: collapse;
+  width: 100%;
+  border-collapse: collapse;
 }
 
 .visit-table-section-red th {
-    background-color: #d9534f;
-    color: white;
-    padding: 10px;
-    text-align: left;
+  background-color: #d9534f;
+  color: white;
+  padding: 10px;
+  text-align: left;
 }
 
 .visit-table-section-red td {
-    border-bottom: 1px solid #ccc;
-    padding: 10px;
-    background-color: #fff; 
-    color: #333; 
+  border-bottom: 1px solid #ccc;
+  padding: 10px;
+  background-color: #fff;
+  color: #333;
 }
 
 .visit-table-section-red tr:hover {
-    background-color: #f9c2c2; 
+  background-color: #f9c2c2;
 }
 
 .visit-table-section-red .btn-warning {
-    background-color: #f0ad4e;
-    border: none;
-    border-radius: 4px;
-    color: #fff;
-    padding: 5px 10px;
+  background-color: #f0ad4e;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  padding: 5px 10px;
 }
 
 .visit-table-section-red .btn-warning:hover {
-    background-color: #ec971f;
+  background-color: #ec971f;
 }
 
 .visit-table-section-red .btn-danger {
-    background-color: #d9534f; 
-    border: none;
-    border-radius: 4px;
-    color: #fff;
-    padding: 5px 10px;
+  background-color: #d9534f;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  padding: 5px 10px;
 }
 
 .visit-table-section-red .btn-danger:hover {
-    background-color: #c9302c; 
+  background-color: #c9302c;
 }

--- a/petclinic-frontend/src/features/visits/Emergency/AddEmergencyForm.css
+++ b/petclinic-frontend/src/features/visits/Emergency/AddEmergencyForm.css
@@ -1,144 +1,142 @@
-
 .add-emergency-form {
-    max-width: 500px;
-    margin: 0 auto;
-    background-color: #fff5f5; 
-    padding: 25px;
-    border-radius: 12px;
-    border: 2px solid #d9534f; 
-    box-shadow: 0 0 15px rgba(217, 83, 79, 0.6); 
-    animation: pulse-border 1.5s infinite; 
-  }
-  
-  /* Pulse effect for the form */
-  @keyframes pulse-border {
-    0% {
-      box-shadow: 0 0 15px rgba(217, 83, 79, 0.6);
-    }
-    50% {
-      box-shadow: 0 0 25px rgba(217, 83, 79, 1);
-    }
-    100% {
-      box-shadow: 0 0 15px rgba(217, 83, 79, 0.6);
-    }
-  }
-  
-  .add-emergency-form h2 {
-    color: #a94442; 
-    text-align: center;
-    margin-bottom: 25px;
-    text-transform: uppercase;
-    letter-spacing: 2px; 
-  }
-  
-  .add-emergency-form label {
-    display: block;
-    color: #333;
-    font-weight: bold;
-    margin-bottom: 7px;
-    text-transform: uppercase;
-    font-size: 0.95em;
-  }
-  
-  .add-emergency-form input[type="text"],
-  .add-emergency-form textarea,
-  .add-emergency-form select,
-  .add-emergency-form input[type="date"] {
-    width: 100%;
-    padding: 12px;
-    margin-bottom: 20px;
-    border: 1px solid #ccc;
-    border-radius: 6px;
-    background-color: #fff;
-    color: #555;
-    transition: border 0.3s, background-color 0.3s;
-  }
-  
-  .add-emergency-form input[type="text"]:focus,
-  .add-emergency-form textarea:focus,
-  .add-emergency-form select:focus,
-  .add-emergency-form input[type="date"]:focus {
-    border-color: #a94442; 
-    background-color: #fff1f1; 
-    outline: none;
-    box-shadow: 0 0 8px rgba(169, 68, 66, 0.6); 
-  }
-  
+  max-width: 500px;
+  margin: 0 auto;
+  background-color: #fff5f5;
+  padding: 25px;
+  border-radius: 12px;
+  border: 2px solid #d9534f;
+  box-shadow: 0 0 15px rgba(217, 83, 79, 0.6);
+  animation: pulse-border 1.5s infinite;
+}
 
-  .add-emergency-form button {
-    width: 100%;
-    background-color: #d9534f;
-    color: #fff;
-    padding: 12px;
-    border: none;
-    border-radius: 6px;
-    font-size: 18px;
-    font-weight: bold;
-    cursor: pointer;
-    text-transform: uppercase;
-    transition: background-color 0.3s, transform 0.1s ease-in-out;
+/* Pulse effect for the form */
+@keyframes pulse-border {
+  0% {
+    box-shadow: 0 0 15px rgba(217, 83, 79, 0.6);
   }
-  
-  .add-emergency-form button:hover {
-    background-color: #c9302c;
-    transform: scale(1.05); 
+  50% {
+    box-shadow: 0 0 25px rgba(217, 83, 79, 1);
   }
-  
+  100% {
+    box-shadow: 0 0 15px rgba(217, 83, 79, 0.6);
+  }
+}
 
-  .success-message,
-  .error-message {
-    text-align: center;
-    font-weight: bold;
-    margin-top: 12px;
-    text-transform: uppercase;
-  }
-  
-  .success-message {
-    color: #5cb85c; 
-    background-color: #f0fdf0; 
-    padding: 10px;
-    border-radius: 6px;
-    border: 2px solid #5cb85c;
-  }
-  
-  .error-message {
-    color: #d9534f;
-    background-color: #fff1f1;
-    padding: 10px;
-    border-radius: 6px;
-    border: 2px solid #d9534f;
-  }
+.add-emergency-form h2 {
+  color: #a94442;
+  text-align: center;
+  margin-bottom: 25px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
 
-  .notification {
-    background-color: #f39c12; 
-    color: #fff;
-    padding: 10px;
-    text-align: center;
-    border-radius: 6px;
-    margin-top: 15px;
-    text-transform: uppercase;
-    animation: blink 1.5s step-start infinite; 
-  }
-  
+.add-emergency-form label {
+  display: block;
+  color: #333;
+  font-weight: bold;
+  margin-bottom: 7px;
+  text-transform: uppercase;
+  font-size: 0.95em;
+}
 
-  @keyframes blink {
-    50% {
-      opacity: 0;
-    }
-  }
- 
-  .loader {
-    text-align: center;
-    color: #5bc0de;
-    font-size: 1.2em;
-    margin-bottom: 20px;
-  }
-  
+.add-emergency-form input[type='text'],
+.add-emergency-form textarea,
+.add-emergency-form select,
+.add-emergency-form input[type='date'] {
+  width: 100%;
+  padding: 12px;
+  margin-bottom: 20px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background-color: #fff;
+  color: #555;
+  transition:
+    border 0.3s,
+    background-color 0.3s;
+}
 
-  .error {
-    color: #d9534f; 
-    font-size: 0.85em;
-    margin-top: -10px;
-    margin-bottom: 10px;
+.add-emergency-form input[type='text']:focus,
+.add-emergency-form textarea:focus,
+.add-emergency-form select:focus,
+.add-emergency-form input[type='date']:focus {
+  border-color: #a94442;
+  background-color: #fff1f1;
+  outline: none;
+  box-shadow: 0 0 8px rgba(169, 68, 66, 0.6);
+}
+
+.add-emergency-form button {
+  width: 100%;
+  background-color: #d9534f;
+  color: #fff;
+  padding: 12px;
+  border: none;
+  border-radius: 6px;
+  font-size: 18px;
+  font-weight: bold;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition:
+    background-color 0.3s,
+    transform 0.1s ease-in-out;
+}
+
+.add-emergency-form button:hover {
+  background-color: #c9302c;
+  transform: scale(1.05);
+}
+
+.success-message,
+.error-message {
+  text-align: center;
+  font-weight: bold;
+  margin-top: 12px;
+  text-transform: uppercase;
+}
+
+.success-message {
+  color: #5cb85c;
+  background-color: #f0fdf0;
+  padding: 10px;
+  border-radius: 6px;
+  border: 2px solid #5cb85c;
+}
+
+.error-message {
+  color: #d9534f;
+  background-color: #fff1f1;
+  padding: 10px;
+  border-radius: 6px;
+  border: 2px solid #d9534f;
+}
+
+.notification {
+  background-color: #f39c12;
+  color: #fff;
+  padding: 10px;
+  text-align: center;
+  border-radius: 6px;
+  margin-top: 15px;
+  text-transform: uppercase;
+  animation: blink 1.5s step-start infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
   }
-  
+}
+
+.loader {
+  text-align: center;
+  color: #5bc0de;
+  font-size: 1.2em;
+  margin-bottom: 20px;
+}
+
+.error {
+  color: #d9534f;
+  font-size: 0.85em;
+  margin-top: -10px;
+  margin-bottom: 10px;
+}

--- a/petclinic-frontend/src/pages/Inventory/Inventories.css
+++ b/petclinic-frontend/src/pages/Inventory/Inventories.css
@@ -1,6 +1,6 @@
-#page-title{
-    margin:0px;
-    padding:0px;
-    margin-top: 30px;
-    margin-bottom: 30px;
+#page-title {
+  margin: 0px;
+  padding: 0px;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }

--- a/petclinic-frontend/src/pages/Vet/DeleteVetPhoto.tsx
+++ b/petclinic-frontend/src/pages/Vet/DeleteVetPhoto.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Button } from 'react-bootstrap';
 import { deleteVetPhoto } from '@/features/veterinarians/api/deleteVetPhoto';
 
@@ -11,7 +11,7 @@ const DeleteVetPhoto: React.FC<DeleteVetPhotoProps> = ({
   vetId,
   onPhotoDeleted,
 }) => {
-  const handleDeletePhoto = async () => {
+  const handleDeletePhoto = async (): Promise<void> => {
     const confirmed = window.confirm(
       "Are you sure you want to delete the vet's photo?"
     );

--- a/petclinic-frontend/src/pages/Vet/DeleteVetPhoto.tsx
+++ b/petclinic-frontend/src/pages/Vet/DeleteVetPhoto.tsx
@@ -3,30 +3,35 @@ import { Button } from 'react-bootstrap';
 import { deleteVetPhoto } from '@/features/veterinarians/api/deleteVetPhoto';
 
 interface DeleteVetPhotoProps {
-    vetId: string;
-    onPhotoDeleted: () => void;
+  vetId: string;
+  onPhotoDeleted: () => void;
 }
 
-const DeleteVetPhoto: React.FC<DeleteVetPhotoProps> = ({ vetId, onPhotoDeleted }) => {
-    const handleDeletePhoto = async () => {
-        const confirmed = window.confirm("Are you sure you want to delete the vet's photo?");
-        if (confirmed) {
-            try {
-                await deleteVetPhoto(vetId);
-                alert('Photo deleted successfully.');
-                onPhotoDeleted();
-            } catch (error) {
-                console.error('Error deleting photo:', error);
-                alert('Failed to delete photo.');
-            }
-        }
-    };
-
-    return (
-        <Button variant="danger" onClick={handleDeletePhoto}>
-            Delete Photo
-        </Button>
+const DeleteVetPhoto: React.FC<DeleteVetPhotoProps> = ({
+  vetId,
+  onPhotoDeleted,
+}) => {
+  const handleDeletePhoto = async () => {
+    const confirmed = window.confirm(
+      "Are you sure you want to delete the vet's photo?"
     );
+    if (confirmed) {
+      try {
+        await deleteVetPhoto(vetId);
+        alert('Photo deleted successfully.');
+        onPhotoDeleted();
+      } catch (error) {
+        console.error('Error deleting photo:', error);
+        alert('Failed to delete photo.');
+      }
+    }
+  };
+
+  return (
+    <Button variant="danger" onClick={handleDeletePhoto}>
+      Delete Photo
+    </Button>
+  );
 };
 
 export default DeleteVetPhoto;

--- a/petclinic-frontend/src/pages/Vet/DeleteVetPhoto.tsx
+++ b/petclinic-frontend/src/pages/Vet/DeleteVetPhoto.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Button } from 'react-bootstrap';
+import { deleteVetPhoto } from '@/features/veterinarians/api/deleteVetPhoto';
+
+interface DeleteVetPhotoProps {
+    vetId: string;
+    onPhotoDeleted: () => void;
+}
+
+const DeleteVetPhoto: React.FC<DeleteVetPhotoProps> = ({ vetId, onPhotoDeleted }) => {
+    const handleDeletePhoto = async () => {
+        const confirmed = window.confirm("Are you sure you want to delete the vet's photo?");
+        if (confirmed) {
+            try {
+                await deleteVetPhoto(vetId);
+                alert('Photo deleted successfully.');
+                onPhotoDeleted();
+            } catch (error) {
+                console.error('Error deleting photo:', error);
+                alert('Failed to delete photo.');
+            }
+        }
+    };
+
+    return (
+        <Button variant="danger" onClick={handleDeletePhoto}>
+            Delete Photo
+        </Button>
+    );
+};
+
+export default DeleteVetPhoto;

--- a/petclinic-frontend/src/pages/Vet/VetDetails.css
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.css
@@ -124,4 +124,3 @@ ul {
 .album-photo-thumbnail:hover {
   transform: scale(1.08);
 }
-

--- a/petclinic-frontend/src/pages/Vet/VetDetails.css
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.css
@@ -14,6 +14,7 @@
 }
 .vet-photo-container {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   margin-bottom: 20px;

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { NavBar } from '@/layouts/AppNavBar.tsx';
 import './VetDetails.css';
@@ -30,6 +30,35 @@ export default function VetDetails(): JSX.Element {
   const [specialtyId, setSpecialtyId] = useState('');
   const [specialtyName, setSpecialtyName] = useState('');
   const [enlargedPhoto, setEnlargedPhoto] = useState<string | null>(null);
+
+  const fetchVetPhoto = useCallback(async (): Promise<void> => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/v2/gateway/vets/${vetId}/photo`,
+        {
+          method: 'GET',
+          headers: {
+            Accept: 'image/*',
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Error: ${response.statusText}`);
+      }
+
+      const blob = await response.blob();
+      const imageUrl = URL.createObjectURL(blob);
+      setPhoto(imageUrl);
+    } catch (error) {
+      setError('Failed to fetch vet photo');
+      setPhoto('/images/vet_default.jpg');
+    }
+  }, [vetId]);
+
+  const handlePhotoDeleted = (): void => {
+    fetchVetPhoto();
+  };
 
   useEffect(() => {
     const fetchVetDetails = async (): Promise<void> => {
@@ -90,36 +119,7 @@ export default function VetDetails(): JSX.Element {
       fetchAlbumPhotos();
       setLoading(false);
     });
-  }, [vetId]);
-
-  const fetchVetPhoto = async (): Promise<void> => {
-    try {
-      const response = await fetch(
-        `http://localhost:8080/api/v2/gateway/vets/${vetId}/photo`,
-        {
-          method: 'GET',
-          headers: {
-            Accept: 'image/*',
-          },
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(`Error: ${response.statusText}`);
-      }
-
-      const blob = await response.blob();
-      const imageUrl = URL.createObjectURL(blob);
-      setPhoto(imageUrl);
-    } catch (error) {
-      setError('Failed to fetch vet photo');
-      setPhoto('/images/vet_default.jpg');
-    }
-  };
-
-  const handlePhotoDeleted = (): void => {
-    fetchVetPhoto();
-  };
+  }, [vetId, fetchVetPhoto]);
 
   const renderWorkHours = (workHoursJson: string): JSX.Element => {
     try {

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { NavBar } from '@/layouts/AppNavBar.tsx';
 import './VetDetails.css';
 import axios from 'axios';
+import DeleteVetPhoto from "@/pages/Vet/DeleteVetPhoto.tsx";
 
 interface VetResponseType {
   vetId: string;
@@ -84,6 +85,13 @@ export default function VetDetails(): JSX.Element {
       }
     };
 
+    fetchVetDetails().then(() => {
+      fetchVetPhoto();
+      fetchAlbumPhotos();
+      setLoading(false);
+    });
+  }, [vetId]);
+
     const fetchVetPhoto = async (): Promise<void> => {
       try {
         const response = await fetch(
@@ -105,15 +113,13 @@ export default function VetDetails(): JSX.Element {
         setPhoto(imageUrl);
       } catch (error) {
         setError('Failed to fetch vet photo');
+        setPhoto('/images/vet_default.jpg');
       }
     };
 
-    fetchVetDetails().then(() => {
+    const handlePhotoDeleted = (): void => {
       fetchVetPhoto();
-      fetchAlbumPhotos();
-      setLoading(false);
-    });
-  }, [vetId]);
+    }
 
   const renderWorkHours = (workHoursJson: string): JSX.Element => {
     try {
@@ -189,6 +195,7 @@ export default function VetDetails(): JSX.Element {
         {photo && (
           <section className="vet-photo-container">
             <img src={photo} alt="Vet" className="vet-photo" />
+            <DeleteVetPhoto vetId={vetId!} onPhotoDeleted={handlePhotoDeleted} />
           </section>
         )}
 

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { NavBar } from '@/layouts/AppNavBar.tsx';
 import './VetDetails.css';
 import axios from 'axios';
-import DeleteVetPhoto from "@/pages/Vet/DeleteVetPhoto.tsx";
+import DeleteVetPhoto from '@/pages/Vet/DeleteVetPhoto.tsx';
 
 interface VetResponseType {
   vetId: string;
@@ -92,34 +92,34 @@ export default function VetDetails(): JSX.Element {
     });
   }, [vetId]);
 
-    const fetchVetPhoto = async (): Promise<void> => {
-      try {
-        const response = await fetch(
-          `http://localhost:8080/api/v2/gateway/vets/${vetId}/photo`,
-          {
-            method: 'GET',
-            headers: {
-              Accept: 'image/*',
-            },
-          }
-        );
-
-        if (!response.ok) {
-          throw new Error(`Error: ${response.statusText}`);
+  const fetchVetPhoto = async (): Promise<void> => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/v2/gateway/vets/${vetId}/photo`,
+        {
+          method: 'GET',
+          headers: {
+            Accept: 'image/*',
+          },
         }
+      );
 
-        const blob = await response.blob();
-        const imageUrl = URL.createObjectURL(blob);
-        setPhoto(imageUrl);
-      } catch (error) {
-        setError('Failed to fetch vet photo');
-        setPhoto('/images/vet_default.jpg');
+      if (!response.ok) {
+        throw new Error(`Error: ${response.statusText}`);
       }
-    };
 
-    const handlePhotoDeleted = (): void => {
-      fetchVetPhoto();
+      const blob = await response.blob();
+      const imageUrl = URL.createObjectURL(blob);
+      setPhoto(imageUrl);
+    } catch (error) {
+      setError('Failed to fetch vet photo');
+      setPhoto('/images/vet_default.jpg');
     }
+  };
+
+  const handlePhotoDeleted = (): void => {
+    fetchVetPhoto();
+  };
 
   const renderWorkHours = (workHoursJson: string): JSX.Element => {
     try {
@@ -195,7 +195,10 @@ export default function VetDetails(): JSX.Element {
         {photo && (
           <section className="vet-photo-container">
             <img src={photo} alt="Vet" className="vet-photo" />
-            <DeleteVetPhoto vetId={vetId!} onPhotoDeleted={handlePhotoDeleted} />
+            <DeleteVetPhoto
+              vetId={vetId!}
+              onPhotoDeleted={handlePhotoDeleted}
+            />
           </section>
         )}
 

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -284,9 +284,12 @@ public class VetController {
 */
 
 
-
-
-
+    @DeleteMapping("{vetId}/photo")
+    public Mono<ResponseEntity<Void>> deletePhotoByVetId(@PathVariable String vetId) {
+        return photoService.deletePhotoByVetId(vetId)
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .onErrorResume(NotFoundException.class, e -> Mono.just(ResponseEntity.notFound().build()));
+    }
 
     @PutMapping("{vetId}/photos/{photoName}")
     public Mono<ResponseEntity<Resource>> updatePhotoByVetId(@PathVariable String vetId, @PathVariable String photoName, @RequestBody Mono<Resource> photo){

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/PhotoService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/PhotoService.java
@@ -13,6 +13,7 @@ public interface PhotoService {
     Mono<Resource> insertPhotoOfVet(String vetId, String photoName, Mono<Resource> photo);
     Mono<Resource> updatePhotoByVetId(String vetId, String photoName, Mono<Resource> photo);
    // Mono<Resource> insertPhotoOfVet(String vetId, String photoName, MultipartFile photo);
+    Mono<Void> deletePhotoByVetId(String vetId);
 
 
 }

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/PhotoServiceImpl.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/PhotoServiceImpl.java
@@ -88,7 +88,9 @@ public class PhotoServiceImpl implements PhotoService {
 
     @Override
     public Mono<Void> deletePhotoByVetId(String vetId) {
-        return photoRepository.deleteByVetId(vetId)
+        return photoRepository.findByVetId(vetId)
+                .switchIfEmpty(Mono.error(new InvalidInputException("Photo not found for vetId: " + vetId)))
+                .flatMap(photo -> photoRepository.deleteByVetId(vetId))
                 .then(insertDefaultPhoto(vetId))
                 .then();
     }


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-1253
## Context:

This ticket implements the functionality to allow to admin to delete a veterinarian's profile photo from the vet details page and revert it to the default profile image without reloading the page.

## Does this PR change the .vscode folder in petclinic-frontend?:

This PR doesn't make any changes to the .vscode nor deletes it.

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes

Frontend Changes:
 - Implemented a React component DeleteVetPhoto.tsx that provides a "Delete Photo" button below the vet's profile picture.
 - The handle requires the admin's confirmation before deleting it.
 - deleteVetPhoto.ts contains the API call to the backend to delete photo in the frontend.

Backend Changes:
 - Created the deletePhotoByVetId method that shows status 204.
 - Created the insertDefaultPhoto method that that replaces the removed photo right after deletion and keeps the 204 status.


## Before and After UI (Required for UI-impacting PRs)

Before: 
/
/
<img width="987" alt="before_vet_details" src="https://github.com/user-attachments/assets/62a96fea-0740-46c2-adc3-2bc34e8942dd">
/
/
After:
/
/
![image](https://github.com/user-attachments/assets/8837e1bc-5d6a-4b38-8fc1-61db25708dd7)
/
/
after delete:
/
/
![image](https://github.com/user-attachments/assets/93b1d4b4-380d-4c78-95b9-c465b18e4f87)


## Dev notes (Optional)
Specific technical changes that should be noted
## Linked pull requests (Optional)
Pull request links