### PR TITLE
bug(INVT-CPC-1417): make uploaded images not required

### DIFF
--- a/petclinic-frontend/src/features/inventories/AddInventoryForm.tsx
+++ b/petclinic-frontend/src/features/inventories/AddInventoryForm.tsx
@@ -178,7 +178,6 @@ const AddInventoryForm: React.FC<AddInventoryProps> = ({
               id="imageUpload"
               accept="image/*"
               onChange={handleImageUpload}
-              required
             />
           </div>
 

--- a/petclinic-frontend/src/features/inventories/EditInventory.tsx
+++ b/petclinic-frontend/src/features/inventories/EditInventory.tsx
@@ -299,7 +299,6 @@ const EditInventory: React.FC = (): JSX.Element => {
                   accept="image/*"
                   onChange={handleFileChange}
                   ref={fileInputRef}
-                  required
                 />
                 {error.uploadedImage && (
                   <span className="error">{error.uploadedImage}</span>


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1417
## Context:
Everytime we want to update our inventory we must always select an image because our uploaded image input box requires a value and it doesn't already have a value. This is because logic isn't implemented to fetch the uploaded image from the database and store that value fetched into the input box. But this isn't needed thanks to this simple fix.
## Does this PR change the .vscode folder in petclinic-frontend?:
**No, it doesn't**
## Changes
• Removed required from both the add inventory form and edit inventory form
## Before and After UI (Required for UI-impacting PRs)
## Dev notes (Optional)
Specific technical changes that should be noted
## Linked pull requests (Optional)
Pull request links