### PR TITLE
bug(INVT-CPC-1465): Fix translation formatting

### DIFF
--- a/petclinic-frontend/src/features/inventories/InventoryProducts.css
+++ b/petclinic-frontend/src/features/inventories/InventoryProducts.css
@@ -200,3 +200,43 @@ select:focus {
   margin: 20px 0;
   float: right;
 }
+.table th,
+.table td {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  text-overflow: initial;
+  line-height: 1.2;
+}
+
+.table td:nth-child(4),
+.table td:nth-child(5),
+.table td:nth-child(6),
+.table td:nth-child(7) {
+  white-space: nowrap;
+}
+
+.table th:nth-child(2),
+.table th:nth-child(3) {
+  min-width: 16ch;
+}
+.table th:nth-child(6) {
+  min-width: 12ch;
+}
+
+.table th:nth-child(4),
+.table th:nth-child(5),
+.table th:nth-child(6) {
+  word-spacing: normal;
+}
+
+@media (min-width: 992px) {
+  .table { table-layout: auto; }
+}
+
+#google_translate_element {
+  float: right;
+  width: auto;
+  max-width: 320px;
+  margin: 12px 0 16px 16px;
+}

--- a/petclinic-frontend/src/features/inventories/InventoryProducts.css
+++ b/petclinic-frontend/src/features/inventories/InventoryProducts.css
@@ -240,3 +240,16 @@ select:focus {
   max-width: 320px;
   margin: 12px 0 16px 16px;
 }
+.card button[type="submit"],
+form button[type="submit"].btn {
+  width: auto !important;
+  min-width: 10rem;
+  max-width: 100%;
+  padding-inline: 16px;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+button.btn {
+  word-break: keep-all;
+}


### PR DESCRIPTION
**JIRA:**
https://champlainsaintlambert.atlassian.net/browse/CPC-1465

## Context:
The ticket is about fixing the UI when translating to other languages, specifically when translating into certain languages, some texts don't fully show up which cuts off some words. Also when using the edit or move button, when brought to their respective page, the translation formatting is also bad there. We are doing this change to make the UI cleaner whether it's in english or any other translated language for a better overall user experience.

## Does this PR change the .vscode folder in petclinic-frontend?:
No.

## Changes
- The only file changed was InventoryProducts.css. 
- Allowed table headers (<th>) and cells (<td>) to wrap/break text so translated French/German/Spanish labels don’t overflow.
- Added column-specific widths (Supply Id, Supply Name, Description, etc.).
- Overrode fixed widths for form buttons like Update and Move so translated labels fit without splitting or clipping.
- Added CSS rules: min-width, white-space: nowrap, and width: auto

## Does this use the v2 API?:
No.

## Does this add a new communication between services?:
No.

## Before and After UI (Required for UI-impacting PRs)
Before(Text is cut off in other languages and is replaced with "..."
<img width="1917" height="990" alt="Screenshot 2025-09-25 203642" src="https://github.com/user-attachments/assets/f213b56c-5ba6-4c72-83e9-0b5d8bdadbc2" />
After(Text fully shows)
<img width="1914" height="983" alt="image" src="https://github.com/user-attachments/assets/399882fb-227a-448a-a8b8-0851f62b24cf" />
Before(Text is overflowing when translated for edit button)
<img width="496" height="696" alt="Screenshot 2025-09-25 205030" src="https://github.com/user-attachments/assets/e07e8d7d-885d-49ba-b723-6ca294f7c4c5" />
After(Fixed)
<img width="1913" height="981" alt="image" src="https://github.com/user-attachments/assets/e799ba93-898c-42e5-865b-531288294bcf" />
Before(Text is overflowing when translated for move button)
<img width="1919" height="984" alt="image" src="https://github.com/user-attachments/assets/84f44629-1070-4249-ba9d-9b61e0e056bf" />
After(Fixed)
<img width="1914" height="708" alt="image" src="https://github.com/user-attachments/assets/76c228ca-7052-4786-89e0-0fbc6a68d1e3" />