### PR TITLE
bug/(PROD-CPC-1414): Fix Null Average Rating Causing 500 Error on New Product Added

### DIFF
--- a/products-service/src/main/java/com/petclinic/products/businesslayer/products/ProductServiceImpl.java
+++ b/products-service/src/main/java/com/petclinic/products/businesslayer/products/ProductServiceImpl.java
@@ -40,6 +40,7 @@ public class ProductServiceImpl implements ProductService {
                 .collectList()
                 .flatMap(ratings -> {
                     if(ratings.isEmpty()){
+                        product.setAverageRating(0.0);
                         return Mono.just(product);
                     }
 

--- a/products-service/src/test/java/com/petclinic/products/businesslayer/ProductServiceUnitTest.java
+++ b/products-service/src/test/java/com/petclinic/products/businesslayer/ProductServiceUnitTest.java
@@ -81,22 +81,38 @@ class ProductServiceUnitTest {
         Double maxPrice = null;
         String sort = null;
 
-        Product product1 = createProduct("1", 50.0, 4.0);
-        Product product2 = createProduct("2", 60.0, 3.0);
-        Product product3 = createProduct("3", 70.0, 5.0);
+        Product product1 = createProduct("1", 50.0,3.5);
+        Product product2 = createProduct("2", 60.0,3.7);
+        Product product3 = createProduct("3", 70.0,5.0);
 
         when(productRepository.findAll()).thenReturn(Flux.just(product1, product2, product3));
 
-        when(ratingRepository.findRatingsByProductId(anyString())).thenReturn(Flux.empty());
-
+        // Mock ratings for each product
+        when(ratingRepository.findRatingsByProductId("1")).thenReturn(
+                Flux.just(
+                        Rating.builder().productId("1").rating((byte) 4).build(),
+                        Rating.builder().productId("1").rating((byte) 4).build()
+                )
+        );
+        when(ratingRepository.findRatingsByProductId("2")).thenReturn(
+                Flux.just(
+                        Rating.builder().productId("2").rating((byte) 3).build()
+                )
+        );
+        when(ratingRepository.findRatingsByProductId("3")).thenReturn(
+                Flux.just(
+                        Rating.builder().productId("3").rating((byte) 5).build(),
+                        Rating.builder().productId("3").rating((byte) 5).build()
+                )
+        );
 
         // When
         Flux<ProductResponseModel> result = productService.getAllProducts(minPrice, maxPrice, minRating, maxRating, sort);
 
         // Then
         StepVerifier.create(result)
-                .expectNextMatches(product -> product.getAverageRating() == 4.0)
-                .expectNextMatches(product -> product.getAverageRating() == 3.0)
+                .expectNextMatches(product -> product.getProductId().equals("1") && product.getAverageRating() == 4.0)
+                .expectNextMatches(product -> product.getProductId().equals("2") && product.getAverageRating() == 3.0)
                 .expectComplete()
                 .verify();
 

--- a/products-service/src/test/java/com/petclinic/products/presentationlayer/products/ProductControllerIntegrationTest.java
+++ b/products-service/src/test/java/com/petclinic/products/presentationlayer/products/ProductControllerIntegrationTest.java
@@ -2,6 +2,8 @@ package com.petclinic.products.presentationlayer.products;
 
 import com.petclinic.products.datalayer.products.Product;
 import com.petclinic.products.datalayer.products.ProductRepository;
+import com.petclinic.products.datalayer.ratings.Rating;
+import com.petclinic.products.datalayer.ratings.RatingRepository;
 import com.petclinic.products.utils.exceptions.NotFoundException;
 import org.junit.jupiter.api.*;
 import org.reactivestreams.Publisher;
@@ -32,6 +34,9 @@ class ProductControllerIntegrationTest {
 
     @Autowired
     private ProductRepository productRepository;
+
+    @Autowired
+    private RatingRepository ratingRepository;
 
     private final String NON_EXISTENT_PRODUCT_ID = UUID.randomUUID().toString();
     private final String INVALID_PRODUCT_ID = "INVALID_PRODUCT_ID";
@@ -90,8 +95,22 @@ class ProductControllerIntegrationTest {
     @Test
     public void whenGetAllProductsSortedByRatingAsc_thenReturnProductsSortedAscending() {
 
-        // Save
-        productRepository.saveAll(List.of(product1, product2));
+        productRepository.saveAll(List.of(product1, product2)).blockLast();
+
+
+        Rating ratingForProduct1 = Rating.builder()
+                .productId(product1.getProductId())
+                .customerId(UUID.randomUUID().toString())
+                .rating((byte) 4)
+                .build();
+
+        Rating ratingForProduct2 = Rating.builder()
+                .productId(product2.getProductId())
+                .customerId(UUID.randomUUID().toString())
+                .rating((byte) 2)
+                .build();
+
+        ratingRepository.saveAll(List.of(ratingForProduct1, ratingForProduct2)).blockLast();
 
         // Act
         webTestClient.get()
@@ -103,18 +122,50 @@ class ProductControllerIntegrationTest {
                 .expectStatus().isOk()
                 .expectHeader().contentType("text/event-stream;charset=UTF-8")
                 .expectBodyList(ProductResponseModel.class)
-                .value(productResponseModel -> {
-                    assertNotNull(productResponseModel);
-                    assertEquals(2, productResponseModel.size());
-                    assertEquals(product2.getProductId(), productResponseModel.get(0).getProductId());
-                    assertEquals(product1.getProductId(), productResponseModel.get(1).getProductId());
+                .value(productResponseModels -> {
+                    assertNotNull(productResponseModels);
+                    assertEquals(2, productResponseModels.size());
+                    assertEquals(product2.getProductId(), productResponseModels.get(0).getProductId());
+                    assertEquals(product1.getProductId(), productResponseModels.get(1).getProductId());
                 });
     }
     @Test
     public void whenGetAllProductsSortedByRatingDesc_thenReturnProductsSortedDescending() {
 
-        // Save the products to the repository
-        productRepository.saveAll(List.of(product1, product2));
+        productRepository.deleteAll().block();
+        ratingRepository.deleteAll().block();
+
+        Product product1 = Product.builder()
+                .productId("product-1-id")
+                .productName("Product 1")
+                .productDescription("Product 1 Description")
+                .productSalePrice(100.00)
+                .productQuantity(2)
+                .build();
+
+        Product product2 = Product.builder()
+                .productId("product-2-id")
+                .productName("Product 2")
+                .productDescription("Product 2 Description")
+                .productSalePrice(50.00)
+                .productQuantity(2)
+                .build();
+
+        productRepository.saveAll(List.of(product1, product2)).blockLast();
+        Rating ratingForProduct1 = Rating.builder()
+                .productId(product1.getProductId())
+                .customerId(UUID.randomUUID().toString())
+                .rating((byte) 5)
+                .build();
+
+        Rating ratingForProduct2 = Rating.builder()
+                .productId(product2.getProductId())
+                .customerId(UUID.randomUUID().toString())
+                .rating((byte) 3)
+                .build();
+
+        ratingRepository.saveAll(List.of(ratingForProduct1, ratingForProduct2)).blockLast();
+
         // Act
         webTestClient.get()
                 .uri(uriBuilder -> uriBuilder.path("/api/v1/products")
@@ -125,11 +176,11 @@ class ProductControllerIntegrationTest {
                 .expectStatus().isOk()
                 .expectHeader().contentType("text/event-stream;charset=UTF-8")
                 .expectBodyList(ProductResponseModel.class)
-                .value(productResponseModel -> {
-                    assertNotNull(productResponseModel);
-                    assertEquals(2, productResponseModel.size());
-                    assertEquals(product1.getProductId(), productResponseModel.get(0).getProductId());
-                    assertEquals(product2.getProductId(), productResponseModel.get(1).getProductId());
+                .value(productResponseModels -> {
+                    assertNotNull(productResponseModels);
+                    assertEquals(2, productResponseModels.size());
+                    assertEquals(product1.getProductId(), productResponseModels.get(0).getProductId());
+                    assertEquals(product2.getProductId(), productResponseModels.get(1).getProductId());
                 });
     }
 

--- a/products-service/src/test/java/com/petclinic/products/presentationlayer/ratings/RatingControllerIntegrationTest.java
+++ b/products-service/src/test/java/com/petclinic/products/presentationlayer/ratings/RatingControllerIntegrationTest.java
@@ -274,6 +274,13 @@ class RatingControllerIntegrationTest {
 
     @Test
     public void whenAddRatingForProduct_thenRecalculateAverage(){
+
+        productRepository.deleteAll().block();
+        ratingRepository.deleteAll().block();
+
+        productRepository.save(product1).block();
+        ratingRepository.saveAll(Flux.just(rating1Prod1, rating2Prod1)).blockLast();
+
         RatingRequestModel ratingRequestModel = RatingRequestModel.builder()
                 .rating((byte) 5)
                 .build();
@@ -311,7 +318,7 @@ class RatingControllerIntegrationTest {
                 });
 
         StepVerifier.create(ratingRepository.findAll())
-                .expectNextCount(5)
+                .expectNextCount(3)
                 .verifyComplete();
     }
 


### PR DESCRIPTION
**JIRA:** [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1414)
## Context:

This ticket fixes a bug where adding a new product without ratings caused a 500 error due to a NullPointerException in the getAverageRating() method. The issue was that the averageRating was set to null, which caused problems with sorting and filtering. The fix now sets averageRating to 0.0 by default
## Does this PR change the .vscode folder in petclinic-frontend?:
No, this PR does not change anything in the .vscode folder.

## Changes

- Updated getAverageRating() method in ProductServiceImpl.java to set averageRating to 0.0 when there are no ratings.
- Fixed tests that were causing issues.

## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://github.com/user-attachments/assets/581c3f27-6506-4b19-a791-8c8371d244e4)

After:
![image](https://github.com/user-attachments/assets/ebc80464-ce01-42e6-a1ad-e2e7db17e5ed)

