### PR TITLE
conf(AUTH-CPC-1580): fix go workflow failing due to swag version compatibility

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.20'
+          go-version: '1.24'
 
       - name: Install Go Swagger CLI
         run: go install github.com/swaggo/swag/cmd/swag@v1.3.2

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-# Test commit

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+# Test commit


### PR DESCRIPTION
https://champlainsaintlambert.atlassian.net/browse/CPC-1580 
## Context:

The Go workflow in the CI/CD pipeline was failing for everyone because the swag tool version 1.3.2 requires Go 1.24 features but the workflow was using Go 1.20.14 blocking the CI/CD pipeline.

## Does this PR change the .vscode folder in petclinic-frontend?:
No

## Changes

Updated Go version from 1.20 to 1.24 in .github/workflows/go.yml

## Does this use the v2 API?:

If the PR uses the v2 API, explain why
No

## Does this add a new communication between services?:
No
## Before and After UI (Required for UI-impacting PRs)
No UI change
## Dev notes (Optional)
Specific technical changes that should be noted
## Linked pull requests (Optional)
Pull request links