### PR TITLE
feat(VIST-CPC-1315): remove add emergency visit on admin side.

### DIFF
--- a/petclinic-frontend/src/features/visits/VisitListTable.tsx
+++ b/petclinic-frontend/src/features/visits/VisitListTable.tsx
@@ -486,13 +486,13 @@ export default function VisitListTable(): JSX.Element {
         >
           View Reviews
         </button>
-        <button
-          className="btn btn-dark"
-          onClick={() => navigate('/visits/emergency')}
-          title="Create emergency visit"
-        >
-          Create Emergency visit
-        </button>
+        {/*<button*/}
+        {/*  className="btn btn-dark"*/}
+        {/*  onClick={() => navigate('/visits/emergency')}*/}
+        {/*  title="Create emergency visit"*/}
+        {/*>*/}
+        {/*  Create Emergency visit*/}
+        {/*</button>*/}
         <button
           className="btn btn-warning"
           onClick={() => navigate(AppRoutePaths.AddVisit)}


### PR DESCRIPTION
**JIRA:** [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1315)
## Context:
Removing the option to add an emergency visit on the admin side because it doesn't make sense that the admin creates it. The user/customer having an emergency with their pet is the one that should create it.
## Does this PR change the .vscode folder in petclinic-frontend?:
No, it doesn't change it.

## Changes
1. Commenting out the button on the visits table for admin
## Before and After UI (Required for UI-impacting PRs)
Before changes:
![before_emergency](https://github.com/user-attachments/assets/4d034f5c-c4bc-4e0a-8e17-68f5dbb6144a)

After changes:
![after_emergency](https://github.com/user-attachments/assets/856f830d-0e9e-4765-ae28-ba6c9e08072b)


