### PR TITLE
feat(VETS-CPC-1388): rework vet page ui

### DIFF
--- a/petclinic-frontend/package-lock.json
+++ b/petclinic-frontend/package-lock.json
@@ -5579,7 +5579,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
       "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
-      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }

--- a/petclinic-frontend/src/features/veterinarians/VetListCard.css
+++ b/petclinic-frontend/src/features/veterinarians/VetListCard.css
@@ -5,17 +5,18 @@
     justify-content: center;
     padding: 20px;
   }
+
   
   .card {
     overflow: hidden;
-    width: 300px;
-    height: 300px;
+    width: 450px !important;
+    height: auto;
     border-radius: 15px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    border: 1px solid #e0e0e0;
-    background-color: white;
+    border: 1px solid #e0e0e0;  
+    background-color: #f0f0f0;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
     padding: 20px;
     transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
@@ -28,16 +29,28 @@
   }
 
   
+  .photo-container {
+    width: 250px !important;
+    height: 250px !important;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-right: 20px;
+  
+  }
+  
   .card-image {
-    width: 100%;
-    height: 100px;
+    width: 200px !important;
+    height: 200px !important;
+    border-radius: 12px;
     object-fit: cover;
-    border-radius: 8px;
-    margin-bottom: 20px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    transition: none;
   }
   
   .card-content {
-    text-align: center;
+    text-align: left;
+    flex-grow: 1;
   }
   
   .card-actions {

--- a/petclinic-frontend/src/features/veterinarians/VetListCard.css
+++ b/petclinic-frontend/src/features/veterinarians/VetListCard.css
@@ -1,0 +1,39 @@
+.card-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+    padding: 20px;
+  }
+  
+  .card {
+    overflow: hidden;
+    width: 300px;
+    height: auto;
+    border-radius: 15px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    border: 1px solid #e0e0e0;
+    background-color: white;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+    transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+    cursor: pointer;
+  }
+  
+  .card:hover {
+    transform: translateY(-10px);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+  }
+  
+  .card-content {
+    text-align: center;
+  }
+  
+  .card-actions {
+    margin-top: 10px;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }

--- a/petclinic-frontend/src/features/veterinarians/VetListCard.css
+++ b/petclinic-frontend/src/features/veterinarians/VetListCard.css
@@ -9,7 +9,7 @@
   .card {
     overflow: hidden;
     width: 300px;
-    height: auto;
+    height: 300px;
     border-radius: 15px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     border: 1px solid #e0e0e0;
@@ -25,6 +25,15 @@
   .card:hover {
     transform: translateY(-10px);
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+  }
+
+  
+  .card-image {
+    width: 100%;
+    height: 100px;
+    object-fit: cover;
+    border-radius: 8px;
+    margin-bottom: 20px;
   }
   
   .card-content {

--- a/petclinic-frontend/src/features/veterinarians/VetListCards.tsx
+++ b/petclinic-frontend/src/features/veterinarians/VetListCards.tsx
@@ -65,17 +65,20 @@ export default function VetCardTable({
             className="card"
             onClick={() => handleCardClick(vet.vetId)}
           >
-            <img
-              src={vetPhotos[vet.vetId] || '/images/vet_default.jpg'}
-              alt="Vet photo"
-              className="card-image"
-            />
+            <div className="photo-container">
+              <img
+                src={vetPhotos[vet.vetId] || '/images/vet_default.jpg'}
+                alt="Vet photo"
+                className="card-image"
+              />
+            </div>
+
             <div className="card-content">
               <h3>
                 {vet.firstName} {vet.lastName}
               </h3>
               <p>
-                Specialties:{' '}
+                <strong>Specialties:</strong>{' '}
                 {vet.specialties.map(specialty => specialty.name).join(', ')}
               </p>
               <div className="card-actions">

--- a/petclinic-frontend/src/features/veterinarians/VetListCards.tsx
+++ b/petclinic-frontend/src/features/veterinarians/VetListCards.tsx
@@ -78,7 +78,6 @@ export default function VetCardTable({
                 Specialties:{' '}
                 {vet.specialties.map(specialty => specialty.name).join(', ')}
               </p>
-              <p>Work Hours: {vet.workHours}</p>
               <div className="card-actions">
                 <button
                   className="btn btn-primary"

--- a/petclinic-frontend/src/features/veterinarians/VetListCards.tsx
+++ b/petclinic-frontend/src/features/veterinarians/VetListCards.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { VetRequestModel } from '@/features/veterinarians/models/VetRequestModel.ts';
+import { useNavigate } from 'react-router-dom';
+import './VetListCard.css';
+import DeleteVet from '@/pages/Vet/DeleteVet.tsx';
+import { deleteVet } from '@/features/veterinarians/api/deleteVet';
+import UpdateVet from '@/pages/Vet/UpdateVet';
+
+interface VetCardTableProps {
+  vets: VetRequestModel[];
+  onDeleteVet: (updatedVets: VetRequestModel[]) => void;
+}
+
+export default function VetCardTable({
+  vets,
+  onDeleteVet,
+}: VetCardTableProps): JSX.Element {
+  const navigate = useNavigate();
+  const [selectedVet, setSelectedVet] = useState<VetRequestModel | null>(null);
+
+  const handleCardClick = (vetId: string): void => {
+    navigate(`/vets/${vetId}`);
+  };
+
+  const handleVetDelete = async (
+    event: React.MouseEvent,
+    vetId: string
+  ): Promise<void> => {
+    event.stopPropagation();
+    try {
+      await deleteVet(vetId);
+      onDeleteVet(vets.filter(vet => vet.vetId !== vetId));
+    } catch (err) {
+      console.error('Error deleting vet:', err);
+    }
+  };
+
+  return (
+    <div className="card-container">
+      {vets.length === 0 ? (
+        <p>No vets found.</p>
+      ) : (
+        vets.map(vet => (
+          <div
+            key={vet.vetId}
+            className="card"
+            onClick={() => handleCardClick(vet.vetId)}
+          >
+            <div className="card-content">
+              <h3>
+                {vet.firstName} {vet.lastName}
+              </h3>
+              <p>
+                Specialties:{' '}
+                {vet.specialties.map(specialty => specialty.name).join(', ')}
+              </p>
+              <div className="card-actions">
+                <button
+                  className="btn btn-primary"
+                  onClick={event => {
+                    event.stopPropagation();
+                    setSelectedVet(vet);
+                  }}
+                >
+                  Update
+                </button>
+                <DeleteVet
+                  vetId={vet.vetId}
+                  onVetDeleted={event => handleVetDelete(event, vet.vetId)}
+                />
+              </div>
+            </div>
+          </div>
+        ))
+      )}
+      {selectedVet && (
+        <UpdateVet vet={selectedVet} onClose={() => setSelectedVet(null)} />
+      )}
+    </div>
+  );
+}

--- a/petclinic-frontend/src/features/veterinarians/api/fetchPhoto.ts
+++ b/petclinic-frontend/src/features/veterinarians/api/fetchPhoto.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+export const fetchVetPhoto = async (vetId: string): Promise<string> => {
+  try {
+    const response = await axios.get(
+      `http://localhost:8080/api/v2/gateway/vets/${vetId}/photo`,
+      {
+        responseType: 'blob',
+        headers: {
+          Accept: 'image/*',
+        },
+      }
+    );
+
+    const blob = response.data;
+    return URL.createObjectURL(blob);
+  } catch (error) {
+    console.error('Failed to fetch vet photo:', error);
+    return '/images/vet_default.jpg';
+  }
+};

--- a/petclinic-frontend/src/pages/Vet/Vet.tsx
+++ b/petclinic-frontend/src/pages/Vet/Vet.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { NavBar } from '@/layouts/AppNavBar.tsx';
 import AddVet from '@/pages/Vet/AddVet.tsx';
-import VetListTable from '@/features/veterinarians/VetListTable.tsx';
 import UploadVetPhoto from '@/pages/Vet/UploadVetPhoto.tsx';
 import { VetRequestModel } from '@/features/veterinarians/models/VetRequestModel.ts';
+import VetCardTable from '@/features/veterinarians/VetListCards';
 
 export default function Vet(): JSX.Element {
   const [searchQuery, setSearchQuery] = useState('');
@@ -75,7 +75,7 @@ export default function Vet(): JSX.Element {
       {error && <p style={{ color: 'red' }}>{error}</p>}
 
       {results.length > 0 ? (
-        <VetListTable vets={results} onDeleteVet={setResults} />
+        <VetCardTable vets={results} onDeleteVet={setResults} />
       ) : (
         <p>No results found.</p>
       )}


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1388
## Context:
On the main page of the vet, we only had a table with info such as first and last and speciality. We didn't have the picture of the vets and the page wasn't presentable. Modifications were made to have a cleaner and presentable vet page. Instead of a table we now have cards that display the first and last name, the vet specialities and their photo.

## Does this PR change the .vscode folder in petclinic-frontend?:
This PR does not affect the .vscode file

## Changes

- Removed the vet table.
- Added cards instead of the table.
- Added the vet photos in the cards on top of the first and last names and specialities.

## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://github.com/user-attachments/assets/0c62fcd0-d572-4cee-9e40-2e17cf134cd5)

After:
![image](https://github.com/user-attachments/assets/d016a3b6-35b5-45b7-ab70-858acfd9295c)

## Dev notes (Optional)
Specific technical changes that should be noted
## Linked pull requests (Optional)
Pull request links