### PR TITLE
bug(CART-CPC-1463): remove duplicate out of stock overlay in wishlist

### DIFF
--- a/petclinic-frontend/src/features/carts/components/UserCart.css
+++ b/petclinic-frontend/src/features/carts/components/UserCart.css
@@ -411,3 +411,18 @@
 .cart-header-title {
   margin-top: 20px;
 }
+
+/* If the overlay is an actual <img> with matching src or alt */
+.Wishlist-items img[src*="out-of-stock" i],
+.Wishlist-items img[alt*="out of stock" i],
+.Wishlist-items .oos-overlay {
+  display: none !important;
+}
+
+/* If the overlay is drawn via pseudo-elements (ribbons/badges) */
+.Wishlist-items *::before,
+.Wishlist-items *::after {
+  /* suppress when OOS ribbon text/image is explicitly called*/
+  background-image: none !important;
+  content: normal; 
+}


### PR DESCRIPTION
##JIRA: https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/73/backlog?selectedIssue=CPC-1463&text=CART

##Context:
This ticket addresses a UI bug where the “Out of Stock” label appeared twice in the Wishlist view, one of them was an image overlay that was on top of the label, and the other one was a text badge that was under the label. It was creating a confusion where two label would be on top of each other making it less appealing and disturbing. The change ensures that only the text badge is displayed, while the duplicate image overlay is hidden.

##Does this PR change the .vscode folder in petclinic-frontend?:
No, this PR does not modify the .vscode folder.

##Changes
Updated UserCart.css to scope styles so that overlay ribbons/images are hidden in the Wishlist section.
Ensured that the text-based “Out of stock” badge remains visible for clarity.
Scoped fix only to Wishlist items — no changes to cart items or other modules.

##Does this use the v2 API?:
No, this change is entirely frontend/UI related and does not touch API calls.
Does this add a new communication between services?:
No, this PR does not introduce any new communication between services.

##Before and After UI (Required for UI-impacting PRs)
Before:
Wishlist items displayed two “Out of Stock” indicators (image overlay + text badge).
After:
Wishlist items display only the text badge “Out of Stock”, with the duplicate image overlay removed.

##images
Before: 
<img width="1482" height="324" alt="image" src="https://github.com/user-attachments/assets/3348ad61-ee3a-4c2e-bde4-cbc7cdec4285" />
After: 
<img width="1489" height="262" alt="image" src="https://github.com/user-attachments/assets/6f389869-d153-4c1b-adb2-481edfdbb945" />


Dev notes (Optional)
Linked pull requests (Optional)