### PR TITLE
feat(VETS-CPC-1296): delete specialties by vet id and specialty id

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -596,6 +596,25 @@ public class VetsServiceClient {
                 .bodyToMono(VetResponseDTO.class);
     }
 
+    public Mono<Void> deleteSpecialtiesByVetId(String vetId, String specialtyId) {
+        return webClientBuilder
+                .build()
+                .delete()
+                .uri(vetsServiceUrl + "/" + vetId + "/specialties/" + specialtyId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, error -> {
+                    HttpStatusCode statusCode = error.statusCode();
+                    if (statusCode.equals(HttpStatus.NOT_FOUND)) {
+                        return Mono.error(new ExistingVetNotFoundException("Vet not found: " + vetId, HttpStatus.NOT_FOUND));
+                    }
+                    return Mono.error(new IllegalArgumentException("Something went wrong with the client"));
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, error ->
+                        Mono.error(new IllegalArgumentException("Something went wrong with the server"))
+                )
+                .bodyToMono(Void.class);
+    }
+
     public Flux<Album> getAllAlbumsByVetId(String vetId) {
         return webClientBuilder.build()
                 .get()

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -123,6 +123,15 @@ public class VetController {
             @RequestBody Mono<SpecialtyDTO> specialties) {
         return vetsServiceClient.addSpecialtiesByVetId(vetId, specialties);
     }
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN,Roles.VET})
+    @DeleteMapping(value = "{vetId}/specialties/{specialtyId}")
+    public Mono<ResponseEntity<Void>> deleteSpecialtiesByVetId(
+            @PathVariable String vetId,
+            @PathVariable String specialtyId) {
+        return vetsServiceClient.deleteSpecialtiesByVetId(vetId, specialtyId)
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
 
     @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS})
     @GetMapping(value = "{vetId}/albums", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClientIntegrationTest.java
@@ -2029,6 +2029,48 @@ class VetsServiceClientIntegrationTest {
         assertEquals("GET", recordedRequest.getMethod());
     }
 
+    @Test
+    void shouldDeleteSpecialty_whenSpecialtyIdIsValid() throws Exception {
+        String vetId = "deb1950c-3c56-45dc-874b-89e352695eb7";
+        String specialtyId = "794ac37f-1e07-43c2-93bc-61839e61d989";
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("")); // Assuming successful delete returns an empty body
+
+        Mono<Void> result = vetsServiceClient.deleteSpecialtiesByVetId(vetId, specialtyId);
+
+        StepVerifier.create(result)
+                .verifyComplete(); // Verifies that the operation completes successfully
+
+        RecordedRequest recordedRequest = server.takeRequest();
+        assertEquals("/deb1950c-3c56-45dc-874b-89e352695eb7/specialties/794ac37f-1e07-43c2-93bc-61839e61d989", recordedRequest.getPath());
+        assertEquals("DELETE", recordedRequest.getMethod());
+    }
+
+    @Test
+    void shouldThrowExistingVetNotFoundException_whenSpecialtyIdIsInvalid() throws Exception {
+        String vetId = "deb1950c-3c56-45dc-874b-89e352695eb7";
+        String specialtyId = "794ac37f-1e07-43c2-93bc-61839e61d9890000";
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(404)
+                .setBody("")); // Simulating a 404 response
+
+        Mono<Void> result = vetsServiceClient.deleteSpecialtiesByVetId(vetId, specialtyId);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable ->
+                        throwable instanceof ExistingVetNotFoundException &&
+                                throwable.getMessage().contains("Vet not found: " + vetId))
+                .verify(); // Verifying the error
+
+        // Validating the request was sent correctly
+        RecordedRequest recordedRequest = server.takeRequest();
+        assertEquals("/deb1950c-3c56-45dc-874b-89e352695eb7/specialties/794ac37f-1e07-43c2-93bc-61839e61d9890000", recordedRequest.getPath());
+        assertEquals("DELETE", recordedRequest.getMethod());
+    }
+
 
 }
 

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -15,7 +15,7 @@ interface VetResponseType {
   workday: string[];
   workHoursJson: string;
   active: boolean;
-  specialties: { name: string }[];
+  specialties: { specialtyId: string; name: string; }[];
 }
 
 export default function VetDetails(): JSX.Element {
@@ -177,6 +177,29 @@ export default function VetDetails(): JSX.Element {
     }
   };
 
+  const handleDeleteSpecialty = async (specialtyId: string): Promise<void> => {
+    try {
+      // Make a DELETE request to the API
+      await axios.delete(
+          `http://localhost:8080/api/v2/gateway/vets/${vetId}/specialties/${specialtyId}`
+      );
+
+      // Update the vet data after deleting the specialty
+      setVet(prevVet =>
+          prevVet
+              ? {
+                ...prevVet,
+                specialties: prevVet.specialties.filter(
+                    specialty => specialty.specialtyId !== specialtyId
+                ), // Remove the deleted specialty from the local state
+              }
+              : null
+      );
+    } catch (error) {
+      setError('Failed to delete specialty');
+    }
+  };
+
   if (loading) return <p>Loading vet details...</p>;
   if (error) return <p>{error}</p>;
 
@@ -242,7 +265,13 @@ export default function VetDetails(): JSX.Element {
               {vet.specialties && vet.specialties.length > 0 ? (
                 <ul>
                   {vet.specialties.map((specialty, index) => (
-                    <li key={index}>{specialty.name}</li>
+                    <li
+                        key={index}>{specialty.name}
+                        <button
+                            onClick={() => handleDeleteSpecialty(specialty.specialtyId)}>
+                            Delete
+                        </button>
+                    </li>
                   ))}
                 </ul>
               ) : (

--- a/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/VetRepository.java
+++ b/vet-service/src/main/java/com/petclinic/vet/dataaccesslayer/VetRepository.java
@@ -26,8 +26,4 @@ public interface VetRepository extends ReactiveMongoRepository<Vet, String> {
 
     Mono<Vet> findVetByVetBillId(String vetBillId);
 
-
-
-
-
 }

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -313,6 +313,15 @@ public class VetController {
         return vetService.addSpecialtiesByVetId(vetId, specialties);
     }
 
+    @DeleteMapping("{vetId}/specialties/{specialtyId}")
+    public Mono<ResponseEntity<Void>> deleteSpecialtiesBySpecialtyId(
+            @PathVariable String vetId,
+            @PathVariable String specialtyId) {
+        return vetService.deleteSpecialtiesBySpecialtyId(vetId, specialtyId)
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+
     @GetMapping("{vetId}/albums")
     public Flux<Album> getAllAlbumsByVetId(@PathVariable String vetId) {
         return albumService.getAllAlbumsByVetId(vetId)

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/VetService.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/VetService.java
@@ -30,4 +30,5 @@ public interface VetService {
     Flux<VetResponseDTO> getVetByIsActive(boolean isActive);
     Mono<VetResponseDTO> getVetByVetBillId(String vetBillId);
     Mono<VetResponseDTO> addSpecialtiesByVetId(String vetId, Mono<SpecialtyDTO> specialtyDTO);
+    Mono<Void> deleteSpecialtiesBySpecialtyId(String vetId, String specialtyId);
 }

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/VetServiceImpl.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/VetServiceImpl.java
@@ -136,7 +136,19 @@ public class VetServiceImpl implements VetService {
                 .build();
     }
 
-
+    @Override
+    public Mono<Void> deleteSpecialtiesBySpecialtyId(String vetId, String specialtyId) {
+        return vetRepository.findVetByVetId(vetId)
+                .switchIfEmpty(Mono.error(new NotFoundException("No vet found with vetId: " + vetId)))
+                .flatMap(vet -> {
+                    Set<Specialty> specialties = vet.getSpecialties().stream()
+                            .filter(specialty -> !specialty.getSpecialtyId().equals(specialtyId))
+                            .collect(Collectors.toSet());
+                    vet.setSpecialties(specialties);
+                    return vetRepository.save(vet);
+                })
+                .then();
+    }
 
 
     @Transactional

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -1931,5 +1931,33 @@ class VetControllerIntegrationTest {
                 .jsonPath("$.message").isEqualTo("Vet not found with id: " + invalidVetId);
     }
 
+    @Test
+    void deleteSpecialtyFromVet_WithValidVetIdAndSpecialtyId_ShouldSucceed() {
+        Vet vet = buildVet("1234");
+
+        Publisher<Vet> setup = vetRepository.deleteAll().thenMany(vetRepository.save(vet));
+        StepVerifier.create(setup)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        client.delete()
+                .uri("/vets/" + vet.getVetId() + "/specialties/" + specialtyDTO.getSpecialtyId())
+                .exchange()
+                .expectStatus().isNoContent() // Expecting a 204 No Content status
+                .expectBody().isEmpty(); // No content expected in the response body
+    }
+
+    @Test
+    void deleteSpecialtyFromVet_WithInvalidVetId_ShouldReturnNotFound() {
+        String invalidVetId = "invalid-vet";
+
+        client.delete()
+                .uri("/vets/" + invalidVetId + "/specialties/" + specialtyDTO.getSpecialtyId())
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("No vet found with vetId: " + invalidVetId);
+    }
 
 }


### PR DESCRIPTION
**JIRA:** link to jira ticket
## Context:
Admin and vets are now able to delete the vets specialties.
## Does this PR change the .vscode folder in petclinic-frontend?:
No

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes

- implemented delete specialties in api gateway and vet service
- tested delete specialties in api gateway and vet service
- implemented the frontend for delete specialties with a button

## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://github.com/user-attachments/assets/98d982cd-1103-463a-8f11-b381665341c1)

After:
![image](https://github.com/user-attachments/assets/283a4031-3b8e-47e7-b56c-47921f527940)
