### PR TITLE
Feat(BILL-CPC-1357): User can see time remaining to pay bill

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillResponseDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillResponseDTO.java
@@ -22,4 +22,5 @@ public class BillResponseDTO {
     private double taxedAmount;
     private BillStatus billStatus;
     private LocalDate dueDate;
+    private Long timeRemaining;
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillResponseDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillResponseDTO.java
@@ -15,8 +15,12 @@ public class BillResponseDTO {
 
     private String billId;
     private String customerId;
+    private String ownerFirstName;
+    private String ownerLastName;
     private String visitType;
     private String vetId;
+    private String vetFirstName;
+    private String vetLastName;
     private LocalDate date;
     private double amount;
     private double taxedAmount;

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -63,6 +63,7 @@ import reactor.test.StepVerifier;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -1894,10 +1895,32 @@ class ApiGatewayControllerTest {
 
     @Test
     void shouldGetAllBills() {
-        BillResponseDTO billResponseDTO = new BillResponseDTO("BillUUID","1","Test type","1",null,25.00, 28.75,BillStatus.PAID,null);
+        BillResponseDTO billResponseDTO =  BillResponseDTO.builder()
+                .billId("BillUUID")
+                .customerId("1")
+                .visitType("Test type")
+                .vetId("1")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,30))
+                .billStatus(BillStatus.UNPAID)
+                .amount(25.00)
+                .taxedAmount(0)
+                .timeRemaining(13L)
+                .build();
 
 
-        BillResponseDTO billResponseDTO2 = new BillResponseDTO("BillUUID2","2","Test type","2",null,27.00, 31.05,BillStatus.UNPAID,null);
+        BillResponseDTO billResponseDTO2 = BillResponseDTO.builder()
+                .billId("BillUUID2")
+                .customerId("2")
+                .visitType("Test type")
+                .vetId("2")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,30))
+                .billStatus(BillStatus.UNPAID)
+                .amount(27.00)
+                .taxedAmount(0)
+                .timeRemaining(13L)
+                .build();
         when(billServiceClient.getAllBilling()).thenReturn(Flux.just(billResponseDTO,billResponseDTO2));
 
         client.get()
@@ -1913,9 +1936,31 @@ class ApiGatewayControllerTest {
 
     @Test
     void shouldGetAllPaidBills() {
-        BillResponseDTO billResponseDTO = new BillResponseDTO("BillUUID","1","Test type","1",null,25.00, 28.75,BillStatus.PAID,null);
+        BillResponseDTO billResponseDTO = BillResponseDTO.builder()
+                .billId("BillUUID")
+                .customerId("1")
+                .visitType("Test type")
+                .vetId("1")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,30))
+                .billStatus(BillStatus.PAID)
+                .amount(25.00)
+                .taxedAmount(0)
+                .timeRemaining(0L)
+                .build();
 
-        BillResponseDTO billResponseDTO2 = new BillResponseDTO("BillUUID2","2","Test type","2",null,27.00, 31.05, BillStatus.PAID,null);
+        BillResponseDTO billResponseDTO2 = BillResponseDTO.builder()
+                .billId("BillUUID2")
+                .customerId("2")
+                .visitType("Test type")
+                .vetId("2")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,30))
+                .billStatus(BillStatus.PAID)
+                .amount(27.00)
+                .taxedAmount(0)
+                .timeRemaining(0L)
+                .build();
         when(billServiceClient.getAllPaidBilling()).thenReturn(Flux.just(billResponseDTO,billResponseDTO2));
 
         client.get()
@@ -1931,9 +1976,31 @@ class ApiGatewayControllerTest {
 
     @Test
     void shouldGetAllUnpaidBills() {
-        BillResponseDTO billResponseDTO = new BillResponseDTO("BillUUID","1","Test type","1",null,25.00, 28.75, BillStatus.UNPAID, null);
+        BillResponseDTO billResponseDTO = BillResponseDTO.builder()
+                .billId("BillUUID")
+                .customerId("1")
+                .visitType("Test type")
+                .vetId("1")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,30))
+                .billStatus(BillStatus.UNPAID)
+                .amount(25.00)
+                .taxedAmount(0)
+                .timeRemaining(13L)
+                .build();
 
-        BillResponseDTO billResponseDTO2 = new BillResponseDTO("BillUUID2","2","Test type","2",null,27.00, 31.05,BillStatus.UNPAID,null);
+        BillResponseDTO billResponseDTO2 = BillResponseDTO.builder()
+                .billId("BillUUID2")
+                .customerId("2")
+                .visitType("Test type")
+                .vetId("2")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,30))
+                .billStatus(BillStatus.UNPAID)
+                .amount(27.00)
+                .taxedAmount(0)
+                .timeRemaining(13L)
+                .build();
         when(billServiceClient.getAllUnpaidBilling()).thenReturn(Flux.just(billResponseDTO,billResponseDTO2));
 
         client.get()
@@ -1949,9 +2016,31 @@ class ApiGatewayControllerTest {
 
     @Test
     void shouldGetAllOverdueBills() {
-        BillResponseDTO billResponseDTO = new BillResponseDTO("BillUUID","1","Test type","1",null,25.00, 28.75, BillStatus.OVERDUE,null);
+        BillResponseDTO billResponseDTO = BillResponseDTO.builder()
+                .billId("BillUUID")
+                .customerId("1")
+                .visitType("Test type")
+                .vetId("1")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,8))
+                .billStatus(BillStatus.OVERDUE)
+                .amount(25.00)
+                .taxedAmount(0)
+                .timeRemaining(0L)
+                .build();
 
-        BillResponseDTO billResponseDTO2 = new BillResponseDTO("BillUUID2","2","Test type","2",null,27.00, 31.05, BillStatus.OVERDUE, null);
+        BillResponseDTO billResponseDTO2 = BillResponseDTO.builder()
+                .billId("BillUUID2")
+                .customerId("2")
+                .visitType("Test type")
+                .vetId("2")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,8))
+                .billStatus(BillStatus.OVERDUE)
+                .amount(27.00)
+                .taxedAmount(0)
+                .timeRemaining(0L)
+                .build();
         when(billServiceClient.getAllOverdueBilling()).thenReturn(Flux.just(billResponseDTO,billResponseDTO2));
 
         client.get()

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillService.java
@@ -1,6 +1,7 @@
 package com.petclinic.billing.businesslayer;
 
 
+import com.petclinic.billing.datalayer.Bill;
 import com.petclinic.billing.datalayer.BillRequestDTO;
 import com.petclinic.billing.datalayer.BillResponseDTO;
 import com.petclinic.billing.datalayer.BillStatus;
@@ -17,6 +18,7 @@ public interface BillService {
 
     Flux<BillResponseDTO> GetAllBillsByStatus(BillStatus status);
 
+    Mono<Bill>CreateBillForDB(Mono<Bill> bill);
 
     Flux<BillResponseDTO> GetAllBills();
 

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -42,8 +42,8 @@ public class BillServiceImpl implements BillService{
                 })
                 .map(EntityDtoUtil::toBillResponseDto)
                 .doOnNext(t -> t.setTaxedAmount(((t.getAmount() * 15)/100)+ t.getAmount()))
-                .doOnNext(t -> t.setTaxedAmount(Math.round(t.getTaxedAmount() * 100.0) / 100.0))
-                .doOnNext(t -> t.setTimeRemaining(timeRemaining(t)));
+                .doOnNext(t -> t.setTaxedAmount(Math.round(t.getTaxedAmount() * 100.0) / 100.0));
+               // .doOnNext(t -> t.setTimeRemaining(timeRemaining(t)));
     }
 
     @Override
@@ -211,7 +211,7 @@ public class BillServiceImpl implements BillService{
         return billRepository.deleteBillsByCustomerId(customerId);
 
     }
-
+/*
     private long timeRemaining(BillResponseDTO bill){
         if (bill.getDueDate().isBefore(LocalDate.now())) {
             return 0;
@@ -219,6 +219,8 @@ public class BillServiceImpl implements BillService{
 
         return Duration.between(LocalDate.now().atStartOfDay(), bill.getDueDate().atStartOfDay()).toDays();
     }
+
+ */
 
 
 

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -10,6 +10,7 @@ import com.petclinic.billing.util.EntityDtoUtil;
 import com.petclinic.billing.util.PdfGenerator;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -25,6 +26,7 @@ import java.util.function.Predicate;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class BillServiceImpl implements BillService{
 
     private final BillRepository billRepository;
@@ -34,7 +36,11 @@ public class BillServiceImpl implements BillService{
     @Override
     public Mono<BillResponseDTO> getBillByBillId(String billUUID) {
 
-        return billRepository.findByBillId(billUUID).map(EntityDtoUtil::toBillResponseDto)
+        return billRepository.findByBillId(billUUID)
+                .doOnNext(bill -> {
+                    log.info("Retrieved Bill: {}", bill);
+                })
+                .map(EntityDtoUtil::toBillResponseDto)
                 .doOnNext(t -> t.setTaxedAmount(((t.getAmount() * 15)/100)+ t.getAmount()))
                 .doOnNext(t -> t.setTaxedAmount(Math.round(t.getTaxedAmount() * 100.0) / 100.0))
                 .doOnNext(t -> t.setTimeRemaining(timeRemaining(t)));

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
@@ -27,4 +27,5 @@ public class Bill {
     private double taxedAmount;
     private BillStatus billStatus;
     private LocalDate dueDate;
+    private Long timeRemaining;
 }

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
@@ -27,5 +27,4 @@ public class Bill {
     private double taxedAmount;
     private BillStatus billStatus;
     private LocalDate dueDate;
-    private Long timeRemaining;
 }

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillResponseDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillResponseDTO.java
@@ -1,5 +1,6 @@
 package com.petclinic.billing.datalayer;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
 import java.time.LocalDate;

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillResponseDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillResponseDTO.java
@@ -24,6 +24,6 @@ public class BillResponseDTO {
     private double taxedAmount;
     private BillStatus billStatus;
     private LocalDate dueDate;
-
+    private Long timeRemaining;
 
     }

--- a/billing-service/src/main/java/com/petclinic/billing/util/DataSetupService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/util/DataSetupService.java
@@ -31,7 +31,7 @@ public class DataSetupService implements CommandLineRunner {
 
         Bill b1 = Bill.builder()
                 .billId(UUID.randomUUID().toString())
-                .customerId("470653d-05c5-4c45-b7a0-7d70f003d2ac")
+                .customerId("f470653d-05c5-4c45-b7a0-7d70f003d2ac")
                 .ownerFirstName("George")
                 .ownerLastName("Doe")
                 .visitType("Regular")
@@ -47,7 +47,7 @@ public class DataSetupService implements CommandLineRunner {
 
         Bill b2 = Bill.builder()
                 .billId(UUID.randomUUID().toString())
-                .customerId("470653d-05c5-4c45-b7a0-7d70f003d2ac")
+                .customerId("f470653d-05c5-4c45-b7a0-7d70f003d2ac")
                 .ownerFirstName("George")
                 .ownerLastName("Doe")
                 .visitType("Regular")
@@ -63,7 +63,7 @@ public class DataSetupService implements CommandLineRunner {
 
         Bill b3 = Bill.builder()
                 .billId(UUID.randomUUID().toString())
-                .customerId("470653d-05c5-4c45-b7a0-7d70f003d2ac")
+                .customerId("f470653d-05c5-4c45-b7a0-7d70f003d2ac")
                 .ownerFirstName("George")
                 .ownerLastName("Doe")
                 .visitType("Regular")
@@ -79,7 +79,7 @@ public class DataSetupService implements CommandLineRunner {
 
         Bill b4 = Bill.builder()
                 .billId(UUID.randomUUID().toString())
-                .customerId("470653d-05c5-4c45-b7a0-7d70f003d2ac")
+                .customerId("f470653d-05c5-4c45-b7a0-7d70f003d2ac")
                 .ownerFirstName("George")
                 .ownerLastName("Doe")
                 .visitType("Regular")

--- a/billing-service/src/main/java/com/petclinic/billing/util/DataSetupService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/util/DataSetupService.java
@@ -2,19 +2,24 @@ package com.petclinic.billing.util;
 
 
 import com.petclinic.billing.businesslayer.BillService;
+import com.petclinic.billing.datalayer.Bill;
+import com.petclinic.billing.datalayer.BillRepository;
 import com.petclinic.billing.datalayer.BillRequestDTO;
 import com.petclinic.billing.datalayer.BillStatus;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import java.time.LocalDate;
+import java.util.UUID;
 
 
 @Service
 public class DataSetupService implements CommandLineRunner {
-    private final BillService billService;
+    @Autowired
+    BillService billService;
+
     public DataSetupService(BillService billService) {
         this.billService = billService;
     }
@@ -24,44 +29,263 @@ public class DataSetupService implements CommandLineRunner {
     public void run(String... args) throws Exception {
 
 
-        BillRequestDTO b1 = new BillRequestDTO( "f470653d-05c5-4c45-b7a0-7d70f003d2ac", "general", "1", LocalDate.of(2023,9,19),59.99, BillStatus.PAID, LocalDate.of(2023, 10,3));
-        BillRequestDTO b3 = new BillRequestDTO( "f470653d-05c5-4c45-b7a0-7d70f003d2ac", "operation", "1", LocalDate.of(2023,9,27), 199.99,BillStatus.PAID,LocalDate.of(2023, 10,11));
-        BillRequestDTO b4 = new BillRequestDTO( "f470653d-05c5-4c45-b7a0-7d70f003d2ac", "injury", "1",  LocalDate.of(2023,10,11), 199.99,BillStatus.UNPAID,LocalDate.of(2023, 10,25));
-        BillRequestDTO b2 = new BillRequestDTO( "f470653d-05c5-4c45-b7a0-7d70f003d2ac", "operation", "2", LocalDate.of(2023,10,6), 199.99,BillStatus.OVERDUE,LocalDate.of(2023, 10,20));
-        BillRequestDTO b5 = new BillRequestDTO( "e6c7398e-8ac4-4e10-9ee0-03ef33f0361a", "chronic", "3",  LocalDate.of(2023,10,13), 199.99,BillStatus.UNPAID,LocalDate.of(2023, 10,27));
-        BillRequestDTO b6 = new BillRequestDTO("e6c7398e-8ac4-4e10-9ee0-03ef33f0361a", "general", "2", LocalDate.of(2023, 10, 5), 59.99, BillStatus.PAID, LocalDate.of(2023, 10, 10));
-        BillRequestDTO b7 = new BillRequestDTO("e6c7398e-8ac4-4e10-9ee0-03ef33f0361a", "operation", "3", LocalDate.of(2023, 10, 8), 199.99, BillStatus.PAID, LocalDate.of(2023, 10, 14));
-        BillRequestDTO b8 = new BillRequestDTO("e6c7398e-8ac4-4e10-9ee0-03ef33f0361a", "injury", "2", LocalDate.of(2023, 10, 15), 199.99, BillStatus.OVERDUE, LocalDate.of(2023, 10, 30));
-        BillRequestDTO b9 = new BillRequestDTO("e6c7398e-8ac4-4e10-9ee0-03ef33f0361a", "chronic", "1", LocalDate.of(2023, 10, 18), 199.99, BillStatus.UNPAID, LocalDate.of(2023, 11, 2));
-        BillRequestDTO b10 = new BillRequestDTO("3f59dca2-903e-495c-90c3-7f4d01f3a2aa", "general", "3", LocalDate.of(2023, 10, 21), 59.99, BillStatus.UNPAID, LocalDate.of(2023, 11, 6));
-        BillRequestDTO b11 = new BillRequestDTO("3f59dca2-903e-495c-90c3-7f4d01f3a2aa", "operation", "1", LocalDate.of(2023, 10, 24), 199.99, BillStatus.PAID, LocalDate.of(2023, 11, 10));
-        BillRequestDTO b12 = new BillRequestDTO("a6e0e5b0-5f60-45f0-8ac7-becd8b330486", "injury", "3", LocalDate.of(2023, 10, 27), 199.99, BillStatus.OVERDUE, LocalDate.of(2023, 11, 14));
-        BillRequestDTO b13 = new BillRequestDTO("a6e0e5b0-5f60-45f0-8ac7-becd8b330486", "chronic", "2", LocalDate.of(2023, 10, 30), 199.99, BillStatus.UNPAID, LocalDate.of(2023, 11, 18));
-        BillRequestDTO b14 = new BillRequestDTO("a6e0e5b0-5f60-45f0-8ac7-becd8b330486", "general", "1", LocalDate.of(2023, 11, 2), 59.99, BillStatus.PAID, LocalDate.of(2023, 11, 22));
-        BillRequestDTO b15 = new BillRequestDTO("c6a0fb9d-fc6f-4c21-95fc-4f5e7311d0e2", "operation", "2", LocalDate.of(2023, 11, 5), 199.99, BillStatus.UNPAID, LocalDate.of(2023, 11, 26));
-        BillRequestDTO b16 = new BillRequestDTO("c6a0fb9d-fc6f-4c21-95fc-4f5e7311d0e2", "injury", "1", LocalDate.of(2023, 11, 8), 199.99, BillStatus.PAID, LocalDate.of(2023, 12, 2));
-        BillRequestDTO b17 = new BillRequestDTO("b3d09eab-4085-4b2d-a121-78a0a2f9e501", "chronic", "3", LocalDate.of(2023, 11, 11), 199.99, BillStatus.OVERDUE, LocalDate.of(2023, 12, 6));
-        BillRequestDTO b18 = new BillRequestDTO("b3d09eab-4085-4b2d-a121-78a0a2f9e501", "general", "2", LocalDate.of(2023, 11, 14), 59.99, BillStatus.PAID, LocalDate.of(2023, 12, 10));
-        BillRequestDTO b19 = new BillRequestDTO("b3d09eab-4085-4b2d-a121-78a0a2f9e501", "operation", "3", LocalDate.of(2023, 11, 17), 199.99, BillStatus.UNPAID, LocalDate.of(2023, 12, 14));
-        BillRequestDTO b20 = new BillRequestDTO("b3d09eab-4085-4b2d-a121-78a0a2f9e501", "injury", "1", LocalDate.of(2023, 11, 20), 199.99, BillStatus.PAID, LocalDate.of(2023, 12, 18));
-        BillRequestDTO b21 = new BillRequestDTO("b3d09eab-4085-4b2d-a121-78a0a2f9e501", "chronic", "2", LocalDate.of(2023, 11, 23), 199.99, BillStatus.OVERDUE, LocalDate.of(2023, 12, 22));
-        BillRequestDTO b22 = new BillRequestDTO("5fe81e29-1f1d-4f9d-b249-8d3e0cc0b7dd", "general", "3", LocalDate.of(2023, 11, 26), 59.99, BillStatus.PAID, LocalDate.of(2023, 12, 26));
-        BillRequestDTO b23 = new BillRequestDTO("48f9945a-4ee0-4b0b-9b44-3da829a0f0f7", "operation", "2", LocalDate.of(2023, 11, 29), 199.99, BillStatus.UNPAID, LocalDate.of(2023, 12, 30));
-        BillRequestDTO b24 = new BillRequestDTO("48f9945a-4ee0-4b0b-9b44-3da829a0f0f7", "injury", "1", LocalDate.of(2023, 12, 2), 199.99, BillStatus.PAID, LocalDate.of(2024, 1, 2));
-        BillRequestDTO b25 = new BillRequestDTO("48f9945a-4ee0-4b0b-9b44-3da829a0f0f7", "chronic", "3", LocalDate.of(2023, 12, 5), 199.99, BillStatus.OVERDUE, LocalDate.of(2024, 1, 6));
-        BillRequestDTO b26 = new BillRequestDTO("48f9945a-4ee0-4b0b-9b44-3da829a0f0f7", "general", "2", LocalDate.of(2023, 12, 8), 59.99, BillStatus.UNPAID, LocalDate.of(2024, 1, 10));
-        BillRequestDTO b27 = new BillRequestDTO("48f9945a-4ee0-4b0b-9b44-3da829a0f0f7", "operation", "3", LocalDate.of(2023, 12, 11), 199.99, BillStatus.PAID, LocalDate.of(2024, 1, 14));
-        BillRequestDTO b28 = new BillRequestDTO("9f6accd1-e943-4322-932e-199d93824317", "injury", "1", LocalDate.of(2023, 12, 14), 199.99, BillStatus.PAID, LocalDate.of(2024, 1, 18));
-        BillRequestDTO b29 = new BillRequestDTO("9f6accd1-e943-4322-932e-199d93824317", "chronic", "2", LocalDate.of(2023, 12, 17), 199.99, BillStatus.OVERDUE, LocalDate.of(2024, 1, 22));
-        BillRequestDTO b30 = new BillRequestDTO("7c0d42c2-0c2d-41ce-bd9c-6ca67478956f", "general", "3", LocalDate.of(2023, 12, 20), 59.99, BillStatus.UNPAID, LocalDate.of(2024, 1, 26));
+        Bill b1 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("470653d-05c5-4c45-b7a0-7d70f003d2ac")
+                .ownerFirstName("George")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("1")
+                .vetFirstName("Jane")
+                .vetLastName("Doe")
+                .date(LocalDate.of(2024, 3, 1))
+                .amount(300.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.PAID)
+                .dueDate(LocalDate.of(2024, 3, 31))
+                .timeRemaining(0L)
+                .build();
 
-        Flux.just(b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17, b18, b19, b20, b21, b22, b23, b24, b25, b26, b27, b28, b29, b30)
-                .flatMap(b -> billService.CreateBill(Mono.just(b))
-                        .log(b.toString()))
-                .subscribe();
+        Bill b2 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("470653d-05c5-4c45-b7a0-7d70f003d2ac")
+                .ownerFirstName("George")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("1")
+                .vetFirstName("Jane")
+                .vetLastName("Doe")
+                .date(LocalDate.of(2024, 4, 1))
+                .amount(167.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.PAID)
+                .dueDate(LocalDate.of(2024, 4, 30))
+                .timeRemaining(0L)
+                .build();
 
-        Flux.just(b1,b2,b3,b4,b5)
-                .flatMap(b -> billService.CreateBill(Mono.just(b))
+        Bill b3 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("470653d-05c5-4c45-b7a0-7d70f003d2ac")
+                .ownerFirstName("George")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("1")
+                .vetFirstName("Jane")
+                .vetLastName("Doe")
+                .date(LocalDate.of(2024, 5, 1))
+                .amount(150.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.UNPAID)
+                .dueDate(LocalDate.of(2024, 5, 31))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b4 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("470653d-05c5-4c45-b7a0-7d70f003d2ac")
+                .ownerFirstName("George")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("2")
+                .vetFirstName("James")
+                .vetLastName("Patterson")
+                .date(LocalDate.of(2024, 6, 1))
+                .amount(200.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.UNPAID)
+                .dueDate(LocalDate.of(2024, 6, 30))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b5 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("e6c7398e-8ac4-4e10-9ee0-03ef33f0361a")
+                .ownerFirstName("Betty")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("2")
+                .vetFirstName("James")
+                .vetLastName("Patterson")
+                .date(LocalDate.of(2024, 7, 1))
+                .amount(130.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.UNPAID)
+                .dueDate(LocalDate.of(2024, 7, 31))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b6 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("3f59dca2-903e-495c-90c3-7f4d01f3a2aa")
+                .ownerFirstName("Jane")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("3")
+                .vetFirstName("John")
+                .vetLastName("Doe")
+                .date(LocalDate.of(2024, 8, 1))
+                .amount(100.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.UNPAID)
+                .dueDate(LocalDate.of(2024, 8, 30))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b7 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("3f59dca2-903e-495c-90c3-7f4d01f3a2aa")
+                .ownerFirstName("Edurado")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("4")
+                .vetFirstName("Max")
+                .vetLastName("Lincoln")
+                .date(LocalDate.of(2024, 9, 1))
+                .amount(200.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.UNPAID)
+                .dueDate(LocalDate.of(2024, 9, 30))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b8 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("a6e0e5b0-5f60-45f0-8ac7-becd8b330486")
+                .ownerFirstName("Harold")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("5")
+                .vetFirstName("Kim")
+                .vetLastName("Zimmerman")
+                .date(LocalDate.of(2024, 3, 1))
+                .amount(150.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.UNPAID)
+                .dueDate(LocalDate.of(2024, 4, 30))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b9 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("a6e0e5b0-5f60-45f0-8ac7-becd8b330486")
+                .ownerFirstName("Harold")
+                .ownerLastName("Doe")
+                .visitType("Emergency")
+                .vetId("5")
+                .vetFirstName("Kim")
+                .vetLastName("Zimmerman")
+                .date(LocalDate.of(2024, 5, 1))
+                .amount(400.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.PAID)
+                .dueDate(LocalDate.of(2024, 5, 31))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b10 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("c6a0fb9d-fc6f-4c21-95fc-4f5e7311d0e2")
+                .ownerFirstName("Peter")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("5")
+                .vetFirstName("Kim")
+                .vetLastName("Zimmerman")
+                .date(LocalDate.of(2024, 6, 1))
+                .amount(150.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.PAID)
+                .dueDate(LocalDate.of(2024, 6, 30))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b11 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("b3d09eab-4085-4b2d-a121-78a0a2f9e501")
+                .ownerFirstName("Jean")
+                .ownerLastName("LeBlanc")
+                .visitType("Emergency")
+                .vetId("5")
+                .vetFirstName("Kim")
+                .vetLastName("Zimmerman")
+                .date(LocalDate.of(2024, 7, 1))
+                .amount(500.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.UNPAID)
+                .dueDate(LocalDate.of(2024, 8, 31))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b12 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("5fe81e29-1f1d-4f9d-b249-8d3e0cc0b7dd")
+                .ownerFirstName("Jeff")
+                .ownerLastName("Patterson")
+                .visitType("Regular")
+                .vetId("2")
+                .vetFirstName("James")
+                .vetLastName("Patterson")
+                .date(LocalDate.of(2024, 8, 1))
+                .amount(150.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.PAID)
+                .dueDate(LocalDate.of(2024, 8, 30))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b13 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("48f9945a-4ee0-4b0b-9b44-3da829a0f0f7")
+                .ownerFirstName("Maria")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("2")
+                .vetFirstName("James")
+                .vetLastName("Patterson")
+                .date(LocalDate.of(2024, 9, 1))
+                .amount(200.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.UNPAID)
+                .dueDate(LocalDate.of(2024, 9, 30))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b14 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("9f6accd1-e943-4322-932e-199d93824317")
+                .ownerFirstName("David")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("2")
+                .vetFirstName("James")
+                .vetLastName("Patterson")
+                .date(LocalDate.of(2024, 4, 1))
+                .amount(150.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.PAID)
+                .dueDate(LocalDate.of(2024, 4, 30))
+                .timeRemaining(0L)
+                .build();
+
+        Bill b15 = Bill.builder()
+                .billId(UUID.randomUUID().toString())
+                .customerId("7c0d42c2-0c2d-41ce-bd9c-6ca67478956f")
+                .ownerFirstName("Carlos")
+                .ownerLastName("Doe")
+                .visitType("Regular")
+                .vetId("2")
+                .vetFirstName("James")
+                .vetLastName("Patterson")
+                .date(LocalDate.of(2024, 5, 1))
+                .amount(150.0)
+                .taxedAmount(0.0)
+                .billStatus(BillStatus.UNPAID)
+                .dueDate(LocalDate.of(2024, 5, 31))
+                .timeRemaining(0L)
+                .build();
+
+        Flux.just(b1,b2,b3,b4,b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15)
+                .flatMap(b -> billService.CreateBillForDB(Mono.just(b))
                         .log(b.toString()))
                 .subscribe();
     }

--- a/billing-service/src/main/java/com/petclinic/billing/util/DataSetupService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/util/DataSetupService.java
@@ -41,9 +41,8 @@ public class DataSetupService implements CommandLineRunner {
                 .date(LocalDate.of(2024, 3, 1))
                 .amount(300.0)
                 .taxedAmount(0.0)
-                .billStatus(BillStatus.PAID)
+                .billStatus(BillStatus.OVERDUE)
                 .dueDate(LocalDate.of(2024, 3, 31))
-                .timeRemaining(0L)
                 .build();
 
         Bill b2 = Bill.builder()
@@ -60,7 +59,6 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 4, 30))
-                .timeRemaining(0L)
                 .build();
 
         Bill b3 = Bill.builder()
@@ -75,9 +73,8 @@ public class DataSetupService implements CommandLineRunner {
                 .date(LocalDate.of(2024, 5, 1))
                 .amount(150.0)
                 .taxedAmount(0.0)
-                .billStatus(BillStatus.UNPAID)
+                .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 5, 31))
-                .timeRemaining(0L)
                 .build();
 
         Bill b4 = Bill.builder()
@@ -92,9 +89,8 @@ public class DataSetupService implements CommandLineRunner {
                 .date(LocalDate.of(2024, 6, 1))
                 .amount(200.0)
                 .taxedAmount(0.0)
-                .billStatus(BillStatus.UNPAID)
+                .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 6, 30))
-                .timeRemaining(0L)
                 .build();
 
         Bill b5 = Bill.builder()
@@ -106,12 +102,11 @@ public class DataSetupService implements CommandLineRunner {
                 .vetId("2")
                 .vetFirstName("James")
                 .vetLastName("Patterson")
-                .date(LocalDate.of(2024, 7, 1))
+                .date(LocalDate.of(2024, 10, 1))
                 .amount(130.0)
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.UNPAID)
-                .dueDate(LocalDate.of(2024, 7, 31))
-                .timeRemaining(0L)
+                .dueDate(LocalDate.of(2024, 11, 30))
                 .build();
 
         Bill b6 = Bill.builder()
@@ -128,7 +123,6 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.UNPAID)
                 .dueDate(LocalDate.of(2024, 8, 30))
-                .timeRemaining(0L)
                 .build();
 
         Bill b7 = Bill.builder()
@@ -143,9 +137,8 @@ public class DataSetupService implements CommandLineRunner {
                 .date(LocalDate.of(2024, 9, 1))
                 .amount(200.0)
                 .taxedAmount(0.0)
-                .billStatus(BillStatus.UNPAID)
+                .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 9, 30))
-                .timeRemaining(0L)
                 .build();
 
         Bill b8 = Bill.builder()
@@ -160,9 +153,8 @@ public class DataSetupService implements CommandLineRunner {
                 .date(LocalDate.of(2024, 3, 1))
                 .amount(150.0)
                 .taxedAmount(0.0)
-                .billStatus(BillStatus.UNPAID)
+                .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 4, 30))
-                .timeRemaining(0L)
                 .build();
 
         Bill b9 = Bill.builder()
@@ -179,7 +171,6 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 5, 31))
-                .timeRemaining(0L)
                 .build();
 
         Bill b10 = Bill.builder()
@@ -196,7 +187,6 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 6, 30))
-                .timeRemaining(0L)
                 .build();
 
         Bill b11 = Bill.builder()
