### PR TITLE
feat(VETS-CPC-1373): add education

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -177,6 +177,7 @@ public class VetController {
         return vetsServiceClient.getEducationsByVetId(vetId);
     }
 
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.VET})
     @PostMapping("{vetId}/educations")
     public Mono<ResponseEntity<EducationResponseDTO>> addEducationToVet(
             @PathVariable String vetId,

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -177,6 +177,16 @@ public class VetController {
         return vetsServiceClient.getEducationsByVetId(vetId);
     }
 
+    @PostMapping("{vetId}/educations")
+    public Mono<ResponseEntity<EducationResponseDTO>> addEducationToVet(
+            @PathVariable String vetId,
+            @RequestBody Mono<EducationRequestDTO> educationRequestDTOMono) {
+
+        return vetsServiceClient.addEducationToAVet(vetId, educationRequestDTOMono)
+                .map(education -> ResponseEntity.status(HttpStatus.CREATED).body(education))
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
+    }
+
     @SecuredEndpoint(allowedRoles = {Roles.ANONYMOUS})
     @PutMapping(value = "/{vetId}/educations/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<EducationResponseDTO>> updateEducationByVetIdAndEducationId(

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
@@ -64,6 +64,7 @@ class VetControllerIntegrationTest {
         mockServerConfigAuthService.registerValidateTokenForVetEndpoint();
         mockServerConfigVetService.registerGetVetByIdEndpoint();
         mockServerConfigVetService.registerGetVetByInvalidIdEndpoint();
+        mockServerConfigVetService.registerAddEducationAsUnauthorizedUser("2e26e7a2-8c6e-4e2d-8d60-ad0882e295eb");
 
         mockServerConfigVetService.registerGetPhotoByVetIdEndpoint("ac9adeb8-625b-11ee-8c99-0242ac120002", "mockPhotoData".getBytes());
         mockServerConfigVetService.registerGetPhotoByVetIdEndpointNotFound("invalid-vet-id");
@@ -562,6 +563,30 @@ class VetControllerIntegrationTest {
                 .exchange()
                 .expectStatus().isNotFound();
     }
+
+    @Test
+    public void whenAddEducationAsUnauthorizedUser_thenReturnUnauthorized() {
+        EducationRequestDTO educationRequestDTO = EducationRequestDTO.builder()
+                .vetId("2e26e7a2-8c6e-4e2d-8d60-ad0882e295eb")
+                .schoolName("Harvard University")
+                .degree("Doctor of Veterinary Medicine")
+                .fieldOfStudy("Veterinary Science")
+                .startDate("2015-08-01")
+                .endDate("2019-05-30")
+                .build();
+
+        mockServerConfigVetService.registerAddEducationAsUnauthorizedUser(educationRequestDTO.getVetId());
+
+        webTestClient.post()
+                .uri(VET_ENDPOINT + "/" + educationRequestDTO.getVetId() + "/educations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(educationRequestDTO), EducationRequestDTO.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+
 
 
     @Test

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerUnitTest.java
@@ -5,10 +5,7 @@ import com.petclinic.bffapigateway.domainclientlayer.VetsServiceClient;
 import com.petclinic.bffapigateway.domainclientlayer.VisitsServiceClient;
 import com.petclinic.bffapigateway.dtos.Auth.RegisterVet;
 import com.petclinic.bffapigateway.dtos.Auth.Role;
-import com.petclinic.bffapigateway.dtos.Vets.SpecialtyDTO;
-import com.petclinic.bffapigateway.dtos.Vets.VetRequestDTO;
-import com.petclinic.bffapigateway.dtos.Vets.VetResponseDTO;
-import com.petclinic.bffapigateway.dtos.Vets.Workday;
+import com.petclinic.bffapigateway.dtos.Vets.*;
 import com.petclinic.bffapigateway.utils.Security.Variables.Roles;
 import org.mockito.InjectMocks;
 import org.mockito.Mockito;
@@ -120,6 +117,25 @@ class VetControllerUnitTest {
             .name(Roles.ADMIN.name())
             .build();
 
+    EducationRequestDTO educationRequestDTO = EducationRequestDTO.builder()
+            .vetId("2e26e7a2-8c6e-4e2d-8d60-ad0882e295eb")
+            .schoolName("Harvard University")
+            .degree("Doctor of Veterinary Medicine")
+            .fieldOfStudy("Veterinary Science")
+            .startDate("2015-08-01")
+            .endDate("2019-05-30")
+            .build();
+
+    EducationResponseDTO educationResponseDTO = EducationResponseDTO.builder()
+            .educationId("edu12345")
+            .vetId("2e26e7a2-8c6e-4e2d-8d60-ad0882e295eb")
+            .schoolName("Harvard University")
+            .degree("Doctor of Veterinary Medicine")
+            .fieldOfStudy("Veterinary Science")
+            .startDate("2015-08-01")
+            .endDate("2019-05-30")
+            .build();
+
     //#endregion
 
 
@@ -157,5 +173,54 @@ class VetControllerUnitTest {
 
         verify(authServiceClient, Mockito.times(1)).addVetUser(any(Mono.class));
     }
+
+    @Test
+    void whenAddEducationToVet_asAdmin_thenReturnCreatedEducationDTO() {
+        when(vetsServiceClient.addEducationToAVet(anyString(), any(Mono.class)))
+                .thenReturn(Mono.just(educationResponseDTO));
+
+        Mono<EducationResponseDTO> result = webTestClient.post()
+                .uri(BASE_VET_URL + "/2e26e7a2-8c6e-4e2d-8d60-ad0882e295eb/educations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(educationRequestDTO), EducationRequestDTO.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .returnResult(EducationResponseDTO.class)
+                .getResponseBody()
+                .single();
+
+        StepVerifier.create(result)
+                .expectNextMatches(education -> {
+                    assertNotNull(education);
+                    assertEquals(educationResponseDTO.getEducationId(), education.getEducationId());
+                    assertEquals(educationResponseDTO.getVetId(), education.getVetId());
+                    assertEquals(educationResponseDTO.getSchoolName(), education.getSchoolName());
+                    assertEquals(educationResponseDTO.getDegree(), education.getDegree());
+                    assertEquals(educationResponseDTO.getFieldOfStudy(), education.getFieldOfStudy());
+                    assertEquals(educationResponseDTO.getStartDate(), education.getStartDate());
+                    assertEquals(educationResponseDTO.getEndDate(), education.getEndDate());
+                    return true;
+                })
+                .verifyComplete();
+
+        verify(vetsServiceClient, Mockito.times(1)).addEducationToAVet(anyString(), any(Mono.class));
+    }
+
+    @Test
+    void whenAddEducationToVet_asUnauthorizedUser_thenReturnUnauthorized() {
+        webTestClient.post()
+                .uri(BASE_VET_URL + "/2e26e7a2-8c6e-4e2d-8d60-ad0882e295eb/educations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(educationRequestDTO), EducationRequestDTO.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isUnauthorized();
+
+        verify(vetsServiceClient, Mockito.times(0)).addEducationToAVet(anyString(), any(Mono.class));
+    }
+
+
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerUnitTest.java
@@ -208,19 +208,6 @@ class VetControllerUnitTest {
         verify(vetsServiceClient, Mockito.times(1)).addEducationToAVet(anyString(), any(Mono.class));
     }
 
-    @Test
-    void whenAddEducationToVet_asUnauthorizedUser_thenReturnUnauthorized() {
-        webTestClient.post()
-                .uri(BASE_VET_URL + "/2e26e7a2-8c6e-4e2d-8d60-ad0882e295eb/educations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(educationRequestDTO), EducationRequestDTO.class)
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isUnauthorized();
-
-        verify(vetsServiceClient, Mockito.times(0)).addEducationToAVet(anyString(), any(Mono.class));
-    }
-
 
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigVetService.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigVetService.java
@@ -457,6 +457,31 @@ public class MockServerConfigVetService {
                 );
     }
 
+    public void registerAddEducationAsUnauthorizedUser(String vetId) {
+        mockServerClient_VetService
+                .when(
+                        request()
+                                .withMethod("POST")
+                                .withPath("/vets/" + vetId + "/educations")
+                                .withHeader("Authorization", "Bearer invalid-token")
+                                .withBody(json("{"
+                                        + "\"vetId\":\"2e26e7a2-8c6e-4e2d-8d60-ad0882e295eb\","
+                                        + "\"degree\":\"Doctor of Veterinary Medicine\","
+                                        + "\"schoolName\":\"Harvard University\","
+                                        + "\"fieldOfStudy\":\"Veterinary Science\","
+                                        + "\"startDate\":\"2015-08-01\","
+                                        + "\"endDate\":\"2019-05-30\""
+                                        + "}"))
+                )
+                .respond(
+                        response()
+                                .withStatusCode(403)
+                                .withBody("{\"status\":403,\"message\":\"Unauthorized access: User is not admin or vet.\"}")
+                );
+    }
+
+
+
     public void registerUpdateEducationByVetIdAndEducationIdEndpointNotFound(String vetId, String educationId, EducationRequestDTO education) {
         mockServerClient_VetService.when(
                         request()

--- a/petclinic-frontend/src/features/veterinarians/api/addEducation.ts
+++ b/petclinic-frontend/src/features/veterinarians/api/addEducation.ts
@@ -1,0 +1,10 @@
+import { AxiosResponse } from 'axios';
+import axiosInstance from '@/shared/api/axiosInstance';
+import { EducationRequestModel } from '../models/EducationRequestModel';
+
+export const addVetEducation = async (
+  vetId: string,
+  education: EducationRequestModel
+): Promise<AxiosResponse<void>> => {
+  return await axiosInstance.post<void>(`/vets/${vetId}/educations`, education);
+};

--- a/petclinic-frontend/src/pages/Vet/AddEducation.tsx
+++ b/petclinic-frontend/src/pages/Vet/AddEducation.tsx
@@ -1,0 +1,152 @@
+// AddEducation.tsx
+import React, { useState } from 'react';
+import axios from 'axios';
+import { Button, Modal, Form } from 'react-bootstrap';
+
+interface AddEducationProps {
+  vetId: string | undefined; // Change here to allow undefined
+  onClose: () => void;
+}
+
+const AddEducation: React.FC<AddEducationProps> = ({ vetId, onClose }) => {
+  const [schoolName, setSchoolName] = useState('');
+  const [degree, setDegree] = useState('');
+  const [fieldOfStudy, setFieldOfStudy] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [errors, setErrors] = useState<{ [key: string]: string }>({});
+  const [show, setShow] = useState(false);
+
+  const handleShow = () => setShow(true);
+  const handleClose = () => {
+    setShow(false);
+    onClose(); // Ensure the modal closes correctly
+  };
+
+  const validate = (): boolean => {
+    const newErrors: { [key: string]: string } = {};
+    if (!schoolName) newErrors.schoolName = 'School Name is required';
+    if (!degree) newErrors.degree = 'Degree is required';
+    if (!fieldOfStudy) newErrors.fieldOfStudy = 'Field of Study is required';
+    if (!startDate) newErrors.startDate = 'Start Date is required';
+    if (!endDate) newErrors.endDate = 'End Date is required';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const educationData = {
+      vetId,
+      schoolName,
+      degree,
+      fieldOfStudy,
+      startDate,
+      endDate,
+    };
+
+    try {
+      await axios.post(`http://localhost:8080/api/v2/gateway/vets/${vetId}/educations`, educationData);
+      handleClose(); // Close the form
+      window.location.reload(); // Optionally reload to see updated data
+    } catch (error) {
+      console.error('Failed to add education:', error);
+    }
+  };
+
+  return (
+    <>
+      <Button variant="primary" onClick={handleShow}>
+        Add Education
+      </Button>
+
+      <Modal show={show} onHide={handleClose} backdrop="static" keyboard={false}>
+        <Modal.Header closeButton>
+          <Modal.Title>Add Education</Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          <Form id="addEducationForm" onSubmit={handleSubmit}>
+            <Form.Group className="mb-3">
+              <Form.Label>School Name</Form.Label>
+              <Form.Control
+                type="text"
+                value={schoolName}
+                onChange={e => setSchoolName(e.target.value)}
+                isInvalid={!!errors.schoolName}
+              />
+              <Form.Control.Feedback type="invalid">
+                {errors.schoolName}
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+              <Form.Label>Degree</Form.Label>
+              <Form.Control
+                type="text"
+                value={degree}
+                onChange={e => setDegree(e.target.value)}
+                isInvalid={!!errors.degree}
+              />
+              <Form.Control.Feedback type="invalid">
+                {errors.degree}
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+              <Form.Label>Field of Study</Form.Label>
+              <Form.Control
+                type="text"
+                value={fieldOfStudy}
+                onChange={e => setFieldOfStudy(e.target.value)}
+                isInvalid={!!errors.fieldOfStudy}
+              />
+              <Form.Control.Feedback type="invalid">
+                {errors.fieldOfStudy}
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+              <Form.Label>Start Date</Form.Label>
+              <Form.Control
+                type="date"
+                value={startDate}
+                onChange={e => setStartDate(e.target.value)}
+                isInvalid={!!errors.startDate}
+              />
+              <Form.Control.Feedback type="invalid">
+                {errors.startDate}
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+              <Form.Label>End Date</Form.Label>
+              <Form.Control
+                type="date"
+                value={endDate}
+                onChange={e => setEndDate(e.target.value)}
+                isInvalid={!!errors.endDate}
+              />
+              <Form.Control.Feedback type="invalid">
+                {errors.endDate}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Form>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleClose}>
+            Close
+          </Button>
+          <Button form="addEducationForm" variant="primary" type="submit">
+            Add Education
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+};
+
+export default AddEducation;

--- a/petclinic-frontend/src/pages/Vet/AddEducation.tsx
+++ b/petclinic-frontend/src/pages/Vet/AddEducation.tsx
@@ -1,10 +1,10 @@
-// AddEducation.tsx
+// eslint-disable-next-line import/default
 import React, { useState } from 'react';
 import axios from 'axios';
 import { Button, Modal, Form } from 'react-bootstrap';
 
 interface AddEducationProps {
-  vetId: string | undefined; // Change here to allow undefined
+  vetId: string | undefined;
   onClose: () => void;
 }
 
@@ -17,10 +17,12 @@ const AddEducation: React.FC<AddEducationProps> = ({ vetId, onClose }) => {
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [show, setShow] = useState(false);
 
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   const handleShow = () => setShow(true);
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   const handleClose = () => {
     setShow(false);
-    onClose(); // Ensure the modal closes correctly
+    onClose();
   };
 
   const validate = (): boolean => {
@@ -34,6 +36,7 @@ const AddEducation: React.FC<AddEducationProps> = ({ vetId, onClose }) => {
     return Object.keys(newErrors).length === 0;
   };
 
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!validate()) return;
@@ -48,9 +51,12 @@ const AddEducation: React.FC<AddEducationProps> = ({ vetId, onClose }) => {
     };
 
     try {
-      await axios.post(`http://localhost:8080/api/v2/gateway/vets/${vetId}/educations`, educationData);
-      handleClose(); // Close the form
-      window.location.reload(); // Optionally reload to see updated data
+      await axios.post(
+        `http://localhost:8080/api/v2/gateway/vets/${vetId}/educations`,
+        educationData
+      );
+      handleClose();
+      window.location.reload();
     } catch (error) {
       console.error('Failed to add education:', error);
     }
@@ -62,7 +68,12 @@ const AddEducation: React.FC<AddEducationProps> = ({ vetId, onClose }) => {
         Add Education
       </Button>
 
-      <Modal show={show} onHide={handleClose} backdrop="static" keyboard={false}>
+      <Modal
+        show={show}
+        onHide={handleClose}
+        backdrop="static"
+        keyboard={false}
+      >
         <Modal.Header closeButton>
           <Modal.Title>Add Education</Modal.Title>
         </Modal.Header>

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -5,6 +5,7 @@ import './VetDetails.css';
 import axios from 'axios';
 import DeleteVetPhoto from '@/pages/Vet/DeleteVetPhoto.tsx';
 import UpdateVetEducation from '@/pages/Vet/UpdateVetEducation';
+import AddEducation from '@/pages/Vet/AddEducation.tsx';
 
 interface VetResponseType {
   vetId: string;
@@ -59,6 +60,7 @@ export default function VetDetails(): JSX.Element {
   const [specialtyId, setSpecialtyId] = useState('');
   const [specialtyName, setSpecialtyName] = useState('');
   const [enlargedPhoto, setEnlargedPhoto] = useState<string | null>(null);
+  const [formVisible, setFormVisible] = useState<boolean>(false);
 
   const [selectedEducation, setSelectedEducation] =
     useState<EducationResponseType | null>(null);
@@ -580,6 +582,19 @@ export default function VetDetails(): JSX.Element {
                     <p>
                       <strong>End Date:</strong> {edu.endDate}
                     </p>
+                    <div style={{ marginBottom: '20px', textAlign: 'right' }}>
+                      <button
+                        onClick={() => setFormVisible(prev => !prev)}
+                        style={{
+                          backgroundColor: formVisible ? '#ff6347' : '#4CAF50',
+                        }}
+                      >
+                        {formVisible ? 'Cancel' : 'Add Education'}
+                      </button>
+                      {formVisible && <AddEducation vetId={vetId} onClose={() => setFormVisible(false)} />}
+                    </div>
+
+
                     <button
                       className="btn btn-primary"
                       onClick={event => {

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -591,9 +591,13 @@ export default function VetDetails(): JSX.Element {
                       >
                         {formVisible ? 'Cancel' : 'Add Education'}
                       </button>
-                      {formVisible && <AddEducation vetId={vetId} onClose={() => setFormVisible(false)} />}
+                      {formVisible && (
+                        <AddEducation
+                          vetId={vetId}
+                          onClose={() => setFormVisible(false)}
+                        />
+                      )}
                     </div>
-
 
                     <button
                       className="btn btn-primary"

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -244,9 +244,13 @@ public class VetController {
 
 
     @PostMapping("{vetId}/educations")
-    public Mono<EducationResponseDTO> addEducationToVet(@PathVariable String vetId, @RequestBody Mono<EducationRequestDTO> educationRequestDTOMono){
-        return educationService.addEducationToVet(vetId, educationRequestDTOMono);
+    public Mono<ResponseEntity<EducationResponseDTO>> addEducationToVet(@PathVariable String vetId,
+                                                                        @RequestBody Mono<EducationRequestDTO> educationRequestDTOMono) {
+        return educationService.addEducationToVet(vetId, educationRequestDTOMono)
+                .map(education -> ResponseEntity.status(HttpStatus.CREATED).body(education))
+                .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
+
 
 
 

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -1584,7 +1584,7 @@ class VetControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(education2)
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isCreated()
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody(EducationResponseDTO.class)
                 .value(dto -> {

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -729,7 +729,7 @@ class VetControllerUnitTest {
                 .bodyValue(educationRequestDTO)
                 .accept(APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isCreated()
                 .expectHeader().contentType(APPLICATION_JSON)
                 .expectBody();
 

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -702,7 +702,7 @@ class VetControllerUnitTest {
 
 
     @Test
-    void addEducationWithVetId_ValidValues_ShouldSucceed(){
+    void addEducationWithVetId_ValidValues_ShouldSucceed() {
         EducationRequestDTO educationRequestDTO = EducationRequestDTO.builder()
                 .vetId(VET_ID)
                 .degree("Doctor of Veterinary Medicine")
@@ -722,7 +722,8 @@ class VetControllerUnitTest {
                 .endDate("2014")
                 .build();
 
-        when(educationService.addEducationToVet(VET_ID, Mono.just(educationRequestDTO))).thenReturn(Mono.just(educationResponseDTO));
+        when(educationService.addEducationToVet(eq(VET_ID), any(Mono.class)))
+                .thenReturn(Mono.just(educationResponseDTO));
 
         client.post()
                 .uri("/vets/{vetId}/educations", VET_ID)
@@ -731,10 +732,17 @@ class VetControllerUnitTest {
                 .exchange()
                 .expectStatus().isCreated()
                 .expectHeader().contentType(APPLICATION_JSON)
-                .expectBody();
+                .expectBody(EducationResponseDTO.class)
+                .consumeWith(response -> {
+                    EducationResponseDTO responseBody = response.getResponseBody();
+                    assert responseBody != null; 
+                    assertEquals("3", responseBody.getEducationId());
+                    assertEquals(VET_ID, responseBody.getVetId());
+                });
 
-        Mockito.verify(educationService, times(1)).addEducationToVet(anyString(), any(Mono.class));
+        Mockito.verify(educationService, times(1)).addEducationToVet(eq(VET_ID), any(Mono.class));
     }
+
 
     @Test
     void getPhotoByVetId() {


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1373

## Context:
This ticket is about allowing veterinarians and admins to add a new education onto a vet's detail page.

## Does this PR change the .vscode folder in petclinic-frontend?:
No, it does not change the .vscode folder.

## Changes

- The addEducationToVet method is now secured with roles ADMIN and VET.
- Updated to accept vetId and Mono<EducationRequestDTO>, handling the creation of a new education record for the vet.
- Created methods for separation of concerns in the EducationServiceImpl.
- This method now calls the relevant API endpoint to add education details and returns an EducationResponseDTO wrapped in a Mono.
- Implemented the Add Education button into the front-end.

## Before and After UI (Required for UI-impacting PRs)
Before: 
![image](https://github.com/user-attachments/assets/82079d98-d4af-4336-a9f0-0a09d5dd76b7)

After: 
![image](https://github.com/user-attachments/assets/df34915b-32e2-4ead-9b07-662acb181c05)
![image](https://github.com/user-attachments/assets/358a0019-ec98-4d76-be18-4ecb55fb1fd5)
