### PR TITLE
feat(VETS-CPC-1372): get education by vet id

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -7,10 +7,7 @@ import com.petclinic.bffapigateway.domainclientlayer.VetsServiceClient;
 import com.petclinic.bffapigateway.dtos.Auth.RegisterVet;
 import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerRequestDTO;
 import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerResponseDTO;
-import com.petclinic.bffapigateway.dtos.Vets.Album;
-import com.petclinic.bffapigateway.dtos.Vets.SpecialtyDTO;
-import com.petclinic.bffapigateway.dtos.Vets.VetRequestDTO;
-import com.petclinic.bffapigateway.dtos.Vets.VetResponseDTO;
+import com.petclinic.bffapigateway.dtos.Vets.*;
 import com.petclinic.bffapigateway.exceptions.ExistingVetNotFoundException;
 import com.petclinic.bffapigateway.exceptions.InvalidInputException;
 import com.petclinic.bffapigateway.utils.Security.Annotations.IsUserSpecific;
@@ -164,4 +161,12 @@ public class VetController {
                 .then(Mono.just(ResponseEntity.noContent().<Void>build()))
                 .doOnError(error -> log.error("Error deleting photo for vetId: {}", vetId, error));
     }
+
+    //education
+    @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS})
+    @GetMapping(value = "/{vetId}/educations", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Flux<EducationResponseDTO> getEducationsByVetId(@PathVariable String vetId) {
+        return vetsServiceClient.getEducationsByVetId(vetId);
+    }
+
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -162,19 +162,19 @@ public class VetController {
                 .then(Mono.just(ResponseEntity.noContent().<Void>build()))
                 .doOnError(error -> log.error("Error deleting photo for vetId: {}", vetId, error));
     }
-
-    //education
-    @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS})
-    @GetMapping(value = "/{vetId}/educations", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Flux<EducationResponseDTO> getEducationsByVetId(@PathVariable String vetId) {
-        return vetsServiceClient.getEducationsByVetId(vetId);
-
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.VET})
     @DeleteMapping("/{vetId}/albums/{Id}")
     public Mono<ResponseEntity<Void>> deleteAlbumPhoto(@PathVariable String vetId,@PathVariable Integer Id) {
         return vetsServiceClient.deleteAlbumPhotoById(vetId,Id)
                 .then(Mono.defer(() -> Mono.just(ResponseEntity.noContent().<Void>build())))
                 .onErrorResume(NotFoundException.class, e -> Mono.defer(() -> Mono.just(ResponseEntity.<Void>notFound().build())));
+    }
+
+    //education
+    @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS})
+    @GetMapping(value = "/{vetId}/educations", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Flux<EducationResponseDTO> getEducationsByVetId(@PathVariable String vetId) {
+        return vetsServiceClient.getEducationsByVetId(vetId);
     }
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
@@ -405,5 +405,39 @@ class VetControllerIntegrationTest {
                 .jsonPath("$.message").isEqualTo("Photo not found for vetId: " + vetId);
     }
 
+    @Test
+    void whenGetEducationByVetId_thenReturnEducation() throws JsonProcessingException {
+        String vetId = "ac9adeb8-625b-11ee-8c99-0242ac120002";
+
+        EducationRequestDTO education1 = new EducationRequestDTO(vetId, "school1", "degree1", "field1", "2020-01-01", "2021-01-01");
+        EducationRequestDTO education2 = new EducationRequestDTO(vetId, "school2", "degree2", "field2", "2021-01-01", "2022-01-01");
+
+        mockServerConfigVetService.registerGetEducationByVetIdEndpoint(vetId, List.of(education1, education2));
+
+        webTestClient.get()
+                .uri(VET_ENDPOINT + "/" + vetId + "/educations")
+                .cookie("Bearer", BEARER_TOKEN)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBodyList(EducationRequestDTO.class)
+                .hasSize(2)
+                .contains(education1, education2);
+    }
+
+    @Test
+    void whenGetEducationByInvalidVetId_thenReturnNotFound() {
+        String invalidVetId = "ac9adeb8-625b-11ee-8c99-0242ac12000200";
+
+        mockServerConfigVetService.registerGetEducationByVetIdEndpointNotFound(invalidVetId);
+
+        webTestClient.get()
+                .uri(VET_ENDPOINT + "/" + invalidVetId + "/educations")
+                .cookie("Bearer", BEARER_TOKEN)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigVetService.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigVetService.java
@@ -2,10 +2,7 @@ package com.petclinic.bffapigateway.presentationlayer.v2.mockservers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.petclinic.bffapigateway.dtos.Vets.Album;
-import com.petclinic.bffapigateway.dtos.Vets.SpecialtyDTO;
-import com.petclinic.bffapigateway.dtos.Vets.VetResponseDTO;
-import com.petclinic.bffapigateway.dtos.Vets.Workday;
+import com.petclinic.bffapigateway.dtos.Vets.*;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.springframework.http.MediaType;
@@ -379,6 +376,26 @@ public void stopMockServer() {
                                 .withBody(json("{\"message\":\"Photo not found for vetId: " + vetId + "\"}"))
                 );
     }
+    public void registerGetEducationByVetIdEndpoint(String vetId, List<EducationRequestDTO> educations) throws JsonProcessingException {
+        mockServerClient_VetService.when(
+                        request()
+                                .withMethod("GET")
+                                .withPath("/vets/" + vetId + "/educations"))
+                .respond(
+                        response()
+                                .withStatusCode(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(mapper.writeValueAsString(educations)));
+    }
 
+    public void registerGetEducationByVetIdEndpointNotFound(String vetId) {
+        mockServerClient_VetService.when(
+                        request()
+                                .withMethod("GET")
+                                .withPath("/vets/" + vetId + "/educations"))
+                .respond(
+                        response()
+                                .withStatusCode(404));
+    }
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigVetService.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigVetService.java
@@ -376,17 +376,6 @@ public void stopMockServer() {
                                 .withBody(json("{\"message\":\"Photo not found for vetId: " + vetId + "\"}"))
                 );
     }
-    public void registerGetEducationByVetIdEndpoint(String vetId, List<EducationRequestDTO> educations) throws JsonProcessingException {
-        mockServerClient_VetService.when(
-                        request()
-                                .withMethod("GET")
-                                .withPath("/vets/" + vetId + "/educations"))
-                .respond(
-                        response()
-                                .withStatusCode(200)
-                                .withHeader("Content-Type", "application/json")
-                                .withBody(mapper.writeValueAsString(educations)));
-    }
     public void registerDeleteAlbumPhotoEndpoint(String vetId, Integer albumId) {
         mockServerClient_VetService
                 .when(
@@ -427,6 +416,17 @@ public void stopMockServer() {
                                 .withHeader("Content-Type", "application/json")
                                 .withBody(json("{\"message\":\"Server error occurred while deleting album photo with ID: " + albumId + "\"}"))
                 );
+    }
+    public void registerGetEducationByVetIdEndpoint(String vetId, List<EducationRequestDTO> educations) throws JsonProcessingException {
+        mockServerClient_VetService.when(
+                        request()
+                                .withMethod("GET")
+                                .withPath("/vets/" + vetId + "/educations"))
+                .respond(
+                        response()
+                                .withStatusCode(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(mapper.writeValueAsString(educations)));
     }
 
     public void registerGetEducationByVetIdEndpointNotFound(String vetId) {

--- a/petclinic-frontend/src/features/veterinarians/models/EducationRequestModel.ts
+++ b/petclinic-frontend/src/features/veterinarians/models/EducationRequestModel.ts
@@ -1,0 +1,8 @@
+export interface EducationRequestModel {
+  vetId: string;
+  schoolName: string;
+  degree: string;
+  fieldOfStudy: string;
+  startDate: string;
+  endDate: string;
+}

--- a/petclinic-frontend/src/features/veterinarians/models/EducationResponseModel.ts
+++ b/petclinic-frontend/src/features/veterinarians/models/EducationResponseModel.ts
@@ -1,0 +1,9 @@
+export interface EducationResponseModel {
+  educationId: string;
+  vetId: string;
+  schoolName: string;
+  degree: string;
+  fieldOfStudy: string;
+  startDate: string;
+  endDate: string;
+}

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -19,9 +19,22 @@ interface VetResponseType {
   specialties: { specialtyId: string; name: string }[];
 }
 
+interface EducationResponseType {
+  educationId: string;
+  vetId: string;
+  schoolName: string;
+  degree: string;
+  fieldOfStudy: string;
+  startDate: string;
+  endDate: string;
+}
+
 export default function VetDetails(): JSX.Element {
   const { vetId } = useParams<{ vetId: string }>();
   const [vet, setVet] = useState<VetResponseType | null>(null);
+  const [education, setEducation] = useState<EducationResponseType[] | null>(
+    null
+  );
   const [photo, setPhoto] = useState<string | null>(null);
   const [albumPhotos, setAlbumPhotos] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -78,6 +91,22 @@ export default function VetDetails(): JSX.Element {
       }
     };
 
+    const fetchEducationDetails = async (): Promise<void> => {
+      try {
+        const response = await fetch(
+          `http://localhost:8080/api/v2/gateway/vets/${vetId}/educations`
+        );
+
+        if (!response.ok) {
+          throw new Error(`Error: ${response.statusText}`);
+        }
+        const data: EducationResponseType[] = await response.json();
+        setEducation(data);
+      } catch (error) {
+        setError('Failed to fetch education details');
+      }
+    };
+
     const fetchAlbumPhotos = async (): Promise<void> => {
       try {
         const response = await fetch(
@@ -117,6 +146,7 @@ export default function VetDetails(): JSX.Element {
 
     fetchVetDetails().then(() => {
       fetchVetPhoto();
+      fetchEducationDetails();
       fetchAlbumPhotos();
       setLoading(false);
     });
@@ -388,6 +418,34 @@ export default function VetDetails(): JSX.Element {
                     </div>
                   </form>
                 </div>
+              )}
+            </section>
+
+            <section className="vet-education-info">
+              <h2>Vet Education</h2>
+              {education && education.length > 0 ? (
+                education.map((edu, index) => (
+                  <div key={index}>
+                    <p>
+                      <strong>School Name:</strong> {edu.schoolName}
+                    </p>
+                    <p>
+                      <strong>Degree:</strong> {edu.degree}
+                    </p>
+                    <p>
+                      <strong>Field of Study:</strong> {edu.fieldOfStudy}
+                    </p>
+                    <p>
+                      <strong>Start Date:</strong> {edu.startDate}
+                    </p>
+                    <p>
+                      <strong>End Date:</strong> {edu.endDate}
+                    </p>
+                    <hr />
+                  </div>
+                ))
+              ) : (
+                <p>No education details available</p>
               )}
             </section>
 


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1372
## Context:
Users can now see the vets education.
## Does this PR change the .vscode folder in petclinic-frontend?:
No

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes

- implemented geteducation in api gateway
- tested geteducation in api gateway
- implemented the frontend for geteducation in a list format inside the vets details

## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://github.com/user-attachments/assets/e982e117-e2a5-46bc-8856-c18fae2da674)

After:
![image](https://github.com/user-attachments/assets/db3cf475-5fa5-4f9d-b233-7dbb250751f4)