@@ -211,9 +201,8 @@ public class DataSetupService implements CommandLineRunner {
                 .date(LocalDate.of(2024, 7, 1))
                 .amount(500.0)
                 .taxedAmount(0.0)
-                .billStatus(BillStatus.UNPAID)
-                .dueDate(LocalDate.of(2024, 8, 31))
-                .timeRemaining(0L)
+                .billStatus(BillStatus.PAID)
+                .dueDate(LocalDate.of(2024, 8, 30))
                 .build();
 
         Bill b12 = Bill.builder()
@@ -230,7 +219,6 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 8, 30))
-                .timeRemaining(0L)
                 .build();
 
         Bill b13 = Bill.builder()
@@ -242,12 +230,11 @@ public class DataSetupService implements CommandLineRunner {
                 .vetId("2")
                 .vetFirstName("James")
                 .vetLastName("Patterson")
-                .date(LocalDate.of(2024, 9, 1))
+                .date(LocalDate.of(2024, 10, 1))
                 .amount(200.0)
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.UNPAID)
-                .dueDate(LocalDate.of(2024, 9, 30))
-                .timeRemaining(0L)
+                .dueDate(LocalDate.of(2024, 11, 30))
                 .build();
 
         Bill b14 = Bill.builder()
@@ -264,7 +251,6 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 4, 30))
-                .timeRemaining(0L)
                 .build();
 
         Bill b15 = Bill.builder()
@@ -276,12 +262,11 @@ public class DataSetupService implements CommandLineRunner {
                 .vetId("2")
                 .vetFirstName("James")
                 .vetLastName("Patterson")
-                .date(LocalDate.of(2024, 5, 1))
+                .date(LocalDate.of(2024, 10, 1))
                 .amount(150.0)
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.UNPAID)
-                .dueDate(LocalDate.of(2024, 5, 31))
-                .timeRemaining(0L)
+                .dueDate(LocalDate.of(2024, 11, 30))
                 .build();
 
         Flux.just(b1,b2,b3,b4,b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15)

--- a/billing-service/src/main/java/com/petclinic/billing/util/EntityDtoUtil.java
+++ b/billing-service/src/main/java/com/petclinic/billing/util/EntityDtoUtil.java
@@ -7,6 +7,8 @@ import com.petclinic.billing.datalayer.BillRequestDTO;
 import com.petclinic.billing.datalayer.BillResponseDTO;
 import org.springframework.beans.BeanUtils;
 
+import java.time.Duration;
+import java.time.LocalDate;
 import java.util.UUID;
 
 
@@ -16,7 +18,21 @@ public class EntityDtoUtil {
 
     public static BillResponseDTO toBillResponseDto(Bill bill){
         BillResponseDTO billResponseDTO =new BillResponseDTO();
-        BeanUtils.copyProperties(bill,billResponseDTO);
+        //BeanUtils.copyProperties(bill,billResponseDTO);
+        billResponseDTO.setBillId(bill.getBillId());
+        billResponseDTO.setCustomerId(bill.getCustomerId());
+        billResponseDTO.setOwnerFirstName(bill.getOwnerFirstName());
+        billResponseDTO.setOwnerLastName(bill.getOwnerLastName());
+        billResponseDTO.setVisitType(bill.getVisitType());
+        billResponseDTO.setVetId(bill.getVetId());
+        billResponseDTO.setVetFirstName(bill.getVetFirstName());
+        billResponseDTO.setVetLastName(bill.getVetLastName());
+        billResponseDTO.setDate(bill.getDate());
+        billResponseDTO.setAmount(bill.getAmount());
+        billResponseDTO.setTaxedAmount(bill.getTaxedAmount());
+        billResponseDTO.setBillStatus(bill.getBillStatus());
+        billResponseDTO.setDueDate(bill.getDueDate());
+        billResponseDTO.setTimeRemaining(timeRemaining(bill));
         return billResponseDTO;
     }
 
@@ -24,6 +40,14 @@ public class EntityDtoUtil {
         Bill bill = new Bill();
         BeanUtils.copyProperties(billRequestDTO,bill);
         return bill;
+    }
+
+    private static long timeRemaining(Bill bill){
+        if (bill.getDueDate().isBefore(LocalDate.now())) {
+            return 0;
+        }
+
+        return Duration.between(LocalDate.now().atStartOfDay(), bill.getDueDate().atStartOfDay()).toDays();
     }
 
 //    public static Bill toBillEntityRC(RequestContextAdd rc){

--- a/billing-service/src/main/java/com/petclinic/billing/util/EntityDtoUtil.java
+++ b/billing-service/src/main/java/com/petclinic/billing/util/EntityDtoUtil.java
@@ -5,13 +5,14 @@ package com.petclinic.billing.util;
 import com.petclinic.billing.datalayer.Bill;
 import com.petclinic.billing.datalayer.BillRequestDTO;
 import com.petclinic.billing.datalayer.BillResponseDTO;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeanUtils;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.util.UUID;
 
-
+@Slf4j
 public class EntityDtoUtil {
 
 
@@ -33,6 +34,10 @@ public class EntityDtoUtil {
         billResponseDTO.setBillStatus(bill.getBillStatus());
         billResponseDTO.setDueDate(bill.getDueDate());
         billResponseDTO.setTimeRemaining(timeRemaining(bill));
+
+        log.info("Mapped BillResponseDTO: {}", billResponseDTO);
+
+
         return billResponseDTO;
     }
 

--- a/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
@@ -87,6 +87,8 @@ public class BillServiceImplTest {
                 .vetId("vetId1")
                 .vetFirstName("vetFirstName1")
                 .vetLastName("vetLastName1")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,30))
                 .build();
         Bill bill2 = Bill.builder()
                 .billId("billId-2")
@@ -97,6 +99,8 @@ public class BillServiceImplTest {
                 .vetId("vetId2")
                 .vetFirstName("vetFirstName2")
                 .vetLastName("vetLastName2")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,30))
                 .build();
         Bill bill3 = Bill.builder()
                 .billId("billId-3")
@@ -107,6 +111,8 @@ public class BillServiceImplTest {
                 .vetId("vetId3")
                 .vetFirstName("vetFirstName3")
                 .vetLastName("vetLastName3")
+                .date(LocalDate.of(2024,10,1))
+                .dueDate(LocalDate.of(2024,10,30))
                 .build();
 
         Pageable pageable = PageRequest.of(0, 2);

--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/CustomerBillsControllerIntegrationTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/CustomerBillsControllerIntegrationTest.java
@@ -75,16 +75,14 @@ public class CustomerBillsControllerIntegrationTest {
     }
 
     private Bill buildBill() {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2022, Calendar.SEPTEMBER, 25);
-        LocalDate date = calendar.getTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
         return Bill.builder()
                 .billId("1")
                 .customerId("custId")
                 .vetId("vetId")
                 .visitType("surgery")
-                .date(date)
+                .date(LocalDate.now().minusDays(10))
                 .amount(150.0)
+                .dueDate(LocalDate.now().plusDays(20))
                 .build();
     }
 

--- a/petclinic-frontend/src/features/bills/BillsListTable.tsx
+++ b/petclinic-frontend/src/features/bills/BillsListTable.tsx
@@ -167,9 +167,7 @@ export default function BillsListTable(): JSX.Element {
                   <td>{bill.amount}</td>
                   <td>{bill.taxedAmount}</td>
                   <td>
-                    {bill.billStatus === 'PAID' ? (
-                      <span>Bill is paid</span>
-                    ) : bill.billStatus === 'OVERDUE' ? (
+                    {bill.billStatus === 'OVERDUE' ? (
                       <span style={{ color: 'red' }}>Overdue</span>
                     ) : (
                       bill.billStatus

--- a/petclinic-frontend/src/features/bills/BillsListTable.tsx
+++ b/petclinic-frontend/src/features/bills/BillsListTable.tsx
@@ -116,8 +116,6 @@ export default function BillsListTable(): JSX.Element {
 
   return (
     <div>
-      <h2>Bills</h2>
-
       {/* Dropdown to filter bills by status */}
       <div>
         <label htmlFor="statusFilter">Filter by Status:</label>

--- a/petclinic-frontend/src/features/bills/BillsListTable.tsx
+++ b/petclinic-frontend/src/features/bills/BillsListTable.tsx
@@ -150,6 +150,7 @@ export default function BillsListTable(): JSX.Element {
                 <th>Taxed Amount</th>
                 <th>Status</th>
                 <th>Due Date</th>
+                <th>Time Remaining</th>
                 <th>Download PDF</th>
               </tr>
             </thead>
@@ -167,8 +168,27 @@ export default function BillsListTable(): JSX.Element {
                   <td>{bill.date}</td>
                   <td>{bill.amount}</td>
                   <td>{bill.taxedAmount}</td>
-                  <td>{bill.billStatus}</td>
+                  <td>
+                    {bill.billStatus === 'PAID' ? (
+                      <span>Bill is paid</span>
+                    ) : bill.billStatus === 'OVERDUE' ? (
+                      <span style={{ color: 'red' }}>Overdue</span>
+                    ) : (
+                      bill.billStatus
+                    )}
+                  </td>
                   <td>{bill.dueDate}</td>
+                  <td>
+                    {bill.billStatus === 'PAID' ? (
+                      <span>This bill is paid</span>
+                    ) : bill.timeRemaining === 0 ? (
+                      <span style={{ color: 'red' }}>
+                        0 days remaining to pay bill
+                      </span>
+                    ) : (
+                      `${bill.timeRemaining} days remaining to pay bill`
+                    )}
+                  </td>
                   <td>
                     <button
                       onClick={() =>

--- a/petclinic-frontend/src/features/bills/models/Bill.ts
+++ b/petclinic-frontend/src/features/bills/models/Bill.ts
@@ -12,4 +12,5 @@ export interface Bill {
   taxedAmount: number;
   billStatus: string;
   dueDate: string;
+  timeRemaining: number;
 }


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1357

## Context:

As a customer I want to be able to see the time remaining for my unpaid bills.


Acceptance criteria:

   1. Customer should see the days remaining to pay their unpaid or overdue bills.

   2.The time remaining should only apply to unpaid or overdue bills. PAID bills should have a bills paid or equivalent instead.

## Does this PR change the .vscode folder in petclinic-frontend?:
It does not.

## Changes

- Changed db loader to load bills instead of bill request dtos.
- Changed bill response to have the new field time remaining.
- Changed bill response in api-gateway to have the new field time remaining. 
- Changed bill response in api-gateway to have the vet name and owner name fields.
- Fixed old tests and added new ones to the both the bill testing in the API Gateway and the Bill service.
- Added new method in EntityDtoUtil  to calculate time remaining. 
- Added the time remaining feature to the frontend as well as changed some for the styling for the bill status. 

## Before and After UI (Required for UI-impacting PRs)

<h3> Before </h3>

![image](https://github.com/user-attachments/assets/25593f51-f31e-496a-a30d-fc677a986f2c)

**(Took this from a previous pull request so ignore the red squares)**

<h3> After </h3>


![image](https://github.com/user-attachments/assets/ee47f924-e5f6-426d-bc16-fb5e12cfd36e)


