### PR TITLE
Updated steps to run if failed

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -31,11 +31,13 @@ jobs:
         run: ./gradlew build
 
       - name: Create coverage-data directory and copy contents
+        if: success() || failure()
         run: |
           mkdir -p .qodana/code-coverage
           cp -R */build/reports/* .qodana/code-coverage/
 
       - name: Archive coverage data
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: gradle-coverage-data.zip


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1413
## Context
When Qodana fails, the build report is not packed and archived. This PR attempts to run the archive of build reports even if Qodana build fails.

### Changes Github Workflows

## Changes
- Run archive step when Qodana succeeds or fails