### PR TITLE
Feat/vist cpc 1282 add a way to filter visits by visit description

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClient.java
@@ -56,10 +56,15 @@ public class VisitsServiceClient {
                 .build();
     }
 
-    public Flux<VisitResponseDTO> getAllVisits() {
+    public Flux<VisitResponseDTO> getAllVisits(String description){
         return this.webClient
                 .get()
-                .uri(reviewUrl)
+                .uri(uriBuilder -> {
+                    if (description != null) {
+                        uriBuilder.queryParam("description", description).build();
+                    }
+                    return uriBuilder.build();
+                })
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, error -> Mono.error(new IllegalArgumentException("Something went wrong and we got a 400 error")))
                 .onStatus(HttpStatusCode::is5xxServerError, error -> Mono.error(new IllegalArgumentException("Something went wrong and we got a 500 error")))

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -334,8 +334,8 @@ public class BFFApiGatewayController {
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
     @GetMapping(value = "visits", produces= MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<VisitResponseDTO> getAllVisits() {
-        return visitsServiceClient.getAllVisits();
+    public Flux<VisitResponseDTO> getAllVisits(@RequestParam(required = false) String description){
+        return visitsServiceClient.getAllVisits(description);
     }
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN,Roles.VET,Roles.OWNER})

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
@@ -39,8 +39,8 @@ public class VisitController {
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
     @GetMapping(value = "", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<Flux<VisitResponseDTO>> getAllVisits() {
-        return ResponseEntity.ok().body(visitsServiceClient.getAllVisits());
+    public ResponseEntity<Flux<VisitResponseDTO>> getAllVisits(@RequestParam(required = false) String description){
+        return ResponseEntity.ok().body(visitsServiceClient.getAllVisits(description));
     }
     @SecuredEndpoint(allowedRoles = {Roles.ALL})
     @GetMapping(value = "/{visitId}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VisitsServiceClientIntegrationTest.java
@@ -107,7 +107,7 @@ class VisitsServiceClientIntegrationTest {
         server.enqueue(new MockResponse().setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .setBody(objectMapper.writeValueAsString(Arrays.asList(visitResponseDTO, visitResponseDTO2))).addHeader("Content-Type", "application/json"));
 
-        Flux<VisitResponseDTO> visitResponseDTOFlux = visitsServiceClient.getAllVisits();
+        Flux<VisitResponseDTO> visitResponseDTOFlux = visitsServiceClient.getAllVisits(visitResponseDTO.getDescription());
         StepVerifier.create(visitResponseDTOFlux)
                 .expectNext(visitResponseDTO)
                 .expectNext(visitResponseDTO2)
@@ -115,16 +115,18 @@ class VisitsServiceClientIntegrationTest {
     }
     @Test
     void getAllVisits_400Error()throws IllegalArgumentException{
+        String description = "test"; // Add a description here
         server.enqueue(new MockResponse().setResponseCode(400).addHeader("Content-Type", "application/json"));
-        Flux<VisitResponseDTO> visitResponseDTOFlux = visitsServiceClient.getAllVisits();
+        Flux<VisitResponseDTO> visitResponseDTOFlux = visitsServiceClient.getAllVisits(description); // Pass the description to the method
         StepVerifier.create(visitResponseDTOFlux)
-            .expectErrorMatches(throwable -> throwable instanceof IllegalArgumentException && Objects.equals(throwable.getMessage(), "Something went wrong and we got a 400 error"))
-            .verify();
+                .expectErrorMatches(throwable -> throwable instanceof IllegalArgumentException && Objects.equals(throwable.getMessage(), "Something went wrong and we got a 400 error"))
+                .verify();
     }
     @Test
     void getAllVisits_500Error()throws IllegalArgumentException{
+        String description = "test"; // Add a description here
         server.enqueue(new MockResponse().setResponseCode(500).addHeader("Content-Type", "application/json"));
-        Flux<VisitResponseDTO> visitResponseDTOFlux = visitsServiceClient.getAllVisits();
+        Flux<VisitResponseDTO> visitResponseDTOFlux = visitsServiceClient.getAllVisits(description);
         StepVerifier.create(visitResponseDTOFlux)
             .expectErrorMatches(throwable -> throwable instanceof IllegalArgumentException && Objects.equals(throwable.getMessage(), "Something went wrong and we got a 500 error"))
             .verify();

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -2422,6 +2422,7 @@ class ApiGatewayControllerTest {
     }
     @Test
     void shouldGetAllVisits() {
+        // Sample VisitResponseDTO objects
         VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder()
                 .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
                 .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
@@ -2437,6 +2438,7 @@ class ApiGatewayControllerTest {
                 .status(Status.UPCOMING)
                 .visitEndDate(LocalDateTime.parse("2024-11-25 14:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .build();
+
         VisitResponseDTO visitResponseDTO2 = VisitResponseDTO.builder()
                 .visitId("73b5c112-5703-4fb7-b7bc-ac8186811ae1")
                 .visitDate(LocalDateTime.parse("2024-11-25 13:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
@@ -2452,18 +2454,29 @@ class ApiGatewayControllerTest {
                 .status(Status.UPCOMING)
                 .visitEndDate(LocalDateTime.parse("2024-11-25 14:45", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .build();
-        when(visitsServiceClient.getAllVisits()).thenReturn(Flux.just(visitResponseDTO,visitResponseDTO2));
 
+        // Mocking the service call
+        String description = "this is a dummy description";
+        when(visitsServiceClient.getAllVisits(description)).thenReturn(Flux.just(visitResponseDTO, visitResponseDTO2));
+
+        // Performing the request and asserting results
         client.get()
-                .uri("/api/gateway/visits")
+                .uri(uriBuilder -> uriBuilder
+                        .path("/api/gateway/visits")
+                        .queryParam("description", description)
+                        .build())
                 .accept(MediaType.TEXT_EVENT_STREAM)
                 .exchange()
                 .expectStatus().isOk()
-                .expectHeader().contentType(MediaType.TEXT_EVENT_STREAM_VALUE+";charset=UTF-8")
+                .expectHeader().contentType(MediaType.TEXT_EVENT_STREAM_VALUE + ";charset=UTF-8")
                 .expectBodyList(VisitResponseDTO.class)
-                .value((list)->assertEquals(list.size(),2));
-        Mockito.verify(visitsServiceClient,times(1)).getAllVisits();
+                .value(list -> assertEquals(2, list.size()));  // Assert list size is 2
+
+        // Verifying the method call with the right argument
+        Mockito.verify(visitsServiceClient, times(1)).getAllVisits(description);
     }
+
+
     @Test
     void getVisitsByOwnerId_shouldReturnOk(){
         //arrange

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
@@ -155,19 +155,23 @@ public class VisitControllerUnitTest {
     @Test
     void getAllVisits_whenAllPropertiesExist_thenReturnFluxResponseDTO() {
         // Arrange
-        when(visitsServiceClient.getAllVisits())
+        String description = "test"; // Add a description here
+        when(visitsServiceClient.getAllVisits(description))
                 .thenReturn(Flux.just(visitResponseDTO1));
 
         // Act
         webTestClient.get()
-                .uri(BASE_VISIT_URL)
+                .uri(uriBuilder -> uriBuilder.path(BASE_VISIT_URL)
+                        .queryParam("description", description)
+                        .build())
                 .accept(MediaType.TEXT_EVENT_STREAM)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBodyList(VisitResponseDTO.class)
                 .hasSize(1);
+
         // Assert
-        verify(visitsServiceClient, times(1)).getAllVisits();
+        verify(visitsServiceClient, times(1)).getAllVisits(description);
     }
 
     @Test
@@ -305,9 +309,10 @@ public class VisitControllerUnitTest {
     }
 
     @Test
-    void getAllVisits_whenNoVisitsExist_thenReturnEmptyFlux() {
+    void getAllVisits_whenNoVisitsExist_thenReturnEmptyFlux(){
+        String description = null;
         // Arrange
-        when(visitsServiceClient.getAllVisits())
+        when(visitsServiceClient.getAllVisits(description))
                 .thenReturn(Flux.empty()); // no visits should not throw an error
         // Act
         webTestClient.get()
@@ -318,7 +323,7 @@ public class VisitControllerUnitTest {
                 .expectBodyList(VisitResponseDTO.class)
                 .hasSize(0);
         // Assert
-        verify(visitsServiceClient, times(1)).getAllVisits();
+        verify(visitsServiceClient, times(1)).getAllVisits(description);
     }
 
     @Test

--- a/petclinic-frontend/.vscode/settings.json
+++ b/petclinic-frontend/.vscode/settings.json
@@ -1,27 +1,26 @@
 {
-    "editor.formatOnSave": true,
-    "prettier.configPath": "./.prettierrc.json",
-    "window.zoomLevel": -1,
-    "files.autoSave": "afterDelay",
-    "workbench.iconTheme": "material-icon-theme",
-    "[typescriptreact]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "typescript.updateImportsOnFileMove.enabled": "always",
-    "files.autoSaveWorkspaceFilesOnly": true,
-    "github.copilot.preferredAccount": "nimar",
-    "notebook.formatOnSave.enabled": true,
-    "[typescript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "editor.codeActionsOnSave": {
-          "source.fixAll.eslint": "explicit"
-        },
-        "eslint.validate": [
-          "javascript",
-          "javascriptreact",
-          "typescript",
-          "typescriptreact"
-        ]
-      
+  "editor.formatOnSave": true,
+  "prettier.configPath": "./.prettierrc.json",
+  "window.zoomLevel": -1,
+  "files.autoSave": "afterDelay",
+  "workbench.iconTheme": "material-icon-theme",
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "typescript.updateImportsOnFileMove.enabled": "always",
+  "files.autoSaveWorkspaceFilesOnly": true,
+  "github.copilot.preferredAccount": "nimar",
+  "notebook.formatOnSave.enabled": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ]
 }

--- a/petclinic-frontend/package-lock.json
+++ b/petclinic-frontend/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@originjs/vite-plugin-federation": "1.3.5",
         "@types/node": "20.12.12",
-        "@types/react": "^18.3.3",
+        "@types/react": "^18.3.11",
         "@types/react-bootstrap": "^0.32.37",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "7.1.0",
@@ -1223,9 +1223,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "version": "18.3.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+      "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",

--- a/petclinic-frontend/package.json
+++ b/petclinic-frontend/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@originjs/vite-plugin-federation": "1.3.5",
     "@types/node": "20.12.12",
-    "@types/react": "^18.3.3",
+    "@types/react": "^18.3.11",
     "@types/react-bootstrap": "^0.32.37",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "7.1.0",

--- a/petclinic-frontend/src/features/visits/VisitListTable.tsx
+++ b/petclinic-frontend/src/features/visits/VisitListTable.tsx
@@ -71,7 +71,6 @@ export default function VisitListTable(): JSX.Element {
         });
         setVisitsAll(oldVisits => {
           if (!oldVisits.some(visit => visit.visitId === newVisit.visitId)) {
-            console.log('allVisits:', visitsAll);
             return [...oldVisits, newVisit];
           }
           return oldVisits;
@@ -182,8 +181,6 @@ export default function VisitListTable(): JSX.Element {
           visit.description.toLowerCase().includes(searchTerm.toLowerCase())
         )
       );
-      console.log('visitsAll', visitsAll);
-      console.log('visitsList', visitsList);
     } else {
       return;
     }

--- a/petclinic-frontend/src/features/visits/VisitListTable.tsx
+++ b/petclinic-frontend/src/features/visits/VisitListTable.tsx
@@ -10,6 +10,8 @@ import './Emergency.css';
 
 export default function VisitListTable(): JSX.Element {
   const [visitsList, setVisitsList] = useState<Visit[]>([]);
+  const [visitsAll, setVisitsAll] = useState<Visit[]>([]);
+  const [searchTerm, setSearchTerm] = useState<string>(''); // Search term state
   const [emergencyList, setEmergencyList] = useState<EmergencyResponseDTO[]>(
     []
   );
@@ -61,6 +63,19 @@ export default function VisitListTable(): JSX.Element {
             }
           });
         }
+        setVisitsList(oldVisits => {
+          if (!oldVisits.some(visit => visit.visitId === newVisit.visitId)) {
+            return [...oldVisits, newVisit];
+          }
+          return oldVisits;
+        });
+        setVisitsAll(oldVisits => {
+          if (!oldVisits.some(visit => visit.visitId === newVisit.visitId)) {
+            console.log('allVisits:', visitsAll);
+            return [...oldVisits, newVisit];
+          }
+          return oldVisits;
+        });
       } catch (error) {
         console.error('Error parsing SSE data:', error);
       }
@@ -150,6 +165,31 @@ export default function VisitListTable(): JSX.Element {
     };
   }, []);
 
+  useEffect(() => {
+    if (searchTerm) {
+      //async (): Promise<void> => {
+      //  try {
+      //    console.log('searchTerm:', searchTerm);
+      //   const list = await getAllVisits(searchTerm);
+      //  setVisitsList(list);
+      //   console.log('visitsList:', visitsList);
+      //  } catch (error) {
+      //    console.error('Error fetching visits:', error);
+      // }
+      //};
+      setVisitsList(
+        visitsAll.filter(visit =>
+          visit.description.toLowerCase().includes(searchTerm.toLowerCase())
+        )
+      );
+      console.log('visitsAll', visitsAll);
+      console.log('visitsList', visitsList);
+    } else {
+      return;
+    }
+  }, [searchTerm, visitsAll, visitsList]);
+
+  // Filter visits based on status
   const confirmedVisits = visitsList.filter(
     visit => visit.status === 'CONFIRMED'
   );
@@ -444,6 +484,16 @@ export default function VisitListTable(): JSX.Element {
         >
           Make a Visit
         </button>
+
+        {/* Search bar for filtering visits */}
+        <div className="search-bar">
+          <input
+            type="text"
+            placeholder="Search by visit description"
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.target.value)} // Update the search term when input changes
+          />
+        </div>
       </div>
 
       {/* Emergency Table below buttons, but above visit tables */}

--- a/petclinic-frontend/src/features/visits/api/getAllVisits.ts
+++ b/petclinic-frontend/src/features/visits/api/getAllVisits.ts
@@ -1,0 +1,23 @@
+import axiosInstance from '@/shared/api/axiosInstance.ts';
+import { Visit } from '@/features/visits/models/Visit.ts';
+
+export async function getAllVisits(searchTerm: string): Promise<Visit[]> {
+  const params: Record<string, string> = {};
+  if (searchTerm !== '') params.searchTerm = searchTerm;
+  const res = await axiosInstance.get('/visits', {
+    responseType: 'stream',
+    params,
+  });
+
+  return res.data
+    .split('data:')
+    .map((dataChunk: string) => {
+      try {
+        if (dataChunk == '') return null;
+        return JSON.parse(dataChunk);
+      } catch (err) {
+        console.error('Could not parse JSON: ' + err);
+      }
+    })
+    .filter((data?: JSON) => data !== null);
+}

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitService.java
@@ -10,8 +10,7 @@ import reactor.core.publisher.Mono;
  * Simple interface for all the request controller. Implemented in VisitServiceImpl
  */
 public interface VisitService {
-    Flux<VisitResponseDTO> getAllVisits();
-
+    Flux<VisitResponseDTO> getAllVisits(String description);
     Flux<VisitResponseDTO> getVisitsForPet(String petId);
 
     Flux<VisitResponseDTO> getVisitsForStatus(String statusString);

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImpl.java
@@ -1,6 +1,7 @@
 package com.petclinic.visits.visitsservicenew.BusinessLayer;
 
 import com.petclinic.visits.visitsservicenew.DataLayer.Status;
+import com.petclinic.visits.visitsservicenew.DataLayer.Visit;
 import com.petclinic.visits.visitsservicenew.DataLayer.VisitRepo;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.Auth.AuthServiceClient;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.Auth.UserDetails;
@@ -56,8 +57,17 @@ public class VisitServiceImpl implements VisitService {
      * @return all Visits as Flux
      */
     @Override
-    public Flux<VisitResponseDTO> getAllVisits() {
-        return repo.findAll().flatMap(entityDtoUtil::toVisitResponseDTO);
+    public Flux<VisitResponseDTO> getAllVisits(String descritpion) {
+        Flux<Visit> visits;
+
+        if(descritpion != null && !descritpion.isBlank()){
+            visits = repo.findVisitsByDescriptionContainingIgnoreCase(descritpion);
+        }
+        else {
+            visits = repo.findAll();
+        }
+        return visits.flatMap(entityDtoUtil::toVisitResponseDTO);
+        //return repo.findAll().flatMap(entityDtoUtil::toVisitResponseDTO);
     }
 
     /**

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/VisitRepo.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/VisitRepo.java
@@ -29,4 +29,7 @@ public interface VisitRepo extends ReactiveMongoRepository<Visit, String> {
 
     // In your VisitRepo interface
     Flux<Visit> findByVisitDateAndPractitionerId(LocalDateTime visitDate, String practitionerId);
+
+    Flux<Visit> findVisitsByDescriptionContainingIgnoreCase(String Description);
+
 }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitController.java
@@ -39,9 +39,10 @@ public class VisitController {
      *
      * @return All visits
      */
-    @GetMapping(value = "", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<VisitResponseDTO> getAllVisits() {
-        return visitService.getAllVisits();
+    @GetMapping(value="", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<VisitResponseDTO> getAllVisits(@RequestParam(required = false) String description){
+
+        return visitService.getAllVisits(description);
     }
 
     /**

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/BusinessLayer/VisitServiceImplTest.java
@@ -98,21 +98,41 @@ class VisitServiceImplTest {
 
     @Test
     void getAllVisits() {
-        // Mock the behavior of the repository to return a Flux of visits
-        when(visitRepo.findAll()).thenReturn(Flux.just(visit1));
+        // Mock the behavior of the repository for the case when a description is provided
+        Visit visit1 = new Visit(); // replace with your actual Visit object
+        String description = "checkup";
 
-        // Mock the behavior of entityDtoUtil to map visits to visitResponseDTO
-        when(entityDtoUtil.toVisitResponseDTO(any())).thenReturn(Mono.just(visitResponseDTO));
+        when(visitRepo.findVisitsByDescriptionContainingIgnoreCase(description)).thenReturn(Flux.just(visit1));
 
-        // Execute the method under test
-        Flux<VisitResponseDTO> result = visitService.getAllVisits();
+        // Mock the behavior of the repository for the case when no description is provided
+        Visit visit2 = new Visit(); // replace with another Visit object
+        when(visitRepo.findAll()).thenReturn(Flux.just(visit2));
 
-        // Verify the results using StepVerifier
-        StepVerifier.create(result)
-                .expectNext(visitResponseDTO) // Expect the mapped VisitResponseDTO
+        // Mock the behavior of entityDtoUtil to map visits to VisitResponseDTO
+        VisitResponseDTO visitResponseDTO1 = new VisitResponseDTO(); // replace with your actual VisitResponseDTO object
+        VisitResponseDTO visitResponseDTO2 = new VisitResponseDTO(); // another VisitResponseDTO object
+        when(entityDtoUtil.toVisitResponseDTO(visit1)).thenReturn(Mono.just(visitResponseDTO1));
+        when(entityDtoUtil.toVisitResponseDTO(visit2)).thenReturn(Mono.just(visitResponseDTO2));
+
+        // Test case when description is provided
+        Flux<VisitResponseDTO> resultWithDescription = visitService.getAllVisits(description);
+
+        // Verify the results using StepVerifier for the case when description is provided
+        StepVerifier.create(resultWithDescription)
+                .expectNext(visitResponseDTO1) // Expect the mapped VisitResponseDTO for the filtered visit
+                .expectComplete()
+                .verify();
+
+        // Test case when no description is provided
+        Flux<VisitResponseDTO> resultWithoutDescription = visitService.getAllVisits(null);
+
+        // Verify the results using StepVerifier for the case when no description is provided
+        StepVerifier.create(resultWithoutDescription)
+                .expectNext(visitResponseDTO2) // Expect the mapped VisitResponseDTO for all visits
                 .expectComplete()
                 .verify();
     }
+
 
     @Test
     void getVisitByVisitId() {

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/DataLayer/VisitRepoTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/DataLayer/VisitRepoTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static reactor.core.publisher.Mono.when;
 
 @DataMongoTest
 class VisitRepoTest {
@@ -86,7 +88,19 @@ class VisitRepoTest {
                 }).then(this::deleteVisitByVisitId).verifyComplete();
     }
 
+    @Test
+    void findVisitsByDescriptionContainingIgnoreCase() {
+       StepVerifier.create(visitRepo.findVisitsByDescriptionContainingIgnoreCase(visit1.getDescription().toString()))
+               .expectNextCount(2)
+               .verifyComplete();
+    }
 
+    //@Test
+    //void findVisitsByStatus(){
+    //    StepVerifier.create(visitRepo.findAllByStatus(visit1.getStatus().toString()))
+    //            .expectNextCount(2)
+    //            .verifyComplete();
+    //}
 
 
     private Visit buildVisit(String uuid,String description, String vetId){

--- a/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
+++ b/visits-service-new/src/test/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitControllerUnitTest.java
@@ -6,6 +6,7 @@ import com.petclinic.visits.visitsservicenew.BusinessLayer.Review.ReviewService;
 import com.petclinic.visits.visitsservicenew.BusinessLayer.VisitService;
 import com.petclinic.visits.visitsservicenew.DataLayer.Emergency.UrgencyLevel;
 import com.petclinic.visits.visitsservicenew.DataLayer.Status;
+import com.petclinic.visits.visitsservicenew.DataLayer.Visit;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.SpecialtyDTO;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetDTO;
 import com.petclinic.visits.visitsservicenew.DomainClientLayer.Workday;
@@ -101,8 +102,11 @@ class VisitControllerUnitTest {
 
     //private final LocalDateTime visitDate = visitResponseDTO.getVisitDate().withSecond(0);
     @Test
-    void getAllVisits() {
-        when(visitService.getAllVisits()).thenReturn(Flux.just(visitResponseDTO, visitResponseDTO));
+    void getAllVisits(){
+        Visit visit1 = new Visit(); // replace with your actual Visit object
+
+
+        when(visitService.getAllVisits(visit1.getDescription())).thenReturn(Flux.just(visitResponseDTO, visitResponseDTO));
 
         webTestClient.get()
                 .uri("/visits")
@@ -112,7 +116,7 @@ class VisitControllerUnitTest {
                 .expectHeader().contentType(MediaType.TEXT_EVENT_STREAM + ";charset=UTF-8")
                 .returnResult(VisitResponseDTO.class);
 
-        verify(visitService, times(1)).getAllVisits();
+        verify(visitService, times(1)).getAllVisits(visit1.getDescription());
     }
 
     @Test


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1282?atlOrigin=eyJpIjoiMTkzMTE0NDU5MzAzNDE2YjgxY2QwMzk2M2RiYTAyNzEiLCJwIjoiaiJ9 
## Context:
allows for a better way to find a desired visit by searching up its description
## Does this PR change the .vscode folder in petclinic-frontend?:
If the PR changes the .vscode folder, explain why in detail because it should not. 
Be sure to include cgerard321 as a reviewer.

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
I have changed the getAll request to accept a parameter of type String description and have added a way to filter through visits with a search bar
This can be bullet point or sentence format.
## Before and After UI (Required for UI-impacting PRs)
![Screenshot 2024-09-26 153806](https://github.com/user-attachments/assets/37df44bf-6097-4193-bb2d-9c96c63e2376)
![Screenshot (28)](https://github.com/user-attachments/assets/50be12fd-249b-4268-a399-0438aea960dc)

## Dev notes (Optional)
Specific technical changes that should be noted
## Linked pull requests (Optional)
Pull request links