### PR TITLE
bug/(AUTH-CPC-1280): build.gradle should not exclude MapperImpl.class files

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -71,8 +71,7 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: [
-                    "com/petclinic/**/AuthServiceApplication.class",
-                    "**/*MapperImpl.class"
+                    "com/petclinic/**/AuthServiceApplication.class"
             ])
         }))
     }


### PR DESCRIPTION
**JIRA:** [link to jira ticket](https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/15/backlog?epics=visible&selectedIssue=CPC-1280&text=Auth)
## Context:
The mapper impl class was exluded in afterEvaluate testing while it shouldn't in Auth Service
## Does this PR change the .vscode folder in petclinic-frontend?:
It doesn't

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
- Removed the exclusion of mapperImpl.class in afterEvaluate in Auth service build.gradle
## Dev notes
Everything seems to be working fine without the exclusion of it, I do not know why it has been added to the afterEvaluate in the first place