### PR TITLE
bug(BILL-CPC-1299): Fix admin delete bill alert message bugs

### DIFF
--- a/petclinic-frontend/src/features/bills/AdminBillsListTable.tsx
+++ b/petclinic-frontend/src/features/bills/AdminBillsListTable.tsx
@@ -132,9 +132,8 @@ export default function AdminBillsListTable(): JSX.Element {
     try {
       const response = await deleteBill(billToDelete);
       if (response.status === 200 || response.status === 204) {
-        window.alert('Bill ${billId} has been deleted successfully');
+        window.alert(`Bill ${billId} has been deleted successfully`);
         getBillsList(currentPage, 10);
-        window.alert('Cannot delete this bill. It may be unpaid or overdue.');
       }
     } catch (error) {
       window.alert('Cannot delete this bill. It may be unpaid or overdue.');


### PR DESCRIPTION
**JIRA:**
https://champlainsaintlambert.atlassian.net/browse/CPC-1299?atlOrigin=eyJpIjoiNTI0ZmU4MjVkZDIxNDM5ZmIyMDM4M2RhYWMxMDUyYWYiLCJwIjoiaiJ9
## Context:
Fixed the bugs where the "Cannot delete bill" alert message would still appear after deleting a bill as well as the interpolation of billId in the successful alert message.
## Does this PR change the .vscode folder in petclinic-frontend?:
No.

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes

- Removed redundant "Cannot delete bill" message in the handleDelete of AdminBillsListTable.tsx
- Fixed interpolation of billId in alert message of handleDelete in AdminBillsListTable.tsx (replaced single quotes with backticks ``)

