### PR TITLE
bug/(PROD-CPC-1316): Product Filter Menu Close Button

### DIFF
--- a/petclinic-frontend/src/features/products/ProductList.css
+++ b/petclinic-frontend/src/features/products/ProductList.css
@@ -141,3 +141,19 @@
   display: flex;
   justify-content: center;
 }
+.close-button {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  padding: 0px;
+  margin: 0px;
+  top: 20px;
+  right: 20px;
+  cursor: pointer;
+  font-size: 2rem;
+  color: black;
+}
+.close-button:hover {
+  color: white;
+  background-color: #ca2020;
+}


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1316?atlOrigin=eyJpIjoiODJiNjAyYjk3NDE0NDIyN2I4ZjVhOTg2N2NjM2M4YWYiLCJwIjoiaiJ9

## Context:
bug where the close filter menu button would only show on hover, now fixed.
## Does this PR change the .vscode folder in petclinic-frontend?:
no

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
Added some CSS to show the button when not hovered and added some styling as well.
## Before and After UI (Required for UI-impacting PRs)
Before:
<img width="542" alt="Screenshot 2024-10-17 at 8 11 57 PM" src="https://github.com/user-attachments/assets/218c8792-aa67-4fc2-b5e2-3767a15bbb71">
<img width="542" alt="Screenshot 2024-10-17 at 8 12 17 PM" src="https://github.com/user-attachments/assets/6522aecf-148a-4c48-a45e-cf449889bf76">

After:
<img width="353" alt="Screenshot 2024-10-17 at 8 06 32 PM" src="https://github.com/user-attachments/assets/ca252446-e548-4fe7-9546-98ea7a2fb429">
<img width="353" alt="Screenshot 2024-10-17 at 8 06 40 PM" src="https://github.com/user-attachments/assets/b7ad23fc-c76b-4717-ac76-ed3c110015b9">
