### PR TITLE
bug(VETS-CPC-1390): update delete vet profile photo button

### DIFF
--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -41,6 +41,7 @@ export default function VetDetails(): JSX.Element {
     null
   );
   const [photo, setPhoto] = useState<string | null>(null);
+  const [isDefaultPhoto, setIsDefaultPhoto] = useState(false);
   const [albumPhotos, setAlbumPhotos] = useState<AlbumPhotoType[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -71,10 +72,12 @@ export default function VetDetails(): JSX.Element {
     } catch (error) {
       setError('Failed to fetch vet photo');
       setPhoto('/images/vet_default.jpg');
+      setIsDefaultPhoto(true); // This indicates the default photo is being used
     }
   }, [vetId]);
 
   const handlePhotoDeleted = (): void => {
+    setIsDefaultPhoto(true);
     fetchVetPhoto();
   };
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -162,6 +165,7 @@ export default function VetDetails(): JSX.Element {
 
     const localImageUrl = URL.createObjectURL(file);
     setPhoto(localImageUrl);
+    setIsDefaultPhoto(false); // Set to false because a new photo is uploaded
 
     try {
       const response = await fetch(
@@ -183,6 +187,7 @@ export default function VetDetails(): JSX.Element {
       const updatedBlob = await response.blob();
       const updatedImageUrl = URL.createObjectURL(updatedBlob);
       setPhoto(updatedImageUrl);
+      setIsDefaultPhoto(false);
     } catch (error) {
       setError('Failed to update vet photo');
     }
@@ -311,10 +316,12 @@ export default function VetDetails(): JSX.Element {
               onChange={handleUpdateVetProfilePhoto}
               accept="image/*"
             />
-            <DeleteVetPhoto
-              vetId={vetId!}
-              onPhotoDeleted={handlePhotoDeleted}
-            />
+            {!isDefaultPhoto && (
+              <DeleteVetPhoto
+                vetId={vetId!}
+                onPhotoDeleted={handlePhotoDeleted}
+              />
+            )}
           </section>
         )}
 


### PR DESCRIPTION

**JIRA:** link to jira ticket: https://champlainsaintlambert.atlassian.net/browse/CPC-1390 
## Context:
What is the ticket about and why are we doing this change.
before, when the profile picture was default you still had the "delete" button, which was bad for ux because you couldn't actually delete the default picture
## Does this PR change the .vscode folder in petclinic-frontend?: no
If the PR changes the .vscode folder, explain why in detail because it should not. 
Be sure to include cgerard321 as a reviewer.

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
What are the various changes and what other modules do those changes affect.
only changed one file: vet details.tsx
This can be bullet point or sentence format.
## Before and After UI (Required for UI-impacting PRs)
If this is a change to the UI, include before and after screenshots to show the differences.
If this is a new UI feature, include screenshots to show reviewers what it looks like. 
before:
![image](https://github.com/user-attachments/assets/48605281-15ee-49e5-b0bc-dc9c7275c218)
After:
![image](https://github.com/user-attachments/assets/c796f736-4ea0-4e71-b5fe-b514adc8b6a6)


## Dev notes (Optional)
Specific technical changes that should be noted
i changed some lines of the update method, but it works perfectly
## Linked pull requests (Optional)
Pull request links