### PR TITLE
bug(VIST-CPC-1572): fixed the apI fetch of get list getallvisits.ts and getallemergency.ts

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -334,20 +334,6 @@ public class BFFApiGatewayController {
     }
 
 
-
-
-
-
-
-
-
-
-    @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
-    @GetMapping(value = "visits", produces= MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<VisitResponseDTO> getAllVisits(@RequestParam(required = false) String description){
-        return visitsServiceClient.getAllVisits(description);
-    }
-
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN,Roles.VET,Roles.OWNER})
     @IsUserSpecific(idToMatch = {"ownerId"}, bypassRoles = {Roles.ADMIN,Roles.VET})
     @GetMapping(value = "visits/owners/{ownerId}", produces= MediaType.TEXT_EVENT_STREAM_VALUE)

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -334,6 +334,20 @@ public class BFFApiGatewayController {
     }
 
 
+
+
+
+
+
+
+
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
+    @GetMapping(value = "visits", produces= MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<VisitResponseDTO> getAllVisits(@RequestParam(required = false) String description){
+        return visitsServiceClient.getAllVisits(description);
+    }
+
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN,Roles.VET,Roles.OWNER})
     @IsUserSpecific(idToMatch = {"ownerId"}, bypassRoles = {Roles.ADMIN,Roles.VET})
     @GetMapping(value = "visits/owners/{ownerId}", produces= MediaType.TEXT_EVENT_STREAM_VALUE)

--- a/petclinic-frontend/src/features/visits/Emergency/Api/getAllEmergency.ts
+++ b/petclinic-frontend/src/features/visits/Emergency/Api/getAllEmergency.ts
@@ -3,18 +3,7 @@ import { EmergencyResponseDTO } from '../Model/EmergencyResponseDTO';
 
 export async function getAllEmergency(): Promise<EmergencyResponseDTO[]> {
   const response = await axiosInstance.get(`/visits/emergency`, {
-    // responseType: 'stream',
     useV2: true,
   });
-  return response.data // Return only the data
-    // .split('data:')
-    // .map((payLoad: string) => {
-    //   try {
-    //     if (payLoad == '') return null;
-    //     return JSON.parse(payLoad);
-    //   } catch (err) {
-    //     console.error("Can't parse JSON: " + err);
-    //   }
-    // })
-    // .filter((data?: JSON) => data !== null);
+  return response.data;
 }

--- a/petclinic-frontend/src/features/visits/Emergency/Api/getAllEmergency.ts
+++ b/petclinic-frontend/src/features/visits/Emergency/Api/getAllEmergency.ts
@@ -4,17 +4,17 @@ import { EmergencyResponseDTO } from '../Model/EmergencyResponseDTO';
 export async function getAllEmergency(): Promise<EmergencyResponseDTO[]> {
   const response = await axiosInstance.get(`/visits/emergency`, {
     // responseType: 'stream',
-    useV2: false,
+    useV2: true,
   });
   return response.data // Return only the data
-    .split('data:')
-    .map((payLoad: string) => {
-      try {
-        if (payLoad == '') return null;
-        return JSON.parse(payLoad);
-      } catch (err) {
-        console.error("Can't parse JSON: " + err);
-      }
-    })
-    .filter((data?: JSON) => data !== null);
+    // .split('data:')
+    // .map((payLoad: string) => {
+    //   try {
+    //     if (payLoad == '') return null;
+    //     return JSON.parse(payLoad);
+    //   } catch (err) {
+    //     console.error("Can't parse JSON: " + err);
+    //   }
+    // })
+    // .filter((data?: JSON) => data !== null);
 }

--- a/petclinic-frontend/src/features/visits/api/getAllVisits.ts
+++ b/petclinic-frontend/src/features/visits/api/getAllVisits.ts
@@ -5,7 +5,7 @@ export async function getAllVisits(): Promise<VisitResponseModel[]> {
   try {
     const response = await axiosInstance.get('/visits', {
       responseType: 'stream',
-      useV2: false,
+      useV2: true,
     });
     return response.data
       .split('data:')


### PR DESCRIPTION
**JIRA:** [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1572)
## Context:
The  visits table was getting errors when trying to fetch visits and emergency visits. 

## Does this PR change the .vscode folder in petclinic-frontend?:
No

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
- Changed the axios version of getAllVisits and getAllEmergency to V2
- Removed the unused getAllVisits from api gateway V1
- Removed the incorrect data parsing in getAllEmergency 
    - Backend was returning a JSON and frontend was expecting a stream


## Does this use the v2 API?:
No it does not

## Does this add a new communication between services?:
No it does not

## Before and After UI (Required for UI-impacting PRs)

Before
<img width="1881" height="1027" alt="image" src="https://github.com/user-attachments/assets/2ceb53ed-af60-4fc1-b43c-213c6692ba3a" />

After
<img width="1887" height="1034" alt="image" src="https://github.com/user-attachments/assets/c37daec9-ec1f-49e5-a664-c1dbe1b68042" />

## Dev notes (Optional)
Specific technical changes that should be noted
## Linked pull requests (Optional)
Pull request links