### PR TITLE
feat(VIST-CPC-1173): Archive completed visit

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
@@ -2,7 +2,7 @@ package com.petclinic.bffapigateway.domainclientlayer;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-    import com.petclinic.bffapigateway.dtos.Inventory.InventoryRequestDTO;
+import com.petclinic.bffapigateway.dtos.Inventory.InventoryRequestDTO;
 import com.petclinic.bffapigateway.dtos.Inventory.InventoryResponseDTO;
 import com.petclinic.bffapigateway.dtos.Visits.Emergency.EmergencyRequestDTO;
 import com.petclinic.bffapigateway.dtos.Visits.Emergency.EmergencyResponseDTO;
@@ -18,16 +18,14 @@ import com.petclinic.bffapigateway.utils.Rethrower;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.MediaType;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.webjars.NotFoundException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -43,9 +41,10 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 @Component
 public class VisitsServiceClient {
     private final WebClient webClient;
-    private  final String reviewUrl;
+    private final String reviewUrl;
 
     private Rethrower rethrower;
+
     @Autowired
     public VisitsServiceClient(
             @Value("${app.visits-service-new.host}") String visitsServiceHost,
@@ -57,7 +56,7 @@ public class VisitsServiceClient {
                 .build();
     }
 
-    public Flux<VisitResponseDTO> getAllVisits(){
+    public Flux<VisitResponseDTO> getAllVisits() {
         return this.webClient
                 .get()
                 .uri(reviewUrl)
@@ -67,7 +66,7 @@ public class VisitsServiceClient {
                 .bodyToFlux(VisitResponseDTO.class);
     }
 
-    public Flux<VisitResponseDTO> getVisitsForStatus(final String status){
+    public Flux<VisitResponseDTO> getVisitsForStatus(final String status) {
         return webClient
                 .get()
                 .uri("/status/{status}", status)
@@ -76,14 +75,15 @@ public class VisitsServiceClient {
     }
 
 
-    public Flux<VisitResponseDTO> getVisitsForPet(final String petId){
+    public Flux<VisitResponseDTO> getVisitsForPet(final String petId) {
         return webClient
                 .get()
                 .uri("/pets/{petId}", petId)
                 .retrieve()
                 .bodyToFlux(VisitResponseDTO.class);
     }
-    public Flux<VisitResponseDTO> getVisitByPractitionerId(final String practitionerId){
+
+    public Flux<VisitResponseDTO> getVisitByPractitionerId(final String practitionerId) {
         return webClient
                 .get()
                 .uri("/practitioner/{practitionerId}", practitionerId)
@@ -100,7 +100,7 @@ public class VisitsServiceClient {
                 .bodyToMono(VisitResponseDTO.class);
     }
 
-    public Mono<VisitResponseDTO> addVisit(Mono<VisitRequestDTO> visitRequestDTO){
+    public Mono<VisitResponseDTO> addVisit(Mono<VisitRequestDTO> visitRequestDTO) {
         return visitRequestDTO.flatMap(visitRequestDTO1 -> {
             if (visitRequestDTO1.getVisitDate() != null) {
                 LocalDateTime originalDate = visitRequestDTO1.getVisitDate();
@@ -123,72 +123,86 @@ public class VisitsServiceClient {
         Status newStatus = switch (status) {
             case "CONFIRMED" -> Status.CONFIRMED;
             case "COMPLETED" -> Status.COMPLETED;
+            case "ARCHIVED" -> Status.ARCHIVED;
             default -> Status.CANCELLED;
         };
 
         return webClient
-            .put()
-            .uri("/"+ visitId +"/status/" + newStatus)
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .retrieve()
-            .bodyToMono(VisitResponseDTO.class);
+                .put()
+                .uri("/" + visitId + "/status/" + newStatus)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .retrieve()
+                .bodyToMono(VisitResponseDTO.class);
     }
 
     public Mono<VisitResponseDTO> createVisitForPet(VisitRequestDTO visit) {
         return webClient
-            .post()
-            .uri("")
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(Mono.just(visit), VisitRequestDTO.class)
-            .retrieve()
-            .onStatus(HttpStatusCode::is4xxClientError, response -> {
-                HttpStatusCode httpStatus = response.statusCode();
-                return response.bodyToMono(String.class)
-                    .flatMap(errorMessage -> {
-                        try {
-                            ObjectMapper objectMapper = new ObjectMapper();
-                            JsonNode errorNode = objectMapper.readTree(errorMessage);
-                            String message = errorNode.get("message").asText();
+                .post()
+                .uri("")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .body(Mono.just(visit), VisitRequestDTO.class)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> {
+                    HttpStatusCode httpStatus = response.statusCode();
+                    return response.bodyToMono(String.class)
+                            .flatMap(errorMessage -> {
+                                try {
+                                    ObjectMapper objectMapper = new ObjectMapper();
+                                    JsonNode errorNode = objectMapper.readTree(errorMessage);
+                                    String message = errorNode.get("message").asText();
 
-                            if (httpStatus == HttpStatus.NOT_FOUND) {
-                                return Mono.error(new NotFoundException(message));
-                            }
-                            else if (httpStatus == HttpStatus.CONFLICT){
-                                return Mono.error(new DuplicateTimeException(message));
-                            }
-                            else {
-                                return Mono.error(new BadRequestException(message));
-                            }
-                        } catch (IOException e) {
-                            // Handle parsing error
-                            return Mono.error(new BadRequestException("Bad Request"));
-                        }
-                    });
-            })
-            .bodyToMono(VisitResponseDTO.class);
+                                    if (httpStatus == HttpStatus.NOT_FOUND) {
+                                        return Mono.error(new NotFoundException(message));
+                                    } else if (httpStatus == HttpStatus.CONFLICT) {
+                                        return Mono.error(new DuplicateTimeException(message));
+                                    } else {
+                                        return Mono.error(new BadRequestException(message));
+                                    }
+                                } catch (IOException e) {
+                                    // Handle parsing error
+                                    return Mono.error(new BadRequestException("Bad Request"));
+                                }
+                            });
+                })
+                .bodyToMono(VisitResponseDTO.class);
     }
 
-    public Mono<Void> deleteVisitByVisitId(String visitId){
+    public Mono<Void> deleteVisitByVisitId(String visitId) {
         return webClient
                 .delete()
                 .uri("/{visitId}", visitId)
                 .retrieve()
                 .bodyToMono(Void.class);
     }
-    public Mono<Void> deleteAllCancelledVisits(){
+
+    public Mono<Void> deleteAllCancelledVisits() {
         return webClient
                 .delete()
                 .uri("/cancelled")
                 .retrieve()
                 .bodyToMono(Void.class);
     }
-    public Mono<Void> deleteCompletedVisitByVisitId(String visitId){
+
+    public Mono<VisitResponseDTO> archiveCompletedVisit(String visitId, Mono<VisitRequestDTO> visitRequestDTO) {
         return webClient
-                .delete()
-                .uri("/completed/{visitId}", visitId)
+                .put()
+                .uri("/completed/" + visitId + "/archive")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .body(BodyInserters.fromPublisher(visitRequestDTO, VisitRequestDTO.class))
                 .retrieve()
-                .bodyToMono(Void.class);
+                .onStatus(HttpStatusCode::is4xxClientError, response -> response.bodyToMono(String.class)
+                        .flatMap(errorBody -> Mono.error(new BadRequestException(errorBody))))
+                .bodyToMono(VisitResponseDTO.class);
     }
+    public Flux<VisitResponseDTO> getAllArchivedVisits() {
+        return webClient
+                .get()
+                .uri("/archived")
+//                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToFlux(VisitResponseDTO.class);
+    }
+
     /*
     public Flux<VisitDetails> getPreviousVisitsForPet(final String petId) {
         return webClient
@@ -256,8 +270,7 @@ public class VisitsServiceClient {
     }*/
 
 
-
-    public Flux<ReviewResponseDTO> getAllReviews(){
+    public Flux<ReviewResponseDTO> getAllReviews() {
         return webClient
                 .get()
                 .uri(reviewUrl + "/reviews")
@@ -267,7 +280,7 @@ public class VisitsServiceClient {
     }
 
     public Mono<ReviewResponseDTO> createReview(Mono<ReviewRequestDTO> model) {
-        String reviewId= UUID.randomUUID().toString();
+        String reviewId = UUID.randomUUID().toString();
         return model.flatMap(reviewRequestDTO -> {
             return webClient
                     .post()
@@ -299,22 +312,22 @@ public class VisitsServiceClient {
     }
 
     public Mono<VisitResponseDTO> updateVisitByVisitId(String visitId,
-                                                       Mono<VisitRequestDTO> visitRequestDTO){
+                                                       Mono<VisitRequestDTO> visitRequestDTO) {
         return visitRequestDTO.flatMap(requestDTO -> {
-        if (requestDTO.getVisitDate() != null) {
-            LocalDateTime originalDate = requestDTO.getVisitDate();
-            LocalDateTime adjustedDate = originalDate.minusHours(4);
-            requestDTO.setVisitDate(adjustedDate);
-        } else {
-            throw new BadRequestException("Visit date is required");
-        }
-               return webClient
-                        .put()
-                        .uri(reviewUrl + "/" + visitId)
-                        .body(BodyInserters.fromValue(requestDTO))
-                        .retrieve()
-                        .bodyToMono(VisitResponseDTO.class);
-    });
+            if (requestDTO.getVisitDate() != null) {
+                LocalDateTime originalDate = requestDTO.getVisitDate();
+                LocalDateTime adjustedDate = originalDate.minusHours(4);
+                requestDTO.setVisitDate(adjustedDate);
+            } else {
+                throw new BadRequestException("Visit date is required");
+            }
+            return webClient
+                    .put()
+                    .uri(reviewUrl + "/" + visitId)
+                    .body(BodyInserters.fromValue(requestDTO))
+                    .retrieve()
+                    .bodyToMono(VisitResponseDTO.class);
+        });
     }
 
 

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/Status.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/Status.java
@@ -5,6 +5,7 @@ public enum Status {
     UPCOMING,
     COMPLETED,
     CONFIRMED,
-    CANCELLED
+    CANCELLED,
+    ARCHIVED
 
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
@@ -42,6 +42,14 @@ public class VisitController {
     public ResponseEntity<Flux<VisitResponseDTO>> getAllVisits() {
         return ResponseEntity.ok().body(visitsServiceClient.getAllVisits());
     }
+    @SecuredEndpoint(allowedRoles = {Roles.ALL})
+    @GetMapping(value = "/{visitId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<VisitResponseDTO>> getVisitByVisitId(@PathVariable String visitId) {
+        return visitsServiceClient.getVisitByVisitId(visitId)
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
     @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
@@ -105,13 +105,6 @@ public class VisitController {
                         .map(updatedVisit -> ResponseEntity.ok(updatedVisit))
                         .defaultIfEmpty(ResponseEntity.notFound().build())); // Return 404 if not found
     }
-    @IsUserSpecific(idToMatch = {"visitId"})
-    @DeleteMapping(value = "/completed/{visitId}")
-    public Mono<ResponseEntity<Void>> deleteCompletedVisitByVisitId(@PathVariable String visitId) {
-        return visitsServiceClient.deleteCompletedVisitByVisitId(visitId)
-                .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)))
-                .defaultIfEmpty(ResponseEntity.notFound().build());
-    }
 
     //customer visits
     @IsUserSpecific(idToMatch = {"ownerId"}, bypassRoles = {Roles.ADMIN})
@@ -173,5 +166,21 @@ public class VisitController {
                 .map(visitResponseDTO -> new ResponseEntity<>(visitResponseDTO, HttpStatus.OK))
                 .defaultIfEmpty(new ResponseEntity<>(HttpStatus.NOT_FOUND)); // Handle empty responses
     }
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
+    @IsUserSpecific(idToMatch = {"visitId"})
+    @PutMapping(value = "/completed/{visitId}/archive", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<VisitResponseDTO>> archiveCompletedVisit(@PathVariable String visitId, @RequestBody Mono<VisitRequestDTO> visitRequestDTOMono){
+        return visitsServiceClient.archiveCompletedVisit(visitId, visitRequestDTOMono)
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
+    }
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
+    @GetMapping(value = "/archived", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<VisitResponseDTO> getArchivedVisits() {
+        return visitsServiceClient.getAllArchivedVisits();
+    }
+
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerIntegrationTest.java
@@ -113,31 +113,4 @@ public class VisitControllerIntegrationTest {
                 .expectNextCount(3)
                 .verifyComplete();
     }
-
-    @Test
-    void whenDeleteCompletedVisitsById_asAdmin_thenReturnNoContent() {
-        String visitId = "visitId1";
-        webTestClient.delete()
-                .uri("/api/v2/gateway/visits/completed/{visitId}", visitId)
-                .accept(MediaType.APPLICATION_JSON)
-                .cookie("Bearer", jwtTokenForValidAdmin) // admin token
-                .exchange()
-                .expectStatus().isNoContent()
-                .expectBody().isEmpty();
-    }
-
-    @Test
-    void whenDeleteCompletedVisit_ByInvalidId_asAdmin_thenReturnNotFound() {
-        String visitId = "InvalidId";
-        webTestClient.delete()
-                .uri("/api/v2/gateway/visits/completed/{visitId}", visitId)
-                .accept(MediaType.APPLICATION_JSON)
-                .cookie("Bearer", jwtTokenForValidAdmin) // admin token
-                .exchange()
-                .expectStatus().isNotFound();
-
-        StepVerifier
-                .create(Mono.empty())
-                .verifyComplete();
-    }
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
@@ -582,6 +582,7 @@ public class VisitControllerUnitTest {
         verify(bffApiGatewayController, times(1)).getVisitsByOwnerId(ownerId);
     }
 
+<<<<<<< HEAD
     @Test
     void updateVisitStatus_ShouldReturnOK_WhenStatusUpdatedToCancelled() {
         String visitId = "12345";
@@ -628,6 +629,8 @@ public class VisitControllerUnitTest {
         // Verify that the service was called
         verify(visitsServiceClient, times(1)).patchVisitStatus(eq(visitId), eq(status));
     }
+=======
+>>>>>>> dd9f2622 (Finished tests)
 
     @Test
     void archiveCompletedVisit_whenValidRequest_thenReturnVisitResponseDTO() {
@@ -717,4 +720,10 @@ public class VisitControllerUnitTest {
         verify(visitsServiceClient, times(1)).getAllArchivedVisits();
     }
 
+<<<<<<< HEAD
+=======
+
+
+
+>>>>>>> dd9f2622 (Finished tests)
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
@@ -582,7 +582,6 @@ public class VisitControllerUnitTest {
         verify(bffApiGatewayController, times(1)).getVisitsByOwnerId(ownerId);
     }
 
-<<<<<<< HEAD
     @Test
     void updateVisitStatus_ShouldReturnOK_WhenStatusUpdatedToCancelled() {
         String visitId = "12345";
@@ -629,8 +628,6 @@ public class VisitControllerUnitTest {
         // Verify that the service was called
         verify(visitsServiceClient, times(1)).patchVisitStatus(eq(visitId), eq(status));
     }
-=======
->>>>>>> dd9f2622 (Finished tests)
 
     @Test
     void archiveCompletedVisit_whenValidRequest_thenReturnVisitResponseDTO() {
@@ -719,11 +716,4 @@ public class VisitControllerUnitTest {
 
         verify(visitsServiceClient, times(1)).getAllArchivedVisits();
     }
-
-<<<<<<< HEAD
-=======
-
-
-
->>>>>>> dd9f2622 (Finished tests)
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
@@ -80,8 +80,6 @@ public class VisitControllerUnitTest {
             .build();
 
 
-
-
     // ReviewResponseDTO and ReviewRequestDTO for testing purposes
     private final ReviewResponseDTO reviewResponseDTO = ReviewResponseDTO.builder()
             .reviewId("R001")
@@ -153,6 +151,7 @@ public class VisitControllerUnitTest {
         // Assert
         verify(visitsServiceClient, times(1)).getAllReviews();
     }
+
     @Test
     void getAllVisits_whenAllPropertiesExist_thenReturnFluxResponseDTO() {
         // Arrange
@@ -165,7 +164,7 @@ public class VisitControllerUnitTest {
                 .accept(MediaType.TEXT_EVENT_STREAM)
                 .exchange()
                 .expectStatus().isOk()
-                .expectBodyList( VisitResponseDTO.class)
+                .expectBodyList(VisitResponseDTO.class)
                 .hasSize(1);
         // Assert
         verify(visitsServiceClient, times(1)).getAllVisits();
@@ -306,7 +305,7 @@ public class VisitControllerUnitTest {
     }
 
     @Test
-    void getAllVisits_whenNoVisitsExist_thenReturnEmptyFlux(){
+    void getAllVisits_whenNoVisitsExist_thenReturnEmptyFlux() {
         // Arrange
         when(visitsServiceClient.getAllVisits())
                 .thenReturn(Flux.empty()); // no visits should not throw an error
@@ -629,4 +628,93 @@ public class VisitControllerUnitTest {
         // Verify that the service was called
         verify(visitsServiceClient, times(1)).patchVisitStatus(eq(visitId), eq(status));
     }
+
+    @Test
+    void archiveCompletedVisit_whenValidRequest_thenReturnVisitResponseDTO() {
+        String visitId = "visitId1";
+        VisitRequestDTO visitRequestDTO = VisitRequestDTO.builder()
+                .description("Updated Visit Description")
+                .status(Status.COMPLETED)
+                .build();
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId(visitId)
+                .description("Updated Visit Description")
+                .status(Status.COMPLETED)
+                .build();
+
+        when(visitsServiceClient.archiveCompletedVisit(eq(visitId), any(Mono.class)))
+                .thenReturn(Mono.just(visitResponseDTO));
+
+        webTestClient.put()
+                .uri(BASE_VISIT_URL + "/completed/{visitId}/archive", visitId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(visitRequestDTO)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(VisitResponseDTO.class)
+                .isEqualTo(visitResponseDTO);
+
+        verify(visitsServiceClient, times(1)).archiveCompletedVisit(eq(visitId), any(Mono.class));
+    }
+
+    @Test
+    void archiveCompletedVisit_whenInvalidRequest_thenReturnBadRequest() {
+        String visitId = "visitId1";
+        VisitRequestDTO visitRequestDTO = VisitRequestDTO.builder()
+                .description("Updated Visit Description")
+                .status(Status.COMPLETED)
+                .build();
+
+        when(visitsServiceClient.archiveCompletedVisit(eq(visitId), any(Mono.class)))
+                .thenReturn(Mono.empty());
+
+        webTestClient.put()
+                .uri(BASE_VISIT_URL + "/completed/{visitId}/archive", visitId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(visitRequestDTO)
+                .exchange()
+                .expectStatus().isBadRequest();
+
+        verify(visitsServiceClient, times(1)).archiveCompletedVisit(eq(visitId), any(Mono.class));
+    }
+
+    @Test
+    void getArchivedVisits_whenArchivedVisitsExist_thenReturnFluxVisitResponseDTO() {
+        VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
+                .visitId("visitId1")
+                .description("Archived Visit")
+                .status(Status.ARCHIVED)
+                .build();
+
+        when(visitsServiceClient.getAllArchivedVisits())
+                .thenReturn(Flux.just(visitResponseDTO));
+
+        webTestClient.get()
+                .uri(BASE_VISIT_URL + "/archived")
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(VisitResponseDTO.class)
+                .hasSize(1)
+                .contains(visitResponseDTO);
+
+        verify(visitsServiceClient, times(1)).getAllArchivedVisits();
+    }
+
+    @Test
+    void getArchivedVisits_whenNoArchivedVisitsExist_thenReturnEmptyFlux() {
+        when(visitsServiceClient.getAllArchivedVisits())
+                .thenReturn(Flux.empty());
+
+        webTestClient.get()
+                .uri(BASE_VISIT_URL + "/archived")
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(VisitResponseDTO.class)
+                .hasSize(0);
+
+        verify(visitsServiceClient, times(1)).getAllArchivedVisits();
+    }
+
 }

--- a/petclinic-frontend/src/features/visits/VisitListTable.tsx
+++ b/petclinic-frontend/src/features/visits/VisitListTable.tsx
@@ -19,6 +19,7 @@ export default function VisitListTable(): JSX.Element {
   const [confirmedCollapsed, setConfirmedCollapsed] = useState(false);
   const [upcomingCollapsed, setUpcomingCollapsed] = useState(false);
   const [completedCollapsed, setCompletedCollapsed] = useState(false);
+  const [cancelledCollapsed, setCancelledCollapsed] = useState(false);
   const [archivedCollapsed, setArchivedCollapsed] = useState(false);
 
   const navigate = useNavigate();
@@ -158,19 +159,13 @@ export default function VisitListTable(): JSX.Element {
   const completedVisits = visitsList.filter(
     visit => visit.status === 'COMPLETED'
   );
-<<<<<<< HEAD
   const cancelledVisits = visitsList.filter(
     visit => visit.status === 'CANCELLED'
   );
-  const handleDelete = async (visitId: string): Promise<void> => {
-    const confirmDelete = window.confirm(
-      `Are you sure you want to delete visit with ID: ${visitId}?`
-=======
 
   const handleArchive = async (visitId: string): Promise<void> => {
     const confirmArchive = window.confirm(
       `Are you sure you want to archive visit with ID: ${visitId}?`
->>>>>>> d758947e (Adding back deleted methods)
     );
     if (confirmArchive) {
       try {
@@ -323,89 +318,6 @@ export default function VisitListTable(): JSX.Element {
     allowArchive: boolean = false
   ): JSX.Element => (
     <div className="visit-table-section">
-<<<<<<< HEAD
-<<<<<<< HEAD
-      <h2>{title}</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>Visit Id</th>
-            <th>Visit Date</th>
-            <th>Description</th>
-            <th>Pet Name</th>
-            <th>Vet First Name</th>
-            <th>Vet Last Name</th>
-            <th>Vet Email</th>
-            <th>Visit End Date</th>
-            <th>Status</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {visits.map(visit => (
-            <tr key={visit.visitId}>
-              <td>{visit.visitId}</td>
-              <td>{new Date(visit.visitDate).toLocaleString()}</td>
-              <td>{visit.description}</td>
-              <td>{visit.petName}</td>
-              <td>{visit.vetFirstName}</td>
-              <td>{visit.vetLastName}</td>
-              <td>{visit.vetEmail}</td>
-              <td>{new Date(visit.visitEndDate).toLocaleString()}</td>
-              <td
-                style={{
-                  color:
-                    visit.status === 'CONFIRMED'
-                      ? 'green'
-                      : visit.status === 'UPCOMING'
-                        ? 'orange'
-                        : visit.status === 'CANCELLED'
-                          ? 'red'
-                          : visit.status === 'COMPLETED'
-                            ? 'blue'
-                            : 'inherit',
-                }}
-              >
-                {visit.status}
-              </td>
-              <td>
-                <button
-                  className="btn btn-dark"
-                  onClick={() => navigate(`/visits/${visit.visitId}`)}
-                  title="View"
-                >
-                  View
-                </button>
-                <button
-                  className="btn btn-warning"
-                  onClick={() => navigate(`/visits/${visit.visitId}/edit`)}
-                  title="Edit"
-                >
-                  Edit
-                </button>
-                {allowDelete && (
-                  <button
-                    className="btn btn-danger"
-                    onClick={() => handleDelete(visit.visitId)}
-                    title="Delete"
-                  >
-                    Delete
-                  </button>
-                )}
-
-                {visit.status !== 'CANCELLED' &&
-                  visit.status !== 'COMPLETED' && (
-                    <button
-                      className="btn btn-danger"
-                      onClick={() => handleCancel(visit.visitId)}
-                    >
-                      Cancel Visit
-                    </button>
-                  )}
-              </td>
-=======
-=======
->>>>>>> 0d52aeb0 (Fix merge issues)
       <h2
         onClick={() => setCollapsed(!collapsed)}
         style={{ cursor: 'pointer' }}
@@ -446,11 +358,14 @@ export default function VisitListTable(): JSX.Element {
                         ? 'green'
                         : visit.status === 'UPCOMING'
                           ? 'orange'
-                          : visit.status === 'COMPLETED'
-                            ? 'blue'
-                            : visit.status === 'ARCHIVED'
-                              ? 'green'
-                              : 'inherit',
+                          : visit.status === 'CANCELLED'
+                            ? 'red'
+                            : visit.status === 'COMPLETED'
+                              ? 'blue'
+                              : visit.status === 'ARCHIVED'
+                                ? 'gray'
+                                : 'inherit',
+                    fontWeight: 'bold',
                   }}
                 >
                   {visit.status}
@@ -463,10 +378,9 @@ export default function VisitListTable(): JSX.Element {
                   >
                     View
                   </button>
-
                   <button
                     className="btn btn-warning"
-                    onClick={() => navigate(`/visits/${visit.visitId}/edit`)} // Edit button that triggers updateVisit
+                    onClick={() => navigate(`/visits/${visit.visitId}/edit`)}
                     title="Edit"
                   >
                     Edit
@@ -480,6 +394,17 @@ export default function VisitListTable(): JSX.Element {
                       Archive
                     </button>
                   )}
+
+                  {visit.status !== 'CANCELLED' &&
+                    visit.status !== 'ARCHIVED' &&
+                    visit.status !== 'COMPLETED' && (
+                      <button
+                        className="btn btn-danger"
+                        onClick={() => handleCancel(visit.visitId)}
+                      >
+                        Cancel Visit
+                      </button>
+                    )}
                 </td>
               </tr>
             ))}
@@ -488,7 +413,6 @@ export default function VisitListTable(): JSX.Element {
       )}
     </div>
   );
-
   return (
     <div>
       <div className="visit-actions">
@@ -525,14 +449,6 @@ export default function VisitListTable(): JSX.Element {
       {/* Emergency Table below buttons, but above visit tables */}
       {renderEmergencyTable('Emergency Visits', emergencyList)}
 
-<<<<<<< HEAD
-      {renderTable('Confirmed Visits', confirmedVisits)}
-      {renderTable('Upcoming Visits', upcomingVisits)}
-      {renderTable('Cancelled Visits', cancelledVisits)}
-      {renderTable('Completed Visits', completedVisits, true)}
-=======
-=======
->>>>>>> 0d52aeb0 (Fix merge issues)
       {renderTable(
         'Confirmed Visits',
         confirmedVisits,
@@ -553,11 +469,16 @@ export default function VisitListTable(): JSX.Element {
         true
       )}
       {renderTable(
+        'Cancelled Visits',
+        cancelledVisits,
+        cancelledCollapsed,
+        setCancelledCollapsed
+      )}
+      {renderTable(
         'Archived Visits',
         archivedVisits,
         archivedCollapsed,
-        setArchivedCollapsed,
-        false
+        setArchivedCollapsed
       )}
     </div>
   );

--- a/petclinic-frontend/src/features/visits/VisitListTable.tsx
+++ b/petclinic-frontend/src/features/visits/VisitListTable.tsx
@@ -10,11 +10,9 @@ import './Emergency.css';
 
 export default function VisitListTable(): JSX.Element {
   const [visitsList, setVisitsList] = useState<Visit[]>([]);
-<<<<<<< HEAD
   const [emergencyList, setEmergencyList] = useState<EmergencyResponseDTO[]>(
     []
   );
-=======
   const [archivedVisits, setArchivedVisits] = useState<Visit[]>([]);
 
   //make tables collapsable
@@ -23,7 +21,6 @@ export default function VisitListTable(): JSX.Element {
   const [completedCollapsed, setCompletedCollapsed] = useState(false);
   const [archivedCollapsed, setArchivedCollapsed] = useState(false);
 
->>>>>>> b9f80b66 (Fully implemented the archive feature and collapsable tables)
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -79,7 +76,6 @@ export default function VisitListTable(): JSX.Element {
   }, []);
 
   useEffect(() => {
-<<<<<<< HEAD
     // Fetch emergency visits
     async function fetchEmergencies(): Promise<void> {
       try {
@@ -110,7 +106,7 @@ export default function VisitListTable(): JSX.Element {
     }
   };
 
-=======
+  useEffect(() => {
     const archivedEventSource = new EventSource(
       'http://localhost:8080/api/v2/gateway/visits/archived',
       {
@@ -153,7 +149,6 @@ export default function VisitListTable(): JSX.Element {
     };
   }, []);
 
->>>>>>> b9f80b66 (Fully implemented the archive feature and collapsable tables)
   const confirmedVisits = visitsList.filter(
     visit => visit.status === 'CONFIRMED'
   );
@@ -329,6 +324,7 @@ export default function VisitListTable(): JSX.Element {
   ): JSX.Element => (
     <div className="visit-table-section">
 <<<<<<< HEAD
+<<<<<<< HEAD
       <h2>{title}</h2>
       <table>
         <thead>
@@ -408,6 +404,8 @@ export default function VisitListTable(): JSX.Element {
                   )}
               </td>
 =======
+=======
+>>>>>>> 0d52aeb0 (Fix merge issues)
       <h2
         onClick={() => setCollapsed(!collapsed)}
         style={{ cursor: 'pointer' }}
@@ -428,7 +426,6 @@ export default function VisitListTable(): JSX.Element {
               <th>Visit End Date</th>
               <th>Status</th>
               <th>Actions</th>
->>>>>>> b9f80b66 (Fully implemented the archive feature and collapsable tables)
             </tr>
           </thead>
           <tbody>
@@ -525,15 +522,17 @@ export default function VisitListTable(): JSX.Element {
         </button>
       </div>
 
-<<<<<<< HEAD
       {/* Emergency Table below buttons, but above visit tables */}
       {renderEmergencyTable('Emergency Visits', emergencyList)}
 
+<<<<<<< HEAD
       {renderTable('Confirmed Visits', confirmedVisits)}
       {renderTable('Upcoming Visits', upcomingVisits)}
       {renderTable('Cancelled Visits', cancelledVisits)}
       {renderTable('Completed Visits', completedVisits, true)}
 =======
+=======
+>>>>>>> 0d52aeb0 (Fix merge issues)
       {renderTable(
         'Confirmed Visits',
         confirmedVisits,
@@ -560,7 +559,6 @@ export default function VisitListTable(): JSX.Element {
         setArchivedCollapsed,
         false
       )}
->>>>>>> b9f80b66 (Fully implemented the archive feature and collapsable tables)
     </div>
   );
 }

--- a/petclinic-frontend/src/pages/Visit/Visit.tsx
+++ b/petclinic-frontend/src/pages/Visit/Visit.tsx
@@ -7,7 +7,7 @@ export default function Visits(): JSX.Element {
     <>
       <NavBar />
       <div className="page-container">
-        <h2>This is the Visits Page</h2>
+        <h2>Visits!</h2>
         <VisitListTable />
       </div>
     </>

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
@@ -37,6 +37,7 @@ public interface VisitService {
     Mono<VisitResponseDTO> archiveCompletedVisit(String visitId, Mono<VisitRequestDTO> visitRequestDTO);
 
     Flux<VisitResponseDTO> getAllArchivedVisits();
+
 //    Mono<VetDTO> testingGetVetDTO(String vetId);
 //    Mono<PetResponseDTO> testingGetPetDTO(int petId);
 

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
@@ -11,19 +11,32 @@ import reactor.core.publisher.Mono;
  */
 public interface VisitService {
     Flux<VisitResponseDTO> getAllVisits();
+
     Flux<VisitResponseDTO> getVisitsForPet(String petId);
+
     Flux<VisitResponseDTO> getVisitsForStatus(String statusString);
+
     Flux<VisitResponseDTO> getVisitsForPractitioner(String vetId);
+
     //Flux<VisitResponseDTO> getVisitsByPractitionerIdAndMonth(int practitionerId, int month);
     Mono<VisitResponseDTO> getVisitByVisitId(String visitId);
+
     Mono<VisitResponseDTO> addVisit(Mono<VisitRequestDTO> visitRequestDTOMono);
+
     Mono<VisitResponseDTO> updateVisit(String visitId, Mono<VisitRequestDTO> visitRequestDTOMono);
+
     Mono<VisitResponseDTO> updateStatusForVisitByVisitId(String visitId, String status);
+
     Mono<Void> deleteVisit(String visitId);
+
     Mono<Void> deleteAllCancelledVisits();
-    Mono<Void>deleteCompletedVisitByVisitId(String visitId);
+
+
     Mono<VisitResponseDTO> patchVisitStatusInVisit(String visitId, String status);
 
+    Mono<VisitResponseDTO> archiveCompletedVisit(String visitId, Mono<VisitRequestDTO> visitRequestDTO);
+
+    Flux<VisitResponseDTO> getAllArchivedVisits();
 //    Mono<VetDTO> testingGetVetDTO(String vetId);
 //    Mono<PetResponseDTO> testingGetPetDTO(int petId);
 

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
@@ -87,18 +87,23 @@ public class VisitServiceImpl implements VisitService {
         switch (statusString) { // Transform string back into enumerator
             case ("UPCOMING"):
                 status = Status.UPCOMING;
+                break;
 
             case ("CONFIRMED"):
                 status = Status.CONFIRMED;
+                break;
 
             case ("CANCELLED"):
                 status = Status.CANCELLED;
+                break;
 
             case ("ARCHIVED"):
                 status = Status.ARCHIVED;
+                break;
 
             default:
                 status = Status.COMPLETED;
+                break;
         }
         return repo.findAllByStatus(statusString)
                 .flatMap(entityDtoUtil::toVisitResponseDTO);
@@ -243,16 +248,13 @@ public class VisitServiceImpl implements VisitService {
                 .flatMap(entityDtoUtil::toVisitResponseDTO);
     }
 
+    @Override
+    public Flux<VisitResponseDTO> getAllArchivedVisits() {
+        return repo.findAllByStatus("ARCHIVED")
+                .switchIfEmpty(Mono.defer(() -> Mono.error(new NotFoundException("No archived visits were found"))))
+                .flatMap(entityDtoUtil::toVisitResponseDTO);
+    }
 
-//    @Override
-//    public Mono<Void> deleteCompletedVisitByVisitId(String visitId) {
-//        return repo.findByVisitId(visitId)
-//                .filter(visit -> visit.getStatus() == Status.COMPLETED)
-//                .switchIfEmpty(Mono.defer(() -> Mono.error(new NotFoundException("Cannot Find visit id" + visitId))))
-//                .flatMap(visit -> repo.deleteByVisitId(visit.getVisitId()))
-//                .doOnSuccess(v -> log.info("Successfully deleted completed visit with id: {}", visitId))
-//                .doOnError(e -> log.error("Failed to delete completed visit with id: {}", visitId, e));
-//    }
 
 //    @Override
 //    public Mono<VetDTO> testingGetVetDTO(String vetId) {

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
@@ -235,18 +235,11 @@ public class VisitServiceImpl implements VisitService {
                 .switchIfEmpty(Mono.error(new BadRequestException("Cannot archive a visit that is not completed.")))
                 .doOnNext(visit -> {
                     visit.setStatus(Status.ARCHIVED);
-//                    visit.setVisitId(visitId);
                 })
                 .flatMap(repo::save)
 
                 .flatMap(entityDtoUtil::toVisitResponseDTO);
     }
-//    @Override
-//    public Flux<VisitResponseDTO> getAllArchivedVisits() {
-//        return repo.findAllByStatus("ARCHIVED")
-//                .switchIfEmpty(Mono.defer(() -> Mono.error(new NotFoundException("No archived visits were found"))))
-//                .flatMap(entityDtoUtil::toVisitResponseDTO);
-//    }
 
     @Override
     public Flux<VisitResponseDTO> getAllArchivedVisits() {

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
@@ -241,12 +241,12 @@ public class VisitServiceImpl implements VisitService {
 
                 .flatMap(entityDtoUtil::toVisitResponseDTO);
     }
-    @Override
-    public Flux<VisitResponseDTO> getAllArchivedVisits() {
-        return repo.findAllByStatus("ARCHIVED")
-                .switchIfEmpty(Mono.defer(() -> Mono.error(new NotFoundException("No archived visits were found"))))
-                .flatMap(entityDtoUtil::toVisitResponseDTO);
-    }
+//    @Override
+//    public Flux<VisitResponseDTO> getAllArchivedVisits() {
+//        return repo.findAllByStatus("ARCHIVED")
+//                .switchIfEmpty(Mono.defer(() -> Mono.error(new NotFoundException("No archived visits were found"))))
+//                .flatMap(entityDtoUtil::toVisitResponseDTO);
+//    }
 
     @Override
     public Flux<VisitResponseDTO> getAllArchivedVisits() {

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/DataSetupService.java
@@ -1,7 +1,6 @@
 package com.petclinic.visits.visitsservicenew.DataLayer;
 
 
-
 import com.petclinic.visits.visitsservicenew.DataLayer.Emergency.Emergency;
 import com.petclinic.visits.visitsservicenew.DataLayer.Emergency.EmergencyRepository;
 import com.petclinic.visits.visitsservicenew.DataLayer.Emergency.UrgencyLevel;
@@ -36,13 +35,13 @@ public class DataSetupService implements CommandLineRunner {
     private void setupVisits() {
         Visit visit1 = buildVisit("visitId1", "2022-11-24 13:00", "this is a dummy description", "ecb109cd-57ea-4b85-b51e-99751fd1c349", "69f852ca-625b-11ee-8c99-0242ac120002", Status.UPCOMING, LocalDateTime.parse("2024-11-24 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
         Visit visit2 = buildVisit("visitId2", "2022-03-01 13:00", "Dog Needs Meds", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85766-625b-11ee-8c99-0242ac120002", Status.COMPLETED, LocalDateTime.parse("2022-03-01 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
-        Visit visit3 = buildVisit("visitId3", "2020-07-19 13:00","Dog Needs Surgery After Meds", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85bda-625b-11ee-8c99-0242ac120002", Status.COMPLETED, LocalDateTime.parse("2020-07-19 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
-        Visit visit4 = buildVisit("visitId4", "2022-12-24 13:00", "Dog Needs Physio-Therapy", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85d2e-625b-11ee-8c99-0242ac120002", Status.UPCOMING, LocalDateTime.parse("2022-12-24 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
+        Visit visit3 = buildVisit("visitId3", "2020-07-19 13:00", "Dog Needs Surgery After Meds", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85bda-625b-11ee-8c99-0242ac120002", Status.COMPLETED, LocalDateTime.parse("2020-07-19 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
+        Visit visit4 = buildVisit("visitId4", "2022-12-24 13:00", "Dog Needs Physio-Therapy", "0e4d8481-b611-4e52-baed-af16caa8bf8a", "69f85d2e-625b-11ee-8c99-0242ac120002", Status.ARCHIVED, LocalDateTime.parse("2022-12-24 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
         Visit visit5 = buildVisit("visitId5", "2023-12-24 13:00", "Cat Needs Check-Up", "53163352-8398-4513-bdff-b7715c056d1d", "ac9adeb8-625b-11ee-8c99-0242ac120002", Status.UPCOMING, LocalDateTime.parse("2023-12-24 13:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
         Visit visit6 = buildVisit("visitId6", "2023-12-05 15:00", "Animal Needs Operation", "53163352-8398-4513-bdff-b7715c056d1d", "ac9adeb8-625b-11ee-8c99-0242ac120002", Status.UPCOMING, LocalDateTime.parse("2023-12-05 15:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
         Visit visit7 = buildVisit("visitId7", "2022-05-20 09:00", "Cat Needs Check-Up", "7056652d-f2fd-4873-a480-5d2e86bed641", "ac9adeb8-625b-11ee-8c99-0242ac120002", Status.CONFIRMED, LocalDateTime.parse("2022-05-20 09:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")).plusHours(1));
 
-        Flux.just(visit1, visit2, visit3,visit4,visit5,visit6,visit7)
+        Flux.just(visit1, visit2, visit3, visit4, visit5, visit6, visit7)
                 .flatMap(visitRepo::insert)
                 .subscribe();
     }
@@ -56,9 +55,9 @@ public class DataSetupService implements CommandLineRunner {
     }
 
     private void setupEmergencies() {
-        Emergency emergency1 = buildEmergency("emergencyId1", "2022-12-01 10:00", "Severe bleeding", "Bobby", UrgencyLevel.HIGH,  "Accident");
-        Emergency emergency2 = buildEmergency("emergencyId2", "2023-01-15 15:00", "Broken leg", "Tommy", UrgencyLevel.MEDIUM,  "Injury");
-        Emergency emergency3 = buildEmergency("emergencyId3", "2023-06-05 09:30", "Breathing issues", "Max", UrgencyLevel.HIGH,  "Respiratory");
+        Emergency emergency1 = buildEmergency("emergencyId1", "2022-12-01 10:00", "Severe bleeding", "Bobby", UrgencyLevel.HIGH, "Accident");
+        Emergency emergency2 = buildEmergency("emergencyId2", "2023-01-15 15:00", "Broken leg", "Tommy", UrgencyLevel.MEDIUM, "Injury");
+        Emergency emergency3 = buildEmergency("emergencyId3", "2023-06-05 09:30", "Breathing issues", "Max", UrgencyLevel.HIGH, "Respiratory");
 
         Flux.just(emergency1, emergency2, emergency3)
                 .flatMap(emergencyRepository::insert)

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/Status.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/Status.java
@@ -6,5 +6,6 @@ public enum Status {
     UPCOMING,
     CONFIRMED,
     COMPLETED,
-    CANCELLED
+    CANCELLED,
+    ARCHIVED
 }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -209,7 +209,6 @@ public class VisitController {
 
 
 
-<<<<<<< HEAD
     //Emergency
 
     @GetMapping(value = "/emergency")
@@ -254,8 +253,7 @@ public class VisitController {
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
-=======
->>>>>>> b9f80b66 (Fully implemented the archive feature and collapsable tables)
+
     @PutMapping(value = "/completed/{visitId}/archive", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<VisitResponseDTO>> archiveCompletedVisit(@PathVariable String visitId, @RequestBody Mono<VisitRequestDTO> visitRequestDTO) {
     return Mono.just(visitId)
@@ -269,17 +267,8 @@ public class VisitController {
     public Flux<VisitResponseDTO> getAllArchivedVisits() {
         return visitService.getAllArchivedVisits();
     }
-    @GetMapping(value = "/archived", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<VisitResponseDTO> getAllArchivedVisits() {
-        return visitService.getAllArchivedVisits();
-    }
 
-//    @DeleteMapping(value = "/completed/{visitId}")
-//    public Mono<ResponseEntity<Void>> deleteCompletedVisitByVisitId(@PathVariable String visitId){
-//        return visitService.deleteCompletedVisitByVisitId(visitId)
-//                .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)))
-//                .defaultIfEmpty(new ResponseEntity<>(HttpStatus.NOT_FOUND));// Return 404 if NotFoundException is thrown
-//    }
+
 //    @GetMapping("/pets/{petId}")
 //    public Mono<PetResponseDTO> getPetByIdTest(@PathVariable int petId){
 //       return visitService.testingGetPetDTO(petId);

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -209,6 +209,7 @@ public class VisitController {
 
 
 
+<<<<<<< HEAD
     //Emergency
 
     @GetMapping(value = "/emergency")
@@ -253,6 +254,8 @@ public class VisitController {
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
+=======
+>>>>>>> b9f80b66 (Fully implemented the archive feature and collapsable tables)
     @PutMapping(value = "/completed/{visitId}/archive", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<VisitResponseDTO>> archiveCompletedVisit(@PathVariable String visitId, @RequestBody Mono<VisitRequestDTO> visitRequestDTO) {
     return Mono.just(visitId)
@@ -260,7 +263,11 @@ public class VisitController {
             .flatMap(id -> visitService.archiveCompletedVisit(id, visitRequestDTO))
             .map(ResponseEntity::ok)
             .defaultIfEmpty(ResponseEntity.badRequest().build());
+    }
 
+    @GetMapping(value = "/archived", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<VisitResponseDTO> getAllArchivedVisits() {
+        return visitService.getAllArchivedVisits();
     }
     @GetMapping(value = "/archived", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<VisitResponseDTO> getAllArchivedVisits() {

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -28,7 +28,6 @@ import reactor.core.publisher.Mono;
 public class VisitController {
     /**
      * We are Accessing the Controller
-     *
      */
     private final VisitService visitService;
     private final ReviewService reviewService;
@@ -37,20 +36,22 @@ public class VisitController {
     /**
      * Simple Get all Visits
      * Accessible through localhost:8080/visits
+     *
      * @return All visits
      */
-    @GetMapping(value="", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<VisitResponseDTO> getAllVisits(){
+    @GetMapping(value = "", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<VisitResponseDTO> getAllVisits() {
         return visitService.getAllVisits();
     }
 
     /**
      * Get all the visits with the vet ID given
      * localhost:8080/visits/practitioner/{VET_ID}
+     *
      * @param practitionerId The Vet ID
      * @return List of visits that have the Given vetID
      */
-    @GetMapping(value="practitioner/{practitionerId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @GetMapping(value = "practitioner/{practitionerId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<VisitResponseDTO> getVisitsByPractitionerId(@PathVariable String practitionerId) {
         return visitService.getVisitsForPractitioner(practitionerId);
     }
@@ -58,33 +59,36 @@ public class VisitController {
     /**
      * Get all the visits with the pet ID given
      * localhost:8080/visits/pets/{petID}
+     *
      * @param petId The Pet id to find the visit for
      * @return All the visit with the common pet ID
      */
-    @GetMapping(value="/pets/{petId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<VisitResponseDTO> getVisitsForPet(@PathVariable String petId){
+    @GetMapping(value = "/pets/{petId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<VisitResponseDTO> getVisitsForPet(@PathVariable String petId) {
         return visitService.getVisitsForPet(petId);
     }
 
     /**
      * Get all the visits by their status ( EX : DataLayer/Status ( ENUM ) )
      * localhost:8080/visits/status/{Status.toString}
+     *
      * @param status The status we are searching for
      * @return All the visits with the status we searched for
      */
     @GetMapping(value = "/status/{status}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<VisitResponseDTO> getVisitsForStatus(@PathVariable String status){
+    public Flux<VisitResponseDTO> getVisitsForStatus(@PathVariable String status) {
         return visitService.getVisitsForStatus(status);
     }
 
     /**
      * Get a visit by its ID
      * localhost:8080/visits/{searchedVisitID}
+     *
      * @param visitId The ID of the visit we are searching for
      * @return The visit we searched for or a not found exception
      */
     @GetMapping("/{visitId}")
-    public Mono<ResponseEntity<VisitResponseDTO>> getVisitByVisitId(@PathVariable String visitId){
+    public Mono<ResponseEntity<VisitResponseDTO>> getVisitByVisitId(@PathVariable String visitId) {
         return visitService.getVisitByVisitId(visitId)
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
@@ -100,41 +104,45 @@ public class VisitController {
     /**
      * Add a new visit. ALSO SEND AN EMAIL
      * localhost:8080/visits @POST
+     *
      * @param visitRequestDTOMono The Request DTO
      * @return The response model of the visit we created
      */
     @PostMapping("")
-    public Mono<VisitResponseDTO> addVisit(@RequestBody Mono<VisitRequestDTO> visitRequestDTOMono){
+    public Mono<VisitResponseDTO> addVisit(@RequestBody Mono<VisitRequestDTO> visitRequestDTOMono) {
         return visitService.addVisit(visitRequestDTOMono);
     }
 
     /**
      * Replace the information of a visit ( Not visit ID )
      * localhost:8080/visits,{existing visit ID} @PUT
-     * @param visitId The visit we want to modify
+     *
+     * @param visitId             The visit we want to modify
      * @param visitRequestDTOMono The new body of the visit
      * @return The new modified visit
      */
     @PutMapping(value = "/{visitId}", consumes = "application/json", produces = "application/json")
-    public Mono<VisitResponseDTO> updateVisitByVisitId(@PathVariable String visitId, @RequestBody Mono<VisitRequestDTO> visitRequestDTOMono){
+    public Mono<VisitResponseDTO> updateVisitByVisitId(@PathVariable String visitId, @RequestBody Mono<VisitRequestDTO> visitRequestDTOMono) {
         return visitService.updateVisit(visitId, visitRequestDTOMono);
     }
 
     /**
      * Change the status of a visit
      * localhost:8080/visits/{existing visit ID}/status/{new Status} @PUT
+     *
      * @param visitId The visit ID of the visit we want to change the status
-     * @param status The new status DataLayer/Status.toString
+     * @param status  The new status DataLayer/Status.toString
      * @return The modified Visit
      */
     @PutMapping(value = "/{visitId}/status/{status}", produces = "application/json")
-    public Mono<VisitResponseDTO> updateStatusForVisitByVisitId(@PathVariable String visitId, @PathVariable String status){
+    public Mono<VisitResponseDTO> updateStatusForVisitByVisitId(@PathVariable String visitId, @PathVariable String status) {
         return visitService.updateStatusForVisitByVisitId(visitId, status);
     }
 
     /**
      * Delete a visit by its ID
      * localhost:8080/visits/{visitId} @DEL
+     *
      * @param visitId The ID of the visit we want to delete
      * @return The body of the visit we just deleted
      */
@@ -147,22 +155,23 @@ public class VisitController {
     /**
      * Delete all visit whose status DataLayer/Status is Cancelled
      * localhost:8080/visits/{visitId} @DEL
+     *
      * @return Deleted Visits
      */
     @DeleteMapping("/cancelled")
-    public Mono<ResponseEntity<Void>> deleteAllCancelLedVisits(){
+    public Mono<ResponseEntity<Void>> deleteAllCancelLedVisits() {
         return visitService.deleteAllCancelledVisits()
                 .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)));
     }
 
 
     @GetMapping(value = "/reviews")
-    public Flux<ReviewResponseDTO> getAllReviews(){
+    public Flux<ReviewResponseDTO> getAllReviews() {
         return reviewService.GetAllReviews();
     }
 
-    @GetMapping(value="/reviews/{reviewId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<ReviewResponseDTO>> getReviewByReviewId(@PathVariable String reviewId){
+    @GetMapping(value = "/reviews/{reviewId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<ReviewResponseDTO>> getReviewByReviewId(@PathVariable String reviewId) {
         return Mono.just(reviewId)
                 .filter(id -> id.length() == 36)
                 .switchIfEmpty(Mono.error(new InvalidInputException("the provided review id is invalid: " + reviewId)))
@@ -172,23 +181,23 @@ public class VisitController {
     }
 
     @PostMapping(value = "/reviews")
-    public Mono<ResponseEntity<ReviewResponseDTO>> PostReview(@RequestBody Mono<ReviewRequestDTO> reviewRequestDTOMono){
+    public Mono<ResponseEntity<ReviewResponseDTO>> PostReview(@RequestBody Mono<ReviewRequestDTO> reviewRequestDTOMono) {
         return reviewService.AddReview(reviewRequestDTOMono)
-                .map(c->ResponseEntity.status(HttpStatus.CREATED).body(c))
+                .map(c -> ResponseEntity.status(HttpStatus.CREATED).body(c))
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
-    @PutMapping(value="/reviews/{reviewId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<ReviewResponseDTO>> UpdateReview(@RequestBody Mono<ReviewRequestDTO> reviewRequestDTOMono, @PathVariable String reviewId){
+    @PutMapping(value = "/reviews/{reviewId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<ReviewResponseDTO>> UpdateReview(@RequestBody Mono<ReviewRequestDTO> reviewRequestDTOMono, @PathVariable String reviewId) {
         return Mono.just(reviewId)
                 .filter(id -> id.length() == 36)
                 .switchIfEmpty(Mono.error(new InvalidInputException("the provided review id is invalid: " + reviewId)))
-                .flatMap(id-> reviewService.UpdateReview(reviewRequestDTOMono,reviewId))
+                .flatMap(id -> reviewService.UpdateReview(reviewRequestDTOMono, reviewId))
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
-    @DeleteMapping(value="/reviews/{reviewId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @DeleteMapping(value = "/reviews/{reviewId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<ReviewResponseDTO>> DeteleReview(@PathVariable String reviewId) {
         return Mono.just(reviewId)
                 .filter(id -> id.length() == 36)
@@ -198,12 +207,6 @@ public class VisitController {
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
-    @DeleteMapping(value = "/completed/{visitId}")
-    public Mono<ResponseEntity<Void>> deleteCompletedVisitByVisitId(@PathVariable String visitId){
-        return visitService.deleteCompletedVisitByVisitId(visitId)
-                .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)))
-                .defaultIfEmpty(new ResponseEntity<>(HttpStatus.NOT_FOUND));// Return 404 if NotFoundException is thrown
-    }
 
 
     //Emergency
@@ -250,6 +253,26 @@ public class VisitController {
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
+    @PutMapping(value = "/completed/{visitId}/archive", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<VisitResponseDTO>> archiveCompletedVisit(@PathVariable String visitId, @RequestBody Mono<VisitRequestDTO> visitRequestDTO) {
+    return Mono.just(visitId)
+            .switchIfEmpty(Mono.error(new InvalidInputException("the provided visit id is invalid: " + visitId)))
+            .flatMap(id -> visitService.archiveCompletedVisit(id, visitRequestDTO))
+            .map(ResponseEntity::ok)
+            .defaultIfEmpty(ResponseEntity.badRequest().build());
+
+    }
+    @GetMapping(value = "/archived", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<VisitResponseDTO> getAllArchivedVisits() {
+        return visitService.getAllArchivedVisits();
+    }
+
+//    @DeleteMapping(value = "/completed/{visitId}")
+//    public Mono<ResponseEntity<Void>> deleteCompletedVisitByVisitId(@PathVariable String visitId){
+//        return visitService.deleteCompletedVisitByVisitId(visitId)
+//                .then(Mono.just(new ResponseEntity<Void>(HttpStatus.NO_CONTENT)))
+//                .defaultIfEmpty(new ResponseEntity<>(HttpStatus.NOT_FOUND));// Return 404 if NotFoundException is thrown
+//    }
 //    @GetMapping("/pets/{petId}")
 //    public Mono<PetResponseDTO> getPetByIdTest(@PathVariable int petId){
 //       return visitService.testingGetPetDTO(petId);

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -208,16 +208,15 @@ public class VisitController {
     }
 
 
-
     //Emergency
 
     @GetMapping(value = "/emergency")
-    public Flux<EmergencyResponseDTO> getAllEmergency(){
+    public Flux<EmergencyResponseDTO> getAllEmergency() {
         return emergencyService.GetAllEmergencies();
     }
 
-    @GetMapping(value="/emergency/{emergencyId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<EmergencyResponseDTO>> getEmergencyByEmergencyId(@PathVariable String emergencyId){
+    @GetMapping(value = "/emergency/{emergencyId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<EmergencyResponseDTO>> getEmergencyByEmergencyId(@PathVariable String emergencyId) {
         return Mono.just(emergencyId)
                 //.filter(id -> id.length() == 36)
                 //.switchIfEmpty(Mono.error(new InvalidInputException("the provided emergency id is invalid: " + emergencyId)))
@@ -227,27 +226,27 @@ public class VisitController {
     }
 
     @PostMapping(value = "/emergency")
-    public Mono<ResponseEntity<EmergencyResponseDTO>> PostEmergency(@RequestBody Mono<EmergencyRequestDTO> emergencyRequestDTOMono){
+    public Mono<ResponseEntity<EmergencyResponseDTO>> PostEmergency(@RequestBody Mono<EmergencyRequestDTO> emergencyRequestDTOMono) {
         return emergencyService.AddEmergency(emergencyRequestDTOMono)
-                .map(c->ResponseEntity.status(HttpStatus.CREATED).body(c))
+                .map(c -> ResponseEntity.status(HttpStatus.CREATED).body(c))
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
-    @PutMapping(value="/emergency/{emergencyId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<EmergencyResponseDTO>> UpdateEmergency(@RequestBody Mono<EmergencyRequestDTO> emergencyRequestDTOMono, @PathVariable String emergencyId){
+    @PutMapping(value = "/emergency/{emergencyId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<EmergencyResponseDTO>> UpdateEmergency(@RequestBody Mono<EmergencyRequestDTO> emergencyRequestDTOMono, @PathVariable String emergencyId) {
         return Mono.just(emergencyId)
                 //.filter(id -> id.length() == 36)
                 //.switchIfEmpty(Mono.error(new InvalidInputException("the provided emergency id is invalid: " + emergencyId)))
-                .flatMap(id-> emergencyService.UpdateEmergency(emergencyRequestDTOMono,emergencyId))
+                .flatMap(id -> emergencyService.UpdateEmergency(emergencyRequestDTOMono, emergencyId))
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
-    @DeleteMapping(value="/emergency/{emergencyId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @DeleteMapping(value = "/emergency/{emergencyId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<EmergencyResponseDTO>> DeteleEmergency(@PathVariable String emergencyId) {
         return Mono.just(emergencyId)
-               // .filter(id -> id.length() == 36)
-               // .switchIfEmpty(Mono.error(new InvalidInputException("the provided emergency id is invalid: " + emergencyId)))
+                // .filter(id -> id.length() == 36)
+                // .switchIfEmpty(Mono.error(new InvalidInputException("the provided emergency id is invalid: " + emergencyId)))
                 .flatMap(emergencyService::DeleteEmergency)
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
@@ -256,16 +255,17 @@ public class VisitController {
 
     @PutMapping(value = "/completed/{visitId}/archive", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<VisitResponseDTO>> archiveCompletedVisit(@PathVariable String visitId, @RequestBody Mono<VisitRequestDTO> visitRequestDTO) {
-    return Mono.just(visitId)
-            .switchIfEmpty(Mono.error(new InvalidInputException("the provided visit id is invalid: " + visitId)))
-            .flatMap(id -> visitService.archiveCompletedVisit(id, visitRequestDTO))
-            .map(ResponseEntity::ok)
-            .defaultIfEmpty(ResponseEntity.badRequest().build());
+        return Mono.just(visitId)
+                .switchIfEmpty(Mono.error(new InvalidInputException("the provided visit id is invalid: " + visitId)))
+                .flatMap(id -> visitService.archiveCompletedVisit(id, visitRequestDTO))
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
 
     @GetMapping(value = "/archived", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<VisitResponseDTO> getAllArchivedVisits() {
-        return visitService.getAllArchivedVisits();
+        return visitService.getAllArchivedVisits()
+                .switchIfEmpty(Mono.error(new NotFoundException("No archived visits found")));
     }
 
 

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtil.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/Utils/EntityDtoUtil.java
@@ -108,6 +108,7 @@ public class EntityDtoUtil {
                 .build();
     }
 
+
     /**
      * Generate a random UUID and returns it. IS NOT ERROR FREEa
      * @return The UUID as a string

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -691,6 +691,38 @@ class VisitControllerUnitTest {
 
         verify(emergencyService, times(1)).DeleteEmergency(emergencyId);
     }
+//    @Test
+//    void whenDeleteCompletedVisitByValidVisitId_returnNoContent() {
+//        // Arrange
+//        String visitId = UUID.randomUUID().toString();
+//        when(visitService.deleteCompletedVisitByVisitId(visitId))
+//                .thenReturn(Mono.empty());
+//
+//        // Act & Assert
+//        webTestClient
+//                .delete()
+//                .uri("/visits/completed/{visitId}", visitId)
+//                .exchange()
+//                .expectStatus().isNoContent();  // Expecting 204 NO CONTENT status.
+//
+//        verify(visitService, times(1)).deleteCompletedVisitByVisitId(visitId);
+//    }
+
+//    @Test
+//    void whenDeleteCompletedVisitByInvalidVisitId_returnNotFound() {
+//        // Arrange
+//        String invalidVisitId = "fakeId";
+//        when(visitService.deleteCompletedVisitByVisitId(invalidVisitId)).thenReturn(Mono.error(new NotFoundException("No visit was found with visitId: " + invalidVisitId)));
+//
+//        // Act & Assert
+//        webTestClient
+//                .delete()
+//                .uri("/visits/completed/{visitId}", invalidVisitId)
+//                .exchange()
+//                .expectStatus().isNotFound()
+//                .expectBody();
+//        verify(visitService, times(1)).deleteCompletedVisitByVisitId(invalidVisitId);
+//    }
 
     @Test
     void updateVisitStatus_ShouldReturnOK_WhenStatusUpdatedToCancelled() {

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -850,7 +850,3 @@ class VisitControllerUnitTest {
     }
 }
 
-
-
-
-

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -41,19 +41,13 @@ class VisitControllerUnitTest {
     private VisitService visitService;
 
     @MockBean
-
     private ReviewService reviewService;
 
     @MockBean
     private EmergencyService emergencyService;
 
-
-
     @Autowired
     private WebTestClient webTestClient;
-
-
-
 
 
 //    @MockBean
@@ -525,41 +519,6 @@ class VisitControllerUnitTest {
 
     }
 
-
-    @Test
-    void whenDeleteCompletedVisitByValidVisitId_returnNoContent() {
-        // Arrange
-        String visitId = UUID.randomUUID().toString();
-        when(visitService.deleteCompletedVisitByVisitId(visitId))
-                .thenReturn(Mono.empty());
-
-        // Act & Assert
-        webTestClient
-                .delete()
-                .uri("/visits/completed/{visitId}", visitId)
-                .exchange()
-                .expectStatus().isNoContent();  // Expecting 204 NO CONTENT status.
-
-        verify(visitService, times(1)).deleteCompletedVisitByVisitId(visitId);
-    }
-
-    @Test
-    void whenDeleteCompletedVisitByInvalidVisitId_returnNotFound() {
-        // Arrange
-        String invalidVisitId = "fakeId";
-        when(visitService.deleteCompletedVisitByVisitId(invalidVisitId)).thenReturn(Mono.error(new NotFoundException("No visit was found with visitId: " + invalidVisitId)));
-
-        // Act & Assert
-        webTestClient
-                .delete()
-                .uri("/visits/completed/{visitId}", invalidVisitId)
-                .exchange()
-                .expectStatus().isNotFound()
-                .expectBody();
-        verify(visitService, times(1)).deleteCompletedVisitByVisitId(invalidVisitId);
-
-    }
-
     @Test
     public void whenGetAllEmergencies_returnEmergencyResponseDTO() {
         // Fixed date for comparison
@@ -779,5 +738,87 @@ class VisitControllerUnitTest {
         // Verify that the service was called
         verify(visitService, times(1)).patchVisitStatusInVisit(eq(visitId), eq(status));
     }
-    
+
+
+    @Test
+    void whenGetAllArchivedVisits_returnVisitResponseDTO() {
+        VisitResponseDTO visitResponseDTO1 = VisitResponseDTO.builder()
+                .visitId(UUID.randomUUID().toString())
+                .visitDate(LocalDateTime.of(2024, 10, 5, 1, 56)) // No seconds or nanoseconds
+                .description("Visit 1")
+                .petId(UUID.randomUUID().toString())
+                .practitionerId(UUID.randomUUID().toString())
+                .status(Status.ARCHIVED)
+                .build();
+
+        VisitResponseDTO visitResponseDTO2 = VisitResponseDTO.builder()
+                .visitId(UUID.randomUUID().toString())
+                .visitDate(LocalDateTime.of(2024, 10, 5, 1, 56)) // No seconds or nanoseconds
+                .description("Visit 2")
+                .petId(UUID.randomUUID().toString())
+                .practitionerId(UUID.randomUUID().toString())
+                .status(Status.ARCHIVED)
+                .build();
+
+        when(visitService.getAllArchivedVisits()).thenReturn(Flux.just(visitResponseDTO1, visitResponseDTO2));
+
+        webTestClient
+                .get()
+                .uri("/visits/archived")
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM)
+                .expectBodyList(VisitResponseDTO.class)
+                .hasSize(2)
+                .contains(visitResponseDTO1, visitResponseDTO2);
+
+        verify(visitService, times(1)).getAllArchivedVisits();
+    }
+
+    @Test
+    void whenCompletedVisitWithValidVisitId_ArchiveVisit() {
+        String visitId = UUID.randomUUID().toString();
+        VisitRequestDTO visitRequestDTO = buildVisitRequestDTO(UUID.randomUUID().toString());
+        VisitResponseDTO visitResponseDTO = buildVisitResponseDto();
+
+        when(visitService.archiveCompletedVisit(anyString(), any(Mono.class))).thenReturn(Mono.just(visitResponseDTO));
+
+        webTestClient
+                .put()
+                .uri("/visits/completed/" + visitId + "/archive")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(visitRequestDTO), VisitRequestDTO.class)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(VisitResponseDTO.class)
+                .isEqualTo(visitResponseDTO);
+
+        verify(visitService, times(1)).archiveCompletedVisit(anyString(), any(Mono.class));
+    }
+
+    @Test
+    void whenCompletedVisitWithInvalidVisitId_ReturnNotFound() {
+        String invalidVisitId = "invalidId";
+        VisitRequestDTO visitRequestDTO = buildVisitRequestDTO(UUID.randomUUID().toString());
+
+        when(visitService.archiveCompletedVisit(eq(invalidVisitId), any(Mono.class)))
+                .thenReturn(Mono.error(new NotFoundException("No visit was found with visitId: " + invalidVisitId)));
+
+        webTestClient
+                .put()
+                .uri("/visits/completed/" + invalidVisitId + "/archive")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(visitRequestDTO), VisitRequestDTO.class)
+                .exchange()
+                .expectStatus().isNotFound();
+
+        verify(visitService, times(1)).archiveCompletedVisit(eq(invalidVisitId), any(Mono.class));
+    }
 }
+
+
+
+
+

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -363,7 +363,6 @@ class VisitsControllerIntegrationTest {
                 .verifyComplete();
     }
 
-<<<<<<< HEAD
     @Test
     void getAllArchivedVisits_returnsNotFoundWhenNoArchivedVisits() {
         visitRepo.deleteAll().block();  // Clear the repository
@@ -609,88 +608,5 @@ class VisitsControllerIntegrationTest {
                 .verifyComplete();
     }
 
-=======
 
-    
-//    @Test
-//    void deleteCompletedVisitByValidVisitId_Return_NoContent() {
-//        // Arrange: Create and save a COMPLETED visit
-//        String validVisitId = "visitId3";
-//        Visit completedVisit = Visit.builder()
-//                .visitId(validVisitId)
-//                .visitDate(LocalDateTime.now())
-//                .description("Completed visit for deletion test")
-//                .petId("3")
-//                .practitionerId(vet.getVetId())
-//                .status(Status.COMPLETED)
-//                .build();
-//
-//        visitRepo.save(completedVisit).block();
-//
-//        // Verify the visit exists and has a status of COMPLETED
-//        StepVerifier
-//                .create(visitRepo.findByVisitId(validVisitId))
-//                .expectNextMatches(visit -> visit.getStatus().equals(Status.COMPLETED))
-//                .verifyComplete();
-//
-//        // Act: Delete the completed visit
-//        webTestClient
-//                .delete()
-//                .uri("/visits/completed/" + validVisitId)
-//                .exchange()
-//                .expectStatus().isNoContent();
-//
-//        // Assert: Verify the visit is deleted
-//        StepVerifier
-//                .create(visitRepo.findByVisitId(validVisitId))
-//                .expectNextCount(0)
-//                .verifyComplete();
-//    }
-//
-//    @Test
-//    void deleteCompletedVisitByInvalidVisitId_Return_NotFound() {
-//        String visitId = "InvalidId";
-//        webTestClient
-//                .delete()
-//                .uri("/visits/completed/" + visitId)
-//                .exchange()
-//                .expectStatus().isNotFound();
-//
-//        StepVerifier
-//                .create(visitRepo.findByVisitId(visitId))
-//                .expectNextCount(0) //confirms that visit does not exist in the database
-//                .verifyComplete();
-//    }
-//
-//    @Test
-//    void deleteCompletedVisitByValidVisitId_Where_StatusIsNotCompleted_Return_NotFound() {
-//        String validId = "ValidId";
-//        Visit CancelledVisit = Visit.builder()
-//                .visitId(validId)
-//                .visitDate(LocalDateTime.now())
-//                .description("Completed visit for deletion test")
-//                .petId("3")
-//                .practitionerId(vet.getVetId())
-//                .status(Status.CANCELLED)
-//                .build();
-//
-//        visitRepo.save(CancelledVisit).block();
-//
-//        StepVerifier
-//                .create(visitRepo.findByVisitId(validId))
-//                .expectNextMatches(visit -> visit.getStatus() == Status.CANCELLED)
-//                .verifyComplete();
-//
-//        webTestClient
-//                .delete()
-//                .uri("/visits/completed/" + CancelledVisit.getVisitId())
-//                .exchange()
-//                .expectStatus().isNotFound();
-//
-//        StepVerifier
-//                .create(visitRepo.findByVisitId(visit1.getVisitId()))
-//                .expectNextCount(1)
-//                .verifyComplete();
-//    }
->>>>>>> b829ef2f (Fix merge issues)
 }

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -65,7 +66,7 @@ class VisitsControllerIntegrationTest {
     String uuidOwner = UUID.randomUUID().toString();
 
     private final String STATUS = "CONFIRMED";
-    private final int dbSize = 4;
+    private final int dbSize = 6;
 
     Set<SpecialtyDTO> set = new HashSet<>();
     Set<Workday> workdaySet = new HashSet<>();
@@ -92,25 +93,39 @@ class VisitsControllerIntegrationTest {
             .photoId(uuidPhoto)
             .ownerId(uuidOwner)
             .build();
+    VisitResponseDTO archivedVisitResponseDTO = VisitResponseDTO.builder()
+            .visitId("visitId4")
+            .visitDate(LocalDateTime.parse("2022-12-24T13:00:00"))
+            .visitEndDate(LocalDateTime.parse("2022-12-24T14:00:00"))
+            .description("Dog Needs Physio-Therapy")
+            .petId("0e4d8481-b611-4e52-baed-af16caa8bf8a")
+            .petName("Leo")
+            .visitDate(LocalDateTime.parse("2022-12-24T13:00:00"))
+            .practitionerId("69f85d2e-625b-11ee-8c99-0242ac120002")
+            .vetFirstName("Rafael")
+            .vetLastName("Ortega")
+            .vetEmail("ortegarafael@email.com")
+            .vetPhoneNumber("(514)-634-8276 #2387")
+            .status(Status.ARCHIVED)
+            .build();
 
     Visit visit1 = buildVisit(uuidVisit1, "this is a dummy description", vet.getVetId());
     Visit visit2 = buildVisit(uuidVisit2, "this is a dummy description", vet.getVetId());
     Visit cancelledVisit1 = buildCancelledVisit(uuidCancelledVisit1, "this is a dummy description", vet.getVetId());
     Visit cancelledVisit2 = buildCancelledVisit(uuidCancelledVisit2, "this is a dummy description", vet.getVetId());
-
+    Visit archivedVisit1 = buildVisitArchivedVisit("visitId1", "this is a dummy description", vet.getVetId());
+    Visit archivedVisit2 = buildVisitArchivedVisit("visitId2", "this is a dummy description for archive2", vet.getVetId());
     private final VisitResponseDTO visitResponseDTO = buildVisitResponseDto(visit1.getVisitId(), vet.getVetId());
     private final VisitRequestDTO visitRequestDTO = buildVisitRequestDto(vet.getVetId());
 
     @BeforeEach
     void dbSetUp() {
-        Publisher<Visit> visitPublisher = visitRepo.deleteAll()
-                .thenMany(visitRepo.save(visit1)
-                        .thenMany(visitRepo.save(visit2)
-                                .thenMany(visitRepo.save(cancelledVisit1)
-                                        .thenMany(visitRepo.save(cancelledVisit2)))));
-
-        StepVerifier.create(visitPublisher).expectNextCount(1).verifyComplete();
+        visitRepo.deleteAll()
+                .thenMany(Flux.just(visit1, visit2, cancelledVisit1, cancelledVisit2, archivedVisit1, archivedVisit2)
+                        .flatMap(visitRepo::save))
+                .blockLast();  // Wait for all operations to complete
     }
+
 
     private Visit buildVisit(String uuid, String description, String vetId) {
         return Visit.builder()
@@ -131,6 +146,18 @@ class VisitsControllerIntegrationTest {
                 .petId("2")
                 .practitionerId(vetId)
                 .status(Status.CANCELLED)
+                .build();
+    }
+
+    private Visit buildVisitArchivedVisit(String uuid, String description, String vetId) {
+        return Visit.builder()
+                .visitId(uuid)
+                .visitDate(LocalDateTime.parse("2022-12-24T13:00:00"))
+                .visitEndDate(LocalDateTime.parse("2022-12-24T14:00:00"))
+                .description(description)
+                .petId("2")
+                .practitionerId(vetId)
+                .status(Status.ARCHIVED)
                 .build();
     }
 
@@ -337,85 +364,172 @@ class VisitsControllerIntegrationTest {
     }
 
     @Test
-    void deleteCompletedVisitByValidVisitId_Return_NoContent() {
-        // Arrange: Create and save a COMPLETED visit
-        String validVisitId = "visitId3";
-        Visit completedVisit = Visit.builder()
-                .visitId(validVisitId)
-                .visitDate(LocalDateTime.now())
-                .description("Completed visit for deletion test")
-                .petId("3")
-                .practitionerId(vet.getVetId())
-                .status(Status.COMPLETED)
-                .build();
+    void getAllArchivedVisits_returnsNotFoundWhenNoArchivedVisits() {
+        visitRepo.deleteAll().block();  // Clear the repository
 
-        visitRepo.save(completedVisit).block();
-
-        // Verify the visit exists and has a status of COMPLETED
-        StepVerifier
-                .create(visitRepo.findByVisitId(validVisitId))
-                .expectNextMatches(visit -> visit.getStatus().equals(Status.COMPLETED))
-                .verifyComplete();
-
-        // Act: Delete the completed visit
         webTestClient
-                .delete()
-                .uri("/visits/completed/" + validVisitId)
+                .get()
+                .uri("/visits/archived")
+                .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isNoContent();
+                .expectStatus().isNotFound()
+                .expectBody();
 
-        // Assert: Verify the visit is deleted
         StepVerifier
-                .create(visitRepo.findByVisitId(validVisitId))
+                .create(visitRepo.findAllByStatus(Status.ARCHIVED.toString()))
                 .expectNextCount(0)
                 .verifyComplete();
     }
 
     @Test
-    void deleteCompletedVisitByInvalidVisitId_Return_NotFound() {
-        String visitId = "InvalidId";
-        webTestClient
-                .delete()
-                .uri("/visits/completed/" + visitId)
-                .exchange()
-                .expectStatus().isNotFound();
+    void getAllArchivedVisits_returnsAllArchivedVisitsFluxDTO() {
+        VisitResponseDTO completedVisit = VisitResponseDTO.builder()
+                .visitId("visitId4")
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .visitEndDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("Dog Needs Physio-Therapy")
+                .petId("0e4d8481-b611-4e52-baed-af16caa8bf8a")
+                .practitionerId("69f85d2e-625b-11ee-8c99-0242ac120002")
+                .status(Status.ARCHIVED)
+                .build();
 
-        StepVerifier
-                .create(visitRepo.findByVisitId(visitId))
-                .expectNextCount(0) //confirms that visit does not exist in the database
-                .verifyComplete();
+        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(completedVisit));
+
+        webTestClient
+                .get()
+                .uri("/visits/archived")
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .exchange()
+                .expectStatus().isOk()  // Verify status is OK
+                .expectHeader().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM)
+                .expectBodyList(VisitResponseDTO.class)
+                .value(Assertions::assertNotNull);
     }
 
     @Test
-    void deleteCompletedVisitByValidVisitId_Where_StatusIsNotCompleted_Return_NotFound() {
-        String validId = "ValidId";
-        Visit CancelledVisit = Visit.builder()
-                .visitId(validId)
-                .visitDate(LocalDateTime.now())
-                .description("Completed visit for deletion test")
-                .petId("3")
+    void archiveCompletedVisit_archivesVisitAndReturnsVisitResponseDTO() {
+        String validCompletedVisitId = "visitId";
+        Visit completedVisit = Visit.builder()
+                .visitId(validCompletedVisitId)
+                .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .description("Dog Needs Physio-Therapy")
+                .petId("0e4d8481-b611-4e52-baed-af16caa8bf8a")
                 .practitionerId(vet.getVetId())
-                .status(Status.CANCELLED)
+                .status(Status.COMPLETED)
+                .build();
+        visitRepo.save(completedVisit).block();
+
+        Visit archivedVisit = Visit.builder()
+                .visitId(validCompletedVisitId)
+                .visitDate(completedVisit.getVisitDate())
+                .description(completedVisit.getDescription())
+                .petId(completedVisit.getPetId())
+                .practitionerId(completedVisit.getPractitionerId())
+                .status(Status.ARCHIVED)
+                .visitEndDate(completedVisit.getVisitDate().plusHours(1))
                 .build();
 
-        visitRepo.save(CancelledVisit).block();
+        VisitResponseDTO archivedVisitResponseDTO = VisitResponseDTO.builder()
+                .visitId(validCompletedVisitId)
+                .visitDate(archivedVisit.getVisitDate())
+                .visitEndDate(archivedVisit.getVisitEndDate())
+                .description(archivedVisit.getDescription())
+                .petId(archivedVisit.getPetId())
+                .practitionerId(archivedVisit.getPractitionerId())
+                .status(Status.ARCHIVED)
+                .build();
 
-        StepVerifier
-                .create(visitRepo.findByVisitId(validId))
-                .expectNextMatches(visit -> visit.getStatus() == Status.CANCELLED)
-                .verifyComplete();
+        // Step 4: Mock the EntityDtoUtil to return the expected DTO
+        when(entityDtoUtil.toVisitResponseDTO(any(Visit.class))).thenReturn(Mono.just(archivedVisitResponseDTO));
 
         webTestClient
-                .delete()
-                .uri("/visits/completed/" + CancelledVisit.getVisitId())
+                .put()
+                .uri("/visits/completed/" + validCompletedVisitId + "/archive")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(visitRequestDTO)
                 .exchange()
-                .expectStatus().isNotFound();
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(VisitResponseDTO.class)
+                .value(response -> {
+                    assertEquals(validCompletedVisitId, response.getVisitId());
+                    assertEquals("Dog Needs Physio-Therapy", response.getDescription());
+                    assertEquals("0e4d8481-b611-4e52-baed-af16caa8bf8a", response.getPetId());
+                    assertEquals(Status.ARCHIVED, response.getStatus());
+                });
 
-        StepVerifier
-                .create(visitRepo.findByVisitId(visit1.getVisitId()))
-                .expectNextCount(1)
+        StepVerifier.create(visitRepo.findByVisitId(validCompletedVisitId))
+                .assertNext(updatedVisit -> {
+                    assertNotNull(updatedVisit, "Archived visit should exist in the repository");
+                    assertEquals(Status.ARCHIVED, updatedVisit.getStatus(), "Visit status should be ARCHIVED");
+                })
                 .verifyComplete();
     }
+//    @Test
+//    void archiveCompletedVisit_withInvalidVisitId_returnsNotFound() {
+//        String invalidVisitId = "invalidId";
+//        VisitRequestDTO visitRequestDTO = buildVisitRequestDTO(UUID.randomUUID().toString());
+//
+//        when(visitService.archiveCompletedVisit(eq(invalidVisitId), any(Mono.class)))
+//                .thenReturn(Mono.error(new NotFoundException("No visit was found with visitId: " + invalidVisitId)));
+//
+//        webTestClient
+//                .put()
+//                .uri("/visits/completed/" + invalidVisitId + "/archive")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .body(Mono.just(visitRequestDTO), VisitRequestDTO.class)
+//                .exchange()
+//                .expectStatus().isNotFound();
+//
+//        verify(visitService, times(1)).archiveCompletedVisit(eq(invalidVisitId), any(Mono.class));
+//    }
+
+//    @Test
+//    void archiveCompletedVisit_withInvalidVisitId_returnsBadRequest() {
+//        String invalidVisitId = "invalidId";
+//        VisitRequestDTO visitRequestDTO = buildVisitRequestDTO(UUID.randomUUID().toString());
+//
+//        when(visitService.archiveCompletedVisit(eq(invalidVisitId), any(Mono.class)))
+//                .thenReturn(Mono.error(new NotFoundException("No visit was found with visitId: " + invalidVisitId)));
+//
+//        webTestClient
+//                .put()
+//                .uri("/visits/completed/" + invalidVisitId + "/archive")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .body(Mono.just(visitRequestDTO), VisitRequestDTO.class)
+//                .exchange()
+//                .expectStatus().isNotFound();
+//
+//        verify(visitService, times(1)).archiveCompletedVisit(eq(invalidVisitId), any(Mono.class));
+//    }
+//
+//    @Test
+//    void archiveCompletedVisit_withEmptyVisitId_returnsBadRequest() {
+//        VisitRequestDTO visitRequestDTO = buildVisitRequestDTO(UUID.randomUUID().toString());
+//
+//        webTestClient
+//                .put()
+//                .uri("/visits/completed//archive")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .body(Mono.just(visitRequestDTO), VisitRequestDTO.class)
+//                .exchange()
+//                .expectStatus().isBadRequest();
+//
+//        verify(visitService, never()).archiveCompletedVisit(anyString(), any(Mono.class));
+//    }
+
+//                .value((visit) -> {
+//                    assertNotNull(visit);
+//                    assertEquals(1, visit.size());
+//                    assertEquals(visit.get(0).getVisitId(), completedVisit.getVisitId());
+//                    assertEquals(visit.get(0).getPractitionerId(), completedVisit.getPractitionerId());
+//                    assertEquals(visit.get(0).getPetId(), completedVisit.getPetId());
+//                    assertEquals(visit.get(0).getDescription(), completedVisit.getDescription());
+//                    assertEquals(visit.get(0).getVisitDate(), completedVisit.getVisitDate());
+//                    assertEquals(visit.get(0).getVisitEndDate(), completedVisit.getVisitEndDate());
+//                    assertEquals(visit.get(0).getStatus(), Status.ARCHIVED);
+//                });
+
 
     @Test
     void updateVisitStatus_ShouldSucceed_WhenStatusUpdatedToCancelled() {
@@ -467,9 +581,6 @@ class VisitsControllerIntegrationTest {
                 .expectNextMatches(visit -> visit.getStatus() == Status.CANCELLED)
                 .verifyComplete();
     }
-
-
-
 
 
     // Test for the NOT_FOUND scenario (when visit does not exist)

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -19,7 +19,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.mongodb.client.model.Filters.eq;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -109,14 +110,17 @@ class VisitsControllerIntegrationTest {
             .status(Status.ARCHIVED)
             .build();
 
+
     Visit visit1 = buildVisit(uuidVisit1, "this is a dummy description", vet.getVetId());
     Visit visit2 = buildVisit(uuidVisit2, "this is a dummy description", vet.getVetId());
     Visit cancelledVisit1 = buildCancelledVisit(uuidCancelledVisit1, "this is a dummy description", vet.getVetId());
     Visit cancelledVisit2 = buildCancelledVisit(uuidCancelledVisit2, "this is a dummy description", vet.getVetId());
     Visit archivedVisit1 = buildVisitArchivedVisit("visitId1", "this is a dummy description", vet.getVetId());
     Visit archivedVisit2 = buildVisitArchivedVisit("visitId2", "this is a dummy description for archive2", vet.getVetId());
+
     private final VisitResponseDTO visitResponseDTO = buildVisitResponseDto(visit1.getVisitId(), vet.getVetId());
     private final VisitRequestDTO visitRequestDTO = buildVisitRequestDto(vet.getVetId());
+
 
     @BeforeEach
     void dbSetUp() {
@@ -465,6 +469,7 @@ class VisitsControllerIntegrationTest {
                 })
                 .verifyComplete();
     }
+
 //    @Test
 //    void archiveCompletedVisit_withInvalidVisitId_returnsNotFound() {
 //        String invalidVisitId = "invalidId";
@@ -529,7 +534,6 @@ class VisitsControllerIntegrationTest {
 //                    assertEquals(visit.get(0).getVisitEndDate(), completedVisit.getVisitEndDate());
 //                    assertEquals(visit.get(0).getStatus(), Status.ARCHIVED);
 //                });
-
 
     @Test
     void updateVisitStatus_ShouldSucceed_WhenStatusUpdatedToCancelled() {
@@ -610,3 +614,4 @@ class VisitsControllerIntegrationTest {
 
 
 }
+

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitsControllerIntegrationTest.java
@@ -363,6 +363,7 @@ class VisitsControllerIntegrationTest {
                 .verifyComplete();
     }
 
+<<<<<<< HEAD
     @Test
     void getAllArchivedVisits_returnsNotFoundWhenNoArchivedVisits() {
         visitRepo.deleteAll().block();  // Clear the repository
@@ -608,4 +609,88 @@ class VisitsControllerIntegrationTest {
                 .verifyComplete();
     }
 
+=======
+
+    
+//    @Test
+//    void deleteCompletedVisitByValidVisitId_Return_NoContent() {
+//        // Arrange: Create and save a COMPLETED visit
+//        String validVisitId = "visitId3";
+//        Visit completedVisit = Visit.builder()
+//                .visitId(validVisitId)
+//                .visitDate(LocalDateTime.now())
+//                .description("Completed visit for deletion test")
+//                .petId("3")
+//                .practitionerId(vet.getVetId())
+//                .status(Status.COMPLETED)
+//                .build();
+//
+//        visitRepo.save(completedVisit).block();
+//
+//        // Verify the visit exists and has a status of COMPLETED
+//        StepVerifier
+//                .create(visitRepo.findByVisitId(validVisitId))
+//                .expectNextMatches(visit -> visit.getStatus().equals(Status.COMPLETED))
+//                .verifyComplete();
+//
+//        // Act: Delete the completed visit
+//        webTestClient
+//                .delete()
+//                .uri("/visits/completed/" + validVisitId)
+//                .exchange()
+//                .expectStatus().isNoContent();
+//
+//        // Assert: Verify the visit is deleted
+//        StepVerifier
+//                .create(visitRepo.findByVisitId(validVisitId))
+//                .expectNextCount(0)
+//                .verifyComplete();
+//    }
+//
+//    @Test
+//    void deleteCompletedVisitByInvalidVisitId_Return_NotFound() {
+//        String visitId = "InvalidId";
+//        webTestClient
+//                .delete()
+//                .uri("/visits/completed/" + visitId)
+//                .exchange()
+//                .expectStatus().isNotFound();
+//
+//        StepVerifier
+//                .create(visitRepo.findByVisitId(visitId))
+//                .expectNextCount(0) //confirms that visit does not exist in the database
+//                .verifyComplete();
+//    }
+//
+//    @Test
+//    void deleteCompletedVisitByValidVisitId_Where_StatusIsNotCompleted_Return_NotFound() {
+//        String validId = "ValidId";
+//        Visit CancelledVisit = Visit.builder()
+//                .visitId(validId)
+//                .visitDate(LocalDateTime.now())
+//                .description("Completed visit for deletion test")
+//                .petId("3")
+//                .practitionerId(vet.getVetId())
+//                .status(Status.CANCELLED)
+//                .build();
+//
+//        visitRepo.save(CancelledVisit).block();
+//
+//        StepVerifier
+//                .create(visitRepo.findByVisitId(validId))
+//                .expectNextMatches(visit -> visit.getStatus() == Status.CANCELLED)
+//                .verifyComplete();
+//
+//        webTestClient
+//                .delete()
+//                .uri("/visits/completed/" + CancelledVisit.getVisitId())
+//                .exchange()
+//                .expectStatus().isNotFound();
+//
+//        StepVerifier
+//                .create(visitRepo.findByVisitId(visit1.getVisitId()))
+//                .expectNextCount(1)
+//                .verifyComplete();
+//    }
+>>>>>>> b829ef2f (Fix merge issues)
 }


### PR DESCRIPTION
**JIRA:** [Jira link](https://champlainsaintlambert.atlassian.net/browse/CPC-1173)

## Context:

The admin will be able to archive COMPLETED visits if the status is set to completed.
## Does this PR change the .vscode folder in petclinic-frontend?:
No.

## Changes

- Removed previous implementation of "Delete Completed Visit" and replaced with "Archive Completed Visit"
- Added a new 'Status' called 'ARCHIVED'
- Archived Button Pops up when Status is set to "COMPLETED"
- Upon archiving a completed visit, a warning pops up and waits for admin confirmation
- getVisitsForStatus switch case has been fixed by adding 'Break;'
- Made tables collapsible for a cleaner UI



## Before and After UI

BEFORE:
![image](https://github.com/user-attachments/assets/d64a84b3-2764-46e0-9ca2-0aa3082c5c3e)

------

AFTER:
<img width="947" alt="image" src="https://github.com/user-attachments/assets/c5123679-a423-4192-a0e1-15b25f80d750">
Collapsible table:
<img width="958" alt="image" src="https://github.com/user-attachments/assets/4c1c87c7-71db-45f6-b8c7-57e50c661478">


## Dev notes
The previous implementation was delete completed visits, however it was recently changed to archive completed visits in order to still maintain the visit information (hence some methods have been removed).
## Linked pull requests
[Pull request link](https://github.com/cgerard321/champlain_petclinic/pull/805)