### PR TITLE
feat(BILL-CPC-1351): Admin can filter bills by month

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClient.java
@@ -311,4 +311,17 @@ public class BillServiceClient {
                 .bodyToMono(byte[].class);
     }
 
+    public Flux<BillResponseDTO> getBillsByMonth(int year, int month) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(billServiceUrl + "/month")
+                .queryParam("year", year)
+                .queryParam("month", month);
+
+        return webClientBuilder.build()
+                .get()
+                .uri(builder.build().toUri())
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToFlux(BillResponseDTO.class);
+    }
+
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/BillController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/BillController.java
@@ -131,4 +131,16 @@ public class BillController {
         return billService.getAllOverdueBills();
     }
 
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
+    @GetMapping(value = "/admin/month", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<BillResponseDTO> getBillsByMonth(
+            @RequestParam int year,
+            @RequestParam int month) {
+        if (year < 0 || month < 1 || month > 12) {
+            throw new InvalidInputException("Invalid year or month: year=" + year + ", month=" + month);
+        }
+
+        return billService.getBillsByMonth(year, month);
+    }
+
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientIntegrationTest.java
@@ -517,8 +517,22 @@ class BillServiceClientIntegrationTest {
                 .verify();
     }
 
+    @Test
+    void whenGetBillsByMonth_thenReturnsResults() throws Exception {
+        List<BillResponseDTO> billResponses = Arrays.asList(billResponseDTO, billResponseDTO2);
+        String jsonResponse = mapper.writeValueAsString(billResponses);
 
+        prepareResponse(response -> response
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(jsonResponse));
 
+        Flux<BillResponseDTO> resultFlux = billServiceClient.getBillsByMonth(1, 2022);
+
+        StepVerifier.create(resultFlux)
+                .expectNextMatches(bill -> "1".equals(bill.getBillId()) && bill.getAmount() == 100.0)
+                .expectNextMatches(bill -> "2".equals(bill.getBillId()) && bill.getAmount() == 150.0)
+                .verifyComplete();
+    }
 
 
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/BillControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/BillControllerIntegrationTest.java
@@ -247,6 +247,24 @@ public class BillControllerIntegrationTest {
                 .expectHeader().contentType(MediaType.APPLICATION_JSON);
     }
 
+    @Test
+    void whenGetBillsByMonthAsAdmin_thenReturnBills() {
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/api/v2/gateway/bills")
+                        .queryParam("month", "10")
+                        .queryParam("year", "2024")
+                        .build())
+                .cookie("Bearer", jwtTokenForValidAdmin)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBodyList(BillResponseDTO.class)
+                .consumeWith(response -> {
+                    assert response.getResponseBody().size() == 2;
+                });
+    }
+
 }
 
 

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/BillControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/BillControllerUnitTest.java
@@ -241,4 +241,35 @@ private final String baseBillURL = "/api/v2/gateway/bills";
                 .exchange()
                 .expectStatus().isBadRequest();
     }
+
+    @Test
+    public void whenGetBillsByMonthWithValidParameters_ThenReturnBills() {
+        when(billServiceClient.getBillsByMonth(2024, 10))
+                .thenReturn(Flux.just(billresponse, billresponse2));
+
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path(baseBillURL + "/admin/month")
+                        .queryParam("year", 2024)
+                        .queryParam("month", 10)
+                        .build())
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(BillResponseDTO.class)
+                .hasSize(2)
+                .contains(billresponse, billresponse2);
+
+        verify(billServiceClient, times(1)).getBillsByMonth(2024, 10);
+    }
+
+    @Test
+    public void whenGetBillsByMonthWithInvalidParameters_ThenReturnUnprocessableEntity() {
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path(baseBillURL + "/admin/month")
+                        .queryParam("year", -1)
+                        .queryParam("month", 13)
+                        .build())
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+    }
 }

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillService.java
@@ -65,4 +65,9 @@ public interface BillService {
     // Method to generate the bill PDF
     Mono<byte[]> generateBillPdf(String customerId, String billId);
 
+    // Method to fetch bills by month
+    Flux<BillResponseDTO> getBillsByMonth(int year, int month);
+
+
+
 }

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -19,7 +19,10 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.function.Predicate;
+
+import static reactor.core.publisher.FluxExtensionsKt.switchIfEmpty;
 
 
 @Service
@@ -266,4 +269,16 @@ public class BillServiceImpl implements BillService{
                     }
                 });
     }
+
+    @Override
+    public Flux<BillResponseDTO> getBillsByMonth(int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate start = yearMonth.atDay(1);
+        LocalDate end = yearMonth.atEndOfMonth().plusDays(1);
+
+        return billRepository.findByDateBetween(start, end)
+                .map(EntityDtoUtil::toBillResponseDto)
+                .switchIfEmpty(Flux.empty());
+    }
+
 }

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillRepository.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillRepository.java
@@ -3,12 +3,15 @@ package com.petclinic.billing.datalayer;
 //import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 //import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
 
 @Repository
 public interface BillRepository extends ReactiveMongoRepository<Bill, String> {
@@ -33,5 +36,7 @@ public interface BillRepository extends ReactiveMongoRepository<Bill, String> {
     Flux<Bill> findAllBillsByBillStatus(BillStatus status);
 
     Flux<Bill> findByCustomerIdAndBillStatus(String customerId, BillStatus status);
-    
+
+    @Query("{ 'date' : { $gte: ?0, $lt: ?1 } }")
+    Flux<Bill> findByDateBetween(LocalDate start, LocalDate end);
 }

--- a/billing-service/src/main/java/com/petclinic/billing/presentationlayer/BillController.java
+++ b/billing-service/src/main/java/com/petclinic/billing/presentationlayer/BillController.java
@@ -178,4 +178,16 @@ public class BillController {
         return billService.deleteBillsByCustomerId(customerId);
     }
 
+    @GetMapping("/bills/month")
+    public Flux<BillResponseDTO> getBillsByMonth(
+            @RequestParam int year,
+            @RequestParam int month) {
+        if (year < 0 || month < 1 || month > 12) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid year or month");
+        }
+
+        return billService.getBillsByMonth(year, month);
+    }
+
+
 }

--- a/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/businesslayer/BillServiceImplTest.java
@@ -589,5 +589,26 @@ public class BillServiceImplTest {
                 .verifyComplete();
     }
 
+    @Test
+    void getBillsByMonth_ShouldReturnBillsForGivenMonth() {
+        // Arrange
+        Bill bill1 = buildBill();
+        Bill bill2 = buildBill();
+        bill2.setBillId("BillUUID2"); // Different ID for distinct objects
+        int year = 2022;
+        int month = 9;
+
+        when(repo.findByDateBetween(any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(Flux.just(bill1, bill2));
+
+        // Act
+        Flux<BillResponseDTO> result = billService.getBillsByMonth(year, month);
+
+        // Assert
+        StepVerifier.create(result)
+                .expectNextCount(2) // Expect both bills
+                .verifyComplete();
+    }
+
 
 }

--- a/billing-service/src/test/java/com/petclinic/billing/datalayer/BillServicePersistenceTests.java
+++ b/billing-service/src/test/java/com/petclinic/billing/datalayer/BillServicePersistenceTests.java
@@ -211,6 +211,25 @@ public class BillServicePersistenceTests {
     }
 
 
+    @Test
+    void shouldFindAllBillsByDateBetween(){
+
+        Bill bill = buildBill();
+
+        Publisher<Bill> setup = repo.deleteAll().thenMany(repo.save(buildBill()));
+        Publisher<Bill> find = repo.findByDateBetween(bill.getDate().minusDays(1), bill.getDate().plusDays(1));
+
+        StepVerifier
+                .create(setup)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        StepVerifier
+                .create(find)
+                .expectNextCount(1)
+                .verifyComplete();
+
+    }
 
 
 }

--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillControllerIntegrationTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillControllerIntegrationTest.java
@@ -524,6 +524,35 @@ class BillControllerIntegrationTest {
                 .jsonPath("$.timeRemaining").isEqualTo(0);
     }
 
+    @Test
+    void getBillsByMonth() {
+        repo.deleteAll().block();
+        for (int i = 1; i <= 5; i++) {
+            repo.save(Bill.builder()
+                    .billId("BillUUID" + i)
+                    .customerId("Cust" + i)
+                    .vetId("1")
+                    .visitType("Routine Check")
+                    .date(LocalDate.of(2022, 9, i))
+                    .amount(100.0)
+                    .billStatus(BillStatus.PAID)
+                    .dueDate(LocalDate.of(2022, 9, i).plusDays(30))
+                    .build()).block();
+        }
+
+        client.get()
+                .uri(uriBuilder -> uriBuilder.path("/bills/month")
+                        .queryParam("year", 2022)
+                        .queryParam("month", 9)
+                        .build())
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBodyList(BillResponseDTO.class)
+                .hasSize(5);
+    }
+
     private Bill buildBillWithPastDueDate() {
 
         LocalDate date = LocalDate.of(2024, 1, 1);

--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillControllerUnitTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillControllerUnitTest.java
@@ -311,6 +311,39 @@ class BillControllerUnitTest {
     }
 
 
+    @Test
+    void whenGetBillsByMonthCalled_thenShouldCallServiceWithCorrectParams() {
+        // Mocking the service layer response
+        when(billService.getBillsByMonth(anyInt(), anyInt()))
+                .thenReturn(Flux.just(responseDTO));
+
+        // Triggering the controller endpoint
+        client.get()
+                .uri(uriBuilder -> uriBuilder.path("/bills/month")
+                        .queryParam("month", 1)
+                        .queryParam("year", 2022)
+                        .build())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(BillResponseDTO.class)
+                .hasSize(1);  // Checking that the response body has exactly 1 element
+
+        // Verifying the correct method calls with correct argument order
+        Mockito.verify(billService, times(1))
+                .getBillsByMonth(2022, 1);  // year first, then month
+    }
+
+    @Test
+    void whenGetBillsByMonthCalledWithInvalidParams_thenShouldBadRequest() {
+        // Triggering the controller endpoint with invalid parameters
+        client.get()
+                .uri(uriBuilder -> uriBuilder.path("/bills/month")
+                        .queryParam("month", 13)
+                        .queryParam("year", -1)
+                        .build())
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
 
 
 }

--- a/petclinic-frontend/src/features/bills/AdminBillsListTable.tsx
+++ b/petclinic-frontend/src/features/bills/AdminBillsListTable.tsx
@@ -14,7 +14,7 @@ import { getAllPaidBills } from '@/features/bills/api/getAllPaidBills.tsx';
 import { getAllOverdueBills } from '@/features/bills/api/getAllOverdueBills.tsx';
 import { getAllUnpaidBills } from '@/features/bills/api/getAllUnpaidBills.tsx';
 import { getBillByBillId } from '@/features/bills/api/GetBillByBillId.tsx';
-import {getBillsByMonth} from "@/features/bills/api/getBillByMonth.tsx";
+import { getBillsByMonth } from '@/features/bills/api/getBillByMonth.tsx';
 
 export default function AdminBillsListTable(): JSX.Element {
   const navigate = useNavigate();
@@ -26,8 +26,12 @@ export default function AdminBillsListTable(): JSX.Element {
   const [filter, setFilter] = useState<FilterModel>({
     customerId: '',
   });
-  const [filterYear, setFilterYear] = useState<number>(new Date().getFullYear());
-  const [filterMonth, setFilterMonth] = useState<number>(new Date().getMonth() + 1);
+  const [filterYear, setFilterYear] = useState<number>(
+    new Date().getFullYear()
+  );
+  const [filterMonth, setFilterMonth] = useState<number>(
+    new Date().getMonth() + 1
+  );
 
   interface FilterModel {
     [key: string]: string;
@@ -142,19 +146,19 @@ export default function AdminBillsListTable(): JSX.Element {
   };
 
   const getFilteredBills = (): Bill[] => {
-    let billsToFilter = filteredBills || billsList;
+    const billsToFilter = filteredBills || billsList;
 
     return billsToFilter.filter(bill => {
       const matchesStatus =
-          !selectedFilter || bill.billStatus.toLowerCase() === selectedFilter.toLowerCase();
+        !selectedFilter ||
+        bill.billStatus.toLowerCase() === selectedFilter.toLowerCase();
 
       const matchesCustomerId =
-          !filter.customerId || bill.customerId.includes(filter.customerId);
+        !filter.customerId || bill.customerId.includes(filter.customerId);
 
       return matchesStatus && matchesCustomerId;
     });
   };
-
 
   const handleCreateBill = async (): Promise<void> => {
     const isValid = validateForm();
@@ -378,9 +382,9 @@ export default function AdminBillsListTable(): JSX.Element {
       <div>
         <label htmlFor="billFilter">Filter Bills by Status: </label>
         <select
-            id="billFilter"
-            value={selectedFilter}
-            onChange={handleFilterChange}
+          id="billFilter"
+          value={selectedFilter}
+          onChange={handleFilterChange}
         >
           <option value="">All Bills</option>
           <option value="unpaid">Unpaid Bills</option>
@@ -392,29 +396,28 @@ export default function AdminBillsListTable(): JSX.Element {
       <div>
         <label htmlFor="yearFilter">Year: </label>
         <input
-            type="number"
-            id="yearFilter"
-            value={filterYear}
-            onChange={e => setFilterYear(parseInt(e.target.value))}
+          type="number"
+          id="yearFilter"
+          value={filterYear}
+          onChange={e => setFilterYear(parseInt(e.target.value))}
         />
 
         <label htmlFor="monthFilter">Month: </label>
         <select
-            id="monthFilter"
-            value={filterMonth}
-            onChange={e => setFilterMonth(parseInt(e.target.value))}
+          id="monthFilter"
+          value={filterMonth}
+          onChange={e => setFilterMonth(parseInt(e.target.value))}
         >
           {Array.from({ length: 12 }, (_, i) => (
-              <option key={i + 1} value={i + 1}>
-                {new Date(0, i).toLocaleString('default', { month: 'long' })}
-              </option>
+            <option key={i + 1} value={i + 1}>
+              {new Date(0, i).toLocaleString('default', { month: 'long' })}
+            </option>
           ))}
         </select>
 
         <button onClick={handleMonthFilter}>Filter by Month</button>
         <button onClick={clearMonthFilter}>Clear Date Filter</button>
       </div>
-
 
       {searchedBill ? (
         <div>

--- a/petclinic-frontend/src/features/bills/AdminBillsListTable.tsx
+++ b/petclinic-frontend/src/features/bills/AdminBillsListTable.tsx
@@ -14,6 +14,7 @@ import { getAllPaidBills } from '@/features/bills/api/getAllPaidBills.tsx';
 import { getAllOverdueBills } from '@/features/bills/api/getAllOverdueBills.tsx';
 import { getAllUnpaidBills } from '@/features/bills/api/getAllUnpaidBills.tsx';
 import { getBillByBillId } from '@/features/bills/api/GetBillByBillId.tsx';
+import {getBillsByMonth} from "@/features/bills/api/getBillByMonth.tsx";
 
 export default function AdminBillsListTable(): JSX.Element {
   const navigate = useNavigate();
@@ -25,6 +26,8 @@ export default function AdminBillsListTable(): JSX.Element {
   const [filter, setFilter] = useState<FilterModel>({
     customerId: '',
   });
+  const [filterYear, setFilterYear] = useState<number>(new Date().getFullYear());
+  const [filterMonth, setFilterMonth] = useState<number>(new Date().getMonth() + 1);
 
   interface FilterModel {
     [key: string]: string;
@@ -118,20 +121,40 @@ export default function AdminBillsListTable(): JSX.Element {
     }
   };
 
+  const handleMonthFilter = async (): Promise<void> => {
+    setError(null);
+    setFilteredBills(null);
+
+    try {
+      const billsByMonth = await getBillsByMonth(filterYear, filterMonth);
+      setFilteredBills(billsByMonth);
+    } catch (err) {
+      console.error('Error fetching bills by month:', err);
+      setError('Error fetching bills by month. Please try again.');
+    }
+  };
+
+  const clearMonthFilter = (): void => {
+    setFilterYear(new Date().getFullYear());
+    setFilterMonth(new Date().getMonth() + 1);
+    setFilteredBills(null);
+    getBillsList(currentPage, 10);
+  };
+
   const getFilteredBills = (): Bill[] => {
-    const billsToFilter = filteredBills || billsList;
+    let billsToFilter = filteredBills || billsList;
 
     return billsToFilter.filter(bill => {
       const matchesStatus =
-        !selectedFilter ||
-        bill.billStatus.toLowerCase() === selectedFilter.toLowerCase();
+          !selectedFilter || bill.billStatus.toLowerCase() === selectedFilter.toLowerCase();
 
       const matchesCustomerId =
-        !filter.customerId || bill.customerId.includes(filter.customerId);
+          !filter.customerId || bill.customerId.includes(filter.customerId);
 
-      return matchesStatus && matchesCustomerId; // Combine filters
+      return matchesStatus && matchesCustomerId;
     });
   };
+
 
   const handleCreateBill = async (): Promise<void> => {
     const isValid = validateForm();
@@ -234,20 +257,6 @@ export default function AdminBillsListTable(): JSX.Element {
         />
         <button onClick={handleSearch}>Search</button>
         {searchedBill && <button onClick={handleGoBack}>Go Back</button>}
-      </div>
-
-      <div>
-        <label htmlFor="billFilter">Filter Bills by Status: </label>
-        <select
-          id="billFilter"
-          value={selectedFilter}
-          onChange={handleFilterChange}
-        >
-          <option value="">All Bills</option>
-          <option value="unpaid">Unpaid Bills</option>
-          <option value="paid">Paid Bills</option>
-          <option value="overdue">Overdue Bills</option>
-        </select>
       </div>
 
       <div>
@@ -365,6 +374,47 @@ export default function AdminBillsListTable(): JSX.Element {
           </form>
         </div>
       )}
+
+      <div>
+        <label htmlFor="billFilter">Filter Bills by Status: </label>
+        <select
+            id="billFilter"
+            value={selectedFilter}
+            onChange={handleFilterChange}
+        >
+          <option value="">All Bills</option>
+          <option value="unpaid">Unpaid Bills</option>
+          <option value="paid">Paid Bills</option>
+          <option value="overdue">Overdue Bills</option>
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="yearFilter">Year: </label>
+        <input
+            type="number"
+            id="yearFilter"
+            value={filterYear}
+            onChange={e => setFilterYear(parseInt(e.target.value))}
+        />
+
+        <label htmlFor="monthFilter">Month: </label>
+        <select
+            id="monthFilter"
+            value={filterMonth}
+            onChange={e => setFilterMonth(parseInt(e.target.value))}
+        >
+          {Array.from({ length: 12 }, (_, i) => (
+              <option key={i + 1} value={i + 1}>
+                {new Date(0, i).toLocaleString('default', { month: 'long' })}
+              </option>
+          ))}
+        </select>
+
+        <button onClick={handleMonthFilter}>Filter by Month</button>
+        <button onClick={clearMonthFilter}>Clear Date Filter</button>
+      </div>
+
 
       {searchedBill ? (
         <div>

--- a/petclinic-frontend/src/features/bills/api/getBillByMonth.tsx
+++ b/petclinic-frontend/src/features/bills/api/getBillByMonth.tsx
@@ -1,0 +1,21 @@
+import axiosInstance from '@/shared/api/axiosInstance.ts';
+import { Bill } from '@/features/bills/models/Bill.ts';
+
+export async function getBillsByMonth(year: number, month: number): Promise<Bill[]> {
+    const response = await axiosInstance.get(`/bills/admin/month`, {
+        params: { year, month },
+        responseType: 'stream',
+    });
+
+    return response.data
+        .split('data:')
+        .map((payLoad: string) => {
+            try {
+                if (payLoad.trim() === '') return null;
+                return JSON.parse(payLoad);
+            } catch (err) {
+                console.error("Can't parse JSON: " + err);
+            }
+        })
+        .filter((data?: Bill) => data !== null);
+}

--- a/petclinic-frontend/src/features/bills/api/getBillByMonth.tsx
+++ b/petclinic-frontend/src/features/bills/api/getBillByMonth.tsx
@@ -1,21 +1,24 @@
 import axiosInstance from '@/shared/api/axiosInstance.ts';
 import { Bill } from '@/features/bills/models/Bill.ts';
 
-export async function getBillsByMonth(year: number, month: number): Promise<Bill[]> {
-    const response = await axiosInstance.get(`/bills/admin/month`, {
-        params: { year, month },
-        responseType: 'stream',
-    });
+export async function getBillsByMonth(
+  year: number,
+  month: number
+): Promise<Bill[]> {
+  const response = await axiosInstance.get(`/bills/admin/month`, {
+    params: { year, month },
+    responseType: 'stream',
+  });
 
-    return response.data
-        .split('data:')
-        .map((payLoad: string) => {
-            try {
-                if (payLoad.trim() === '') return null;
-                return JSON.parse(payLoad);
-            } catch (err) {
-                console.error("Can't parse JSON: " + err);
-            }
-        })
-        .filter((data?: Bill) => data !== null);
+  return response.data
+    .split('data:')
+    .map((payLoad: string) => {
+      try {
+        if (payLoad.trim() === '') return null;
+        return JSON.parse(payLoad);
+      } catch (err) {
+        console.error("Can't parse JSON: " + err);
+      }
+    })
+    .filter((data?: Bill) => data !== null);
 }


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1351
## Context:
What is the ticket about and why are we doing this change.
The admin can now filter the bills by choosing a specific month and year.

## Does this PR change the .vscode folder in petclinic-frontend?:
No
If the PR changes the .vscode folder, explain why in detail because it should not. 
Be sure to include cgerard321 as a reviewer.

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
What are the various changes and what other modules do those changes affect.
This can be bullet point or sentence format.
- Added new method in the BillRepository, BillService, and BillResource to filter the bills by month
- Added a new method in the BillServiceClient, and the Bill Controller in te api-gateway
- Created a new Axios api for getting the bills by month
- Modified the AdminBillsListTable to include a form where the admin can choose a month and a year, a button to apply the filter, and a button to clear the filter

## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://github.com/user-attachments/assets/cb7e4f93-697e-4d3f-aefa-97404dce5d6f)
After:
![image](https://github.com/user-attachments/assets/72c7cb40-7294-40c1-923b-eef4cc9ab99c)

If this is a change to the UI, include before and after screenshots to show the differences.
If this is a new UI feature, include screenshots to show reviewers what it looks like. 
## Dev notes (Optional)
Specific technical changes that should be noted
## Linked pull requests (Optional)
Pull request links