### PR TITLE
feat(VETS-CPC-1374): Delete Education by Vet Id

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/VetsServiceClient.java
@@ -518,12 +518,12 @@ public class VetsServiceClient {
         return webClientBuilder
                 .build()
                 .delete()
-                .uri(vetsServiceUrl + "/" + vetId + "/educations" + "/" + educationId)
+                .uri(vetsServiceUrl + "/" + vetId + "/educations/" + educationId)
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, error -> {
                     HttpStatusCode statusCode = error.statusCode();
                     if (statusCode.equals(HttpStatus.NOT_FOUND))
-                        return Mono.error(new NotFoundException("vetId not found "+vetId+" or educationId not found: " + educationId));
+                        return Mono.error(new NotFoundException("Education not found: " + educationId));
                     return Mono.error(new IllegalArgumentException("Something went wrong with the client"));
                 })
                 .onStatus(HttpStatusCode::is5xxServerError, error ->
@@ -531,6 +531,7 @@ public class VetsServiceClient {
                 )
                 .bodyToMono(Void.class);
     }
+
     public Mono<EducationResponseDTO> updateEducationByVetIdAndByEducationId(String vetId, String educationId, Mono<EducationRequestDTO> educationRequestDTOMono){
         Mono<EducationResponseDTO> educationResponseDTOMono =
                 webClientBuilder

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -205,5 +205,15 @@ public class VetController {
         return vetsServiceClient.getRatingsByVetId(vetId)
                 .doOnError(error -> log.error("Error fetching ratings for vet {}", vetId, error));
     }
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.VET})
+    @DeleteMapping("/{vetId}/educations/{educationId}")
+    public Mono<ResponseEntity<Void>> deleteEducation(
+            @PathVariable String vetId,
+            @PathVariable String educationId) {
+        return vetsServiceClient.deleteEducation(vetId, educationId)
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .onErrorResume(NotFoundException.class, e -> Mono.just(ResponseEntity.notFound().build()));
+    }
 }
 

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VetController.java
@@ -212,8 +212,7 @@ public class VetController {
             @PathVariable String vetId,
             @PathVariable String educationId) {
         return vetsServiceClient.deleteEducation(vetId, educationId)
-                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
-                .onErrorResume(NotFoundException.class, e -> Mono.just(ResponseEntity.notFound().build()));
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()));
     }
 }
 

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
@@ -29,6 +29,7 @@ import reactor.test.StepVerifier;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
 

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/VetControllerIntegrationTest.java
@@ -651,5 +651,42 @@ class VetControllerIntegrationTest {
                     assertTrue(responseBody.contains("vetId not found: " + invalidVetId));
                 });
     }
+
+
+    @Test
+    void whenDeleteEducation_thenReturnNoContent() {
+        String vetId = "ac9adeb8-625b-11ee-8c99-0242ac120002";
+        String educationId = "123e4567-e89b-12d3-a456-426614174000";
+
+        mockServerConfigVetService.registerDeleteEducationEndpoint(vetId, educationId);
+
+        webTestClient.delete()
+                .uri(VET_ENDPOINT + "/" + vetId + "/educations/" + educationId)
+                .cookie("Bearer", BEARER_TOKEN)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNoContent()
+                .expectBody().isEmpty();
+    }
+
+    @Test
+    void whenDeleteEducation_EducationNotFound_thenReturnNotFound() {
+        String vetId = "ac9adeb8-625b-11ee-8c99-0242ac120002";
+        String educationId = "non-existent-education-id";
+
+        mockServerConfigVetService.registerDeleteEducationByVetIdEndpointNotFound(vetId, educationId);
+
+        webTestClient.delete()
+                .uri(VET_ENDPOINT + "/" + vetId + "/educations/" + educationId)
+                .cookie("Bearer", BEARER_TOKEN)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("Education not found: " + educationId);
+    }
+
+
+
 }
 

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigVetService.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigVetService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.petclinic.bffapigateway.dtos.Vets.*;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.JsonBody;
 import org.springframework.http.MediaType;
 
 import java.util.Collections;
@@ -524,5 +525,35 @@ public class MockServerConfigVetService {
                                 .withBody("{\"message\":\"No ratings found for vetId: " + vetId + "\"}")
                 );
     }
+
+    public void registerDeleteEducationEndpoint(String vetId, String educationId) {
+        mockServerClient_VetService
+                .when(
+                        request()
+                                .withMethod("DELETE")
+                                .withPath("/vets/" + vetId + "/educations/" + educationId)
+                )
+                .respond(
+                        response()
+                                .withStatusCode(204)
+                );
+    }
+
+    public void registerDeleteEducationByVetIdEndpointNotFound(String vetId, String educationId) {
+        String responseBody = "{\"message\":\"Education not found: " + educationId + "\"}";
+        mockServerClient_VetService
+                .when(
+                        request()
+                                .withMethod("DELETE")
+                                .withPath("/vets/" + vetId + "/educations/" + educationId)
+                )
+                .respond(
+                        response()
+                                .withStatusCode(404)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(responseBody)
+                );
+    }
+
 
 }

--- a/petclinic-frontend/src/features/veterinarians/api/deleteVetEducation.ts
+++ b/petclinic-frontend/src/features/veterinarians/api/deleteVetEducation.ts
@@ -2,10 +2,10 @@ import { AxiosResponse } from 'axios';
 import axiosInstance from '@/shared/api/axiosInstance';
 
 export const deleteVetEducation = async (
-    vetId: string,
-    educationId: string
+  vetId: string,
+  educationId: string
 ): Promise<AxiosResponse<void>> => {
-    return await axiosInstance.delete<void>(
-        `/vets/${vetId}/educations/${educationId}`
-    );
+  return await axiosInstance.delete<void>(
+    `/vets/${vetId}/educations/${educationId}`
+  );
 };

--- a/petclinic-frontend/src/features/veterinarians/api/deleteVetEducation.ts
+++ b/petclinic-frontend/src/features/veterinarians/api/deleteVetEducation.ts
@@ -1,0 +1,11 @@
+import { AxiosResponse } from 'axios';
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export const deleteVetEducation = async (
+    vetId: string,
+    educationId: string
+): Promise<AxiosResponse<void>> => {
+    return await axiosInstance.delete<void>(
+        `/vets/${vetId}/educations/${educationId}`
+    );
+};

--- a/petclinic-frontend/src/pages/Vet/DeleteVetEducation.tsx
+++ b/petclinic-frontend/src/pages/Vet/DeleteVetEducation.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { deleteVetEducation } from '@/features/veterinarians/api/deleteVetEducation.ts';
+
+interface DeleteVetEducationProps {
+    vetId: string;
+    educationId: string;
+    onEducationDeleted: (educationId: string) => void;
+}
+
+const DeleteVetEducation: React.FC<DeleteVetEducationProps> = ({
+                                                                   vetId,
+                                                                   educationId,
+                                                                   onEducationDeleted,
+                                                               }) => {
+    const handleDeleteEducation = async (
+        event: React.MouseEvent
+    ): Promise<void> => {
+        event.stopPropagation();
+        const confirmed = window.confirm(
+            'Are you sure you want to delete this education entry?'
+        );
+        if (!confirmed) return;
+
+        try {
+            await deleteVetEducation(vetId, educationId);
+
+            // Call the callback function to update the parent component
+            onEducationDeleted(educationId);
+
+            alert('Education entry deleted successfully.');
+        } catch (error) {
+            console.error('Failed to delete education entry:', error);
+            alert('Failed to delete education entry.');
+        }
+    };
+
+    return (
+        <button onClick={handleDeleteEducation} className="btn btn-danger">
+            Delete Education
+        </button>
+    );
+};
+
+export default DeleteVetEducation;

--- a/petclinic-frontend/src/pages/Vet/DeleteVetEducation.tsx
+++ b/petclinic-frontend/src/pages/Vet/DeleteVetEducation.tsx
@@ -1,44 +1,44 @@
-import React from 'react';
+import * as React from 'react';
 import { deleteVetEducation } from '@/features/veterinarians/api/deleteVetEducation.ts';
 
 interface DeleteVetEducationProps {
-    vetId: string;
-    educationId: string;
-    onEducationDeleted: (educationId: string) => void;
+  vetId: string;
+  educationId: string;
+  onEducationDeleted: (educationId: string) => void;
 }
 
 const DeleteVetEducation: React.FC<DeleteVetEducationProps> = ({
-                                                                   vetId,
-                                                                   educationId,
-                                                                   onEducationDeleted,
-                                                               }) => {
-    const handleDeleteEducation = async (
-        event: React.MouseEvent
-    ): Promise<void> => {
-        event.stopPropagation();
-        const confirmed = window.confirm(
-            'Are you sure you want to delete this education entry?'
-        );
-        if (!confirmed) return;
-
-        try {
-            await deleteVetEducation(vetId, educationId);
-
-            // Call the callback function to update the parent component
-            onEducationDeleted(educationId);
-
-            alert('Education entry deleted successfully.');
-        } catch (error) {
-            console.error('Failed to delete education entry:', error);
-            alert('Failed to delete education entry.');
-        }
-    };
-
-    return (
-        <button onClick={handleDeleteEducation} className="btn btn-danger">
-            Delete Education
-        </button>
+  vetId,
+  educationId,
+  onEducationDeleted,
+}) => {
+  const handleDeleteEducation = async (
+    event: React.MouseEvent
+  ): Promise<void> => {
+    event.stopPropagation();
+    const confirmed = window.confirm(
+      'Are you sure you want to delete this education entry?'
     );
+    if (!confirmed) return;
+
+    try {
+      await deleteVetEducation(vetId, educationId);
+
+      // Call the callback function to update the parent component
+      onEducationDeleted(educationId);
+
+      alert('Education entry deleted successfully.');
+    } catch (error) {
+      console.error('Failed to delete education entry:', error);
+      alert('Failed to delete education entry.');
+    }
+  };
+
+  return (
+    <button onClick={handleDeleteEducation} className="btn btn-danger">
+      Delete Education
+    </button>
+  );
 };
 
 export default DeleteVetEducation;

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -626,27 +626,27 @@ export default function VetDetails(): JSX.Element {
                   </div>
                 ))
               ) : (
-                  // When there are no education entries
-                  <div>
-                    <p>No education details available</p>
+                // When there are no education entries
+                <div>
+                  <p>No education details available</p>
 
-                    <div style={{ marginBottom: '20px', textAlign: 'right' }}>
-                      <button
-                          onClick={() => setFormVisible(prev => !prev)}
-                          style={{
-                            backgroundColor: formVisible ? '#ff6347' : '#4CAF50',
-                          }}
-                      >
-                        {formVisible ? 'Cancel' : 'Add Education'}
-                      </button>
-                      {formVisible && (
-                          <AddEducation
-                              vetId={vetId}
-                              onClose={() => setFormVisible(false)}
-                          />
-                      )}
-                    </div>
+                  <div style={{ marginBottom: '20px', textAlign: 'right' }}>
+                    <button
+                      onClick={() => setFormVisible(prev => !prev)}
+                      style={{
+                        backgroundColor: formVisible ? '#ff6347' : '#4CAF50',
+                      }}
+                    >
+                      {formVisible ? 'Cancel' : 'Add Education'}
+                    </button>
+                    {formVisible && (
+                      <AddEducation
+                        vetId={vetId}
+                        onClose={() => setFormVisible(false)}
+                      />
+                    )}
                   </div>
+                </div>
               )}
               {selectedEducation && vetId && (
                 <UpdateVetEducation

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -109,12 +109,12 @@ export default function VetDetails(): JSX.Element {
       setIsDefaultPhoto(true); // This indicates the default photo is being used
     }
   }, [vetId]);
-  
+
   const handleEducationDeleted = (deletedEducationId: string): void => {
     setEducation(prevEducation =>
-        prevEducation
-            ? prevEducation.filter(edu => edu.educationId !== deletedEducationId)
-            : null
+      prevEducation
+        ? prevEducation.filter(edu => edu.educationId !== deletedEducationId)
+        : null
     );
   };
 
@@ -618,9 +618,9 @@ export default function VetDetails(): JSX.Element {
                       Update Education
                     </button>
                     <DeleteVetEducation
-                        vetId={vetId!}
-                        educationId={edu.educationId}
-                        onEducationDeleted={handleEducationDeleted}
+                      vetId={vetId!}
+                      educationId={edu.educationId}
+                      onEducationDeleted={handleEducationDeleted}
                     />
                     <hr />
                   </div>

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -626,7 +626,27 @@ export default function VetDetails(): JSX.Element {
                   </div>
                 ))
               ) : (
-                <p>No education details available</p>
+                  // When there are no education entries
+                  <div>
+                    <p>No education details available</p>
+
+                    <div style={{ marginBottom: '20px', textAlign: 'right' }}>
+                      <button
+                          onClick={() => setFormVisible(prev => !prev)}
+                          style={{
+                            backgroundColor: formVisible ? '#ff6347' : '#4CAF50',
+                          }}
+                      >
+                        {formVisible ? 'Cancel' : 'Add Education'}
+                      </button>
+                      {formVisible && (
+                          <AddEducation
+                              vetId={vetId}
+                              onClose={() => setFormVisible(false)}
+                          />
+                      )}
+                    </div>
+                  </div>
               )}
               {selectedEducation && vetId && (
                 <UpdateVetEducation

--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -6,6 +6,7 @@ import axios from 'axios';
 import DeleteVetPhoto from '@/pages/Vet/DeleteVetPhoto.tsx';
 import UpdateVetEducation from '@/pages/Vet/UpdateVetEducation';
 import AddEducation from '@/pages/Vet/AddEducation.tsx';
+import DeleteVetEducation from '@/pages/Vet/DeleteVetEducation';
 
 interface VetResponseType {
   vetId: string;
@@ -108,6 +109,14 @@ export default function VetDetails(): JSX.Element {
       setIsDefaultPhoto(true); // This indicates the default photo is being used
     }
   }, [vetId]);
+  
+  const handleEducationDeleted = (deletedEducationId: string): void => {
+    setEducation(prevEducation =>
+        prevEducation
+            ? prevEducation.filter(edu => edu.educationId !== deletedEducationId)
+            : null
+    );
+  };
 
   const handlePhotoDeleted = (): void => {
     setIsDefaultPhoto(true);
@@ -608,6 +617,11 @@ export default function VetDetails(): JSX.Element {
                     >
                       Update Education
                     </button>
+                    <DeleteVetEducation
+                        vetId={vetId!}
+                        educationId={edu.educationId}
+                        onEducationDeleted={handleEducationDeleted}
+                    />
                     <hr />
                   </div>
                 ))

--- a/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
+++ b/vet-service/src/main/java/com/petclinic/vet/presentationlayer/VetController.java
@@ -227,12 +227,13 @@ public class VetController {
 
 
     @DeleteMapping("{vetId}/educations/{educationId}")
-    public Mono<Void> deleteEducationByEducationId(@PathVariable String vetId,
-                                                   @PathVariable String educationId){
-        return educationService.deleteEducationByEducationId(vetId, educationId);
-
-
+    public Mono<ResponseEntity<Void>> deleteEducationByEducationId(@PathVariable String vetId,
+                                                                   @PathVariable String educationId){
+        return educationService.deleteEducationByEducationId(vetId, educationId)
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()))
+                .onErrorResume(NotFoundException.class, e -> Mono.just(ResponseEntity.notFound().build()));
     }
+
     @PutMapping("{vetId}/educations/{educationId}")
     public Mono<ResponseEntity<EducationResponseDTO>> updateEducationByVetIdAndEducationId(@PathVariable String vetId,
                                                                                            @PathVariable String educationId,

--- a/vet-service/src/main/java/com/petclinic/vet/servicelayer/education/EducationServiceImpl.java
+++ b/vet-service/src/main/java/com/petclinic/vet/servicelayer/education/EducationServiceImpl.java
@@ -7,12 +7,14 @@ import com.petclinic.vet.dataaccesslayer.VetRepository;
 import com.petclinic.vet.exceptions.InvalidInputException;
 import com.petclinic.vet.exceptions.NotFoundException;
 import com.petclinic.vet.util.EntityDtoUtil;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
+@Slf4j
 @Service
 public class EducationServiceImpl implements EducationService {
     private final VetRepository vetRepository;
@@ -35,8 +37,11 @@ public class EducationServiceImpl implements EducationService {
     @Override
     public Mono<Void> deleteEducationByEducationId(String vetId, String educationId) {
         return educationRepository.findByVetIdAndEducationId(vetId, educationId)
-                .switchIfEmpty(Mono.error(new Exception("Education with id " + educationId + " not found.")))
-                .flatMap(educationRepository::delete);
+                .switchIfEmpty(Mono.error(new NotFoundException("Education with id " + educationId + " not found for vetId " + vetId)))
+                .flatMap(education -> {
+                    log.info("Deleting education with id {} for vetId {}", educationId, vetId);
+                    return educationRepository.delete(education);
+                });
     }
 
     @Override

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerIntegrationTest.java
@@ -1522,22 +1522,25 @@ class VetControllerIntegrationTest {
     }
     @Test
     void deleteAnEducationForVet_WithValidId_ShouldSucceed() {
-        Publisher<Education> setup = educationRepository.deleteAll().
-                thenMany(educationRepository.save(education1));
+        // Setup: Clear repository and save a new education
+        Publisher<Education> setup = educationRepository.deleteAll()
+                .thenMany(educationRepository.save(education1));
 
         StepVerifier
                 .create(setup)
                 .expectNextCount(1)
                 .verifyComplete();
 
+        // Execute: Send DELETE request
         client
                 .delete()
                 .uri("/vets/" + vet.getVetId() + "/educations/{educationId}", education1.getEducationId())
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk()
-                .expectBody();
+                .expectStatus().isNoContent() // Expect 204 No Content
+                .expectBody().isEmpty(); // Expect empty body
     }
+
     @Test
     void updateEducation_withValidVetIdAndValidEducationId_shouldSucceed() {
         Publisher<Education> setup = educationRepository.deleteAll()

--- a/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/presentationlayer/VetControllerUnitTest.java
@@ -646,11 +646,31 @@ class VetControllerUnitTest {
                 .uri("/vets/" + vetId + "/educations/{educationId}", educationId)
                 .accept(APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk();
+                .expectStatus().isNoContent();
+
+        Mockito.verify(educationService, times(1))
+                .deleteEducationByEducationId(vetId, educationId);
+    }
+
+    @Test
+    void deleteEducationForVetByEducationId_EducationNotFound() {
+        String educationId = "non-existent-id";
+        String vetId = "694ac37f-1e07-43c2-93bc-61839e61d989";
+
+        when(educationService.deleteEducationByEducationId(vetId, educationId))
+                .thenReturn(Mono.error(new NotFoundException("Education not found")));
+
+        client
+                .delete()
+                .uri("/vets/" + vetId + "/educations/{educationId}", educationId)
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound();
 
         Mockito.verify(educationService, times(1))
                 .deleteEducationByEducationId(vetId,educationId);
     }
+
     @Test
     void updateEducationWithValidVetIdAndValidEducationId_shouldSucceed(){
         EducationRequestDTO updatedEducation = EducationRequestDTO.builder()

--- a/vet-service/src/test/java/com/petclinic/vet/servicelayer/EducationServiceImplTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/servicelayer/EducationServiceImplTest.java
@@ -87,6 +87,7 @@ class EducationServiceImplTest {
                 .create(deletedEducation)
                 .verifyComplete();
     }
+
     @Test
     void updateEducationOfVet(){
         when(educationRepository.save(any())).thenReturn(Mono.just(education));

--- a/vet-service/src/test/java/com/petclinic/vet/servicelayer/EducationServiceImplTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/servicelayer/EducationServiceImplTest.java
@@ -61,6 +61,20 @@ class EducationServiceImplTest {
     Education education = buildEducation();
     EducationRequestDTO educationRequestDTO = buildEducationRequestDTO();
 
+    @Test
+    void getAllEducationsByVetId() {
+        when(educationRepository.findAllByVetId(anyString())).thenReturn(Flux.just(education));
+
+        Flux<EducationResponseDTO> educationResponseDTO = educationService.getAllEducationsByVetId("1");
+
+        StepVerifier
+                .create(educationResponseDTO)
+                .consumeNextWith(found -> {
+                    assertEquals(education.getEducationId(), found.getEducationId());
+                    assertEquals(education.getVetId(), found.getVetId());
+                })
+                .verifyComplete();
+    }
 
     @Test
     void deleteEducationByEducationId_Success() {

--- a/vet-service/src/test/java/com/petclinic/vet/servicelayer/EducationServiceImplTest.java
+++ b/vet-service/src/test/java/com/petclinic/vet/servicelayer/EducationServiceImplTest.java
@@ -63,21 +63,7 @@ class EducationServiceImplTest {
 
 
     @Test
-    void getAllEducationsByVetId() {
-        when(educationRepository.findAllByVetId(anyString())).thenReturn(Flux.just(education));
-
-        Flux<EducationResponseDTO> educationResponseDTO = educationService.getAllEducationsByVetId("1");
-
-        StepVerifier
-                .create(educationResponseDTO)
-                .consumeNextWith(found -> {
-                    assertEquals(education.getEducationId(), found.getEducationId());
-                    assertEquals(education.getVetId(), found.getVetId());
-                })
-                .verifyComplete();
-    }
-    @Test
-    void deleteEducationByEducationId() {
+    void deleteEducationByEducationId_Success() {
         when(educationRepository.findByVetIdAndEducationId(anyString(), anyString())).thenReturn(Mono.just(education));
         when(educationRepository.delete(any())).thenReturn(Mono.empty());
 
@@ -86,6 +72,18 @@ class EducationServiceImplTest {
         StepVerifier
                 .create(deletedEducation)
                 .verifyComplete();
+    }
+
+    @Test
+    void deleteEducationByEducationId_EducationNotFound() {
+        when(educationRepository.findByVetIdAndEducationId(anyString(), anyString())).thenReturn(Mono.empty());
+
+        Mono<Void> deletedEducation = educationService.deleteEducationByEducationId(education.getVetId(), education.getEducationId());
+
+        StepVerifier
+                .create(deletedEducation)
+                .expectError(NotFoundException.class)
+                .verify();
     }
 
     @Test


### PR DESCRIPTION
JIRA:https://champlainsaintlambert.atlassian.net/browse/CPC-1374

## Context:
This PR implements the functionality to delete an education entry for a veterinarian by their ID. The change addresses the need to allow users to manage veterinarians' education records more effectively, including the ability to remove outdated or incorrect entries. This enhancement improves the user experience by providing more control over the vet profiles in the system.

## Does this PR change the .vscode folder in petclinic-frontend?:
No, this PR does not include any changes to the .vscode folder.

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
Frontend:
 - Added src/features/veterinarians/api/deleteVetEducation.ts to handle API calls to the backend DELETE endpoint for education entries.
 - Added src/pages/Vet/DeleteVetEducation.tsx to provide a reusable component for deleting education entries from the vet details page.
 - Added handleEducationDeleted function to update the local state after an education entry is deleted.
 - Ensured that the "Add Education" button remains visible even after deleting all education entries.
 
Backend:
 - Modified the controller to return 204 No Content instead of 200 OK for DELETE operations without a response body.
 - Changed test assertions to expect 204 No Content in VetControllerIntegrationTest.java.


## Before and After UI (Required for UI-impacting PRs)

Before:

The vet details page displayed education entries without an option to delete them. Users could not remove education records, limiting their ability to manage vet profiles fully.
//

![image](https://github.com/user-attachments/assets/38fb5e40-e7ce-4bec-b1af-8975a9ea6b71)

//
//
//
After:

Each education entry now includes a "Delete Education" button. Users can delete an education entry, which immediately updates the UI to reflect the change. The "Add Education" button remains visible even when there are no education entries.
//

![image](https://github.com/user-attachments/assets/2616b315-9a8a-44d7-af27-a5e4daecede2)

//

![image](https://github.com/user-attachments/assets/bd3601a8-b640-403d-939c-bc766d486572)

//

![image](https://github.com/user-attachments/assets/3b8e6334-fa4b-4020-af56-c99dc05b0563)



## Dev notes (Optional)

Frontend:

 - The DeleteVetEducation component uses an onEducationDeleted callback to update the parent component's state, ensuring the UI reflects the deletion immediately.
 - In VetDetails.tsx, the "Add Education" button is displayed both when education entries exist and when the list is empty.

Backend:

 - Returning 204 No Content for successful DELETE operations adheres to RESTful best practices.
 -  Updated exception handling to ensure proper HTTP status codes and messages are returned.

## Linked pull requests (Optional)
Pull request links