### PR TITLE
(INVT-CPC-1550) Change-Inventory-UUID-Into-Inventory-Name feat(INVT-CPC-1550) Change-Inventory-UUID-Into-Inventory-Name

### DIFF
--- a/api-gateway/src/main/resources/static/css/bill-history.css
+++ b/api-gateway/src/main/resources/static/css/bill-history.css
@@ -1,0 +1,31 @@
+.bill-history-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+}
+
+.bill-history-search {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.bill-history-filter {
+    margin-bottom: 1rem;
+}
+
+.filter-group {
+    margin-bottom: 0.75rem;
+}
+
+.filter-options {
+    display: flex;
+    gap: 1rem;
+}
+
+.filter-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}

--- a/api-gateway/src/main/resources/static/index.html
+++ b/api-gateway/src/main/resources/static/index.html
@@ -20,6 +20,8 @@
     <!-- Vet service styling for vet table on different screen widths-->
     <link href="/css/vets/vetTable.css" rel="stylesheet" type="text/css"/>
 
+    <link href="/css/bill-history.css" rel="stylesheet" type="text/css"/>
+
     <link href="/css/vets/sevenDaysCalendar.css" rel="stylesheet" type="text/css"/>
 
     <!--Vet Service styling for form -->
@@ -43,8 +45,6 @@
     <script src="/webjars/angular-ui-router/1.0.28/release/angular-ui-router.min.js"></script>
 
     <script src="scripts/app.js"></script>
-
-
 
     <script src="scripts/owner-list/owner-list.js"></script>
     <script src="scripts/owner-list/owner-list.controller.js"></script>

--- a/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.controller.js
@@ -1,474 +1,214 @@
 'use strict';
 
 angular.module('billHistory')
-    .controller('BillHistoryController', ['$http','$stateParams', '$scope', '$state', function ($http,$stateParams, $scope, $state) {
-        var vm = this;
-        vm.billHistory = []
-        vm.paidBills = []
-        vm.unpaidBills = []
-        vm.overdueBills = []
+    .controller('BillHistoryController', ['$http','$stateParams', '$scope', '$state',
+        function ($http,$stateParams, $scope, $state) {
+            var vm = this;
 
-        // Pagination properties
-        vm.currentPage = $stateParams.page || 0;
-        vm.pageSize = $stateParams.size || 10; // Number of items per page
-        vm.currentPageOnSite = parseInt(vm.currentPage) + 1;
-
-        vm.billId = null;
-        vm.customerId = null;
-        vm.ownerFirstName = null;
-        vm.ownerLastName = null;
-        vm.visitType = null;
-        vm.vetId = null;
-        vm.vetFirstName = null;
-        vm.vetLastName = null;
-
-        vm.selectedSize = null;
-        vm.searchActive = false;
-
-        vm.baseURL = "api/gateway/bills/bills-pagination";
-        vm.baseURLforTotalNumberOfBillsByFiltering = "api/gateway/bills/bills-filtered-count"
-
-        loadDefaultData();
-
-            // Pageable pageable,
-            // String billId,
-            // String customerId,
-            // String ownerFirstName,
-            // String ownerLastName,
-            // String visitType,
-            // String vetId,
-            // String vetFirstName,
-            // String vetLastName
-
-        function loadTotalItemForDefaultData() {
-
-            return $http.get('api/gateway/bills/bills-count')
-                .then(function (resp) {
-                    console.log(resp);
-                    return resp.data;
-                });
-        }
-
-        function loadTotalItemForSearchData(searchURL) {
-            return $http.get(searchURL)
-                .then(function (resp) {
-                    console.log(resp);
-                    return resp.data;
-                });
-        }
-
-        function loadDefaultData() {
-            // $state.transitionTo('bills', { page: vm.currentPage, size: vm.pageSize}, { notify: false });
-
-            if(!vm.searchActive){
-                loadTotalItemForDefaultData().then(function (totalItems) {
-                    vm.totalItems = totalItems;
-                    vm.totalPages = Math.ceil(vm.totalItems / parseInt(vm.pageSize));
-                    $http.get('api/gateway/bills/bills-pagination?page=' + vm.currentPage + '&size=' + vm.pageSize)
-                        .then(function (resp) {
-                            vm.billHistory = resp.data;
-                            console.log(resp);
-                        });
-
-                    updateCurrentPageOnSite();
-                });
-            }
-        }
-
-
-        vm.searchBillsByPaginationAndFilters = function (currentPage = 0, prevOrNextPressed = false) {
-            // Collect search parameters
-            vm.selectedSize = document.getElementById("sizeInput").value;
-
-            if(!prevOrNextPressed) {
-                vm.billId = document.getElementById("billIdInput").value;
-                vm.customerId = document.getElementById("customerIdInput").value;
-                vm.ownerFirstName = document.getElementById("ownerFirstNameInput").value;
-                vm.ownerLastName = document.getElementById("ownerLastNameInput").value;
-                vm.visitType = document.getElementById("visitTypeInput").value;
-                vm.vetId = document.getElementById("vetIdInput").value;
-                vm.vetFirstName = document.getElementById("vetFirstNameInput").value;
-                vm.vetLastName = document.getElementById("vetLastNameInput").value;
-
-                // Check if all input fields are empty
-                // if (checkIfAllInputFieldsAreEmptyOrNull(vm.billId, vm.customerId, vm.ownerFirstName, vm.ownerLastName,
-                //     vm.visitType, vm.vetId, vm.vetFirstName, vm.vetLastName, vm.selectedSize)) {
-                //     alert("Oops! It seems like you forgot to enter any filter criteria. Please provide some filter input to continue.");
-                //     return;
-                // }
-            }
-
-
-
-            vm.searchActive = true;
-
-            // Construct the search URL
-            var searchURL = vm.baseURL + "?page=" + currentPage.toString();
-            var loadTotalNumberOfDataURL  = vm.baseURLforTotalNumberOfBillsByFiltering + "?";
-
-            if (vm.selectedSize) {
-                searchURL += "&size=" + vm.selectedSize;
-                vm.pageSize = vm.selectedSize
-            } else {
-                searchURL += "&size=" + vm.pageSize;
-            }
-
-            if (vm.billId) {
-                searchURL += "&billId=" + vm.billId;
-                loadTotalNumberOfDataURL += "&billId=" + vm.billId;
-            }
-
-            if (vm.customerId) {
-                searchURL += "&customerId=" + vm.customerId;
-                loadTotalNumberOfDataURL += "&customerId=" + vm.customerId;
-            }
-
-            if (vm.ownerFirstName) {
-                searchURL += "&ownerFirstName=" + vm.ownerFirstName;
-                loadTotalNumberOfDataURL += "&ownerFirstName=" + vm.ownerFirstName;
-            }
-
-            if (vm.ownerLastName) {
-                searchURL += "&ownerLastName=" + vm.ownerLastName;
-                loadTotalNumberOfDataURL += "&ownerLastName=" + vm.ownerLastName;
-            }
-
-            if (vm.visitType) {
-                searchURL += "&visitType=" + vm.visitType;
-                loadTotalNumberOfDataURL += "&visitType=" + vm.visitType;
-            }
-
-            if (vm.vetId) {
-                searchURL += "&vetId=" + vm.vetId;
-                loadTotalNumberOfDataURL += "&vetId=" + vm.vetId;
-            }
-
-            if (vm.vetFirstName) {
-                searchURL += "&vetFirstName=" + vm.vetFirstName;
-                loadTotalNumberOfDataURL += "&vetFirstName=" + vm.vetFirstName;
-            }
-
-            if (vm.vetLastName) {
-                searchURL += "&vetLastName=" + vm.vetLastName;
-                loadTotalNumberOfDataURL += "&vetLastName=" + vm.vetLastName;
-            }
-
-            console.log(searchURL);
-
-            loadTotalItemForSearchData(loadTotalNumberOfDataURL).then(function (totalItems) {
-                vm.totalItems = totalItems;
-                vm.totalPages = Math.ceil(vm.totalItems / parseInt(vm.pageSize));
-            });
-
-            // Rest of your data loading logic
-            $http.get(searchURL)
-                .then(function (resp) {
-                    vm.billHistory = resp.data;
-                    console.log(resp);
-                });
-
-            updateCurrentPageOnSite();
-        }
-
-        vm.goNextPage = function () {
-            if (parseInt(vm.currentPage) + 1 < vm.totalPages) {
-
-                var currentPageInt = parseInt(vm.currentPage) + 1
-                vm.currentPage = currentPageInt.toString();
-                updateCurrentPageOnSite();
-
-                if(vm.searchActive){
-                    vm.searchBillsByPaginationAndFilters(currentPageInt,true)
-                } else {
-                    loadDefaultData();
+            vm.toolbar = { open: null };
+            vm.togglePanel = function(which){
+                vm.toolbar.open = (vm.toolbar.open === which) ? null : which;
+                if (vm.toolbar.open === 'filter') {
+                    vm.tempStatus     = vm.activeStatus;
+                    vm.tempVisitType  = vm.activeVisitType;
+                    vm.tempYear       = vm.filterYear;
                 }
+            };
 
+            (function buildYears(){
+                vm.availableYears = [];
+                var now = new Date().getFullYear();
+                for (var y = now; y >= now - 14; y--) vm.availableYears.push(y);
+            })();
 
+            vm.activeStatus = '';
+            vm.activeVisitType = '';
+            vm.filterYear = '';
+
+            vm.tempStatus = '';
+            vm.tempVisitType = '';
+            vm.tempYear = '';
+
+            vm.applyFilter = function(){
+                vm.activeStatus    = (vm.tempStatus || '').toLowerCase();
+                vm.activeVisitType = (vm.tempVisitType || '').toLowerCase();
+                vm.filterYear      = vm.tempYear || '';
+                vm.toolbar.open = null;
+            };
+            vm.resetFilter = function(){
+                vm.tempStatus = vm.tempVisitType = '';
+                vm.tempYear = '';
+                vm.activeStatus = vm.activeVisitType = '';
+                vm.filterYear = '';
             }
-        }
 
-        vm.goPreviousPage = function () {
-            if (vm.currentPage - 1 >= 0) {
-                var currentPageInt = parseInt(vm.currentPage) - 1
-                vm.currentPage = currentPageInt.toString();
-                updateCurrentPageOnSite();
-
-                if(vm.searchActive){
-                    vm.searchBillsByPaginationAndFilters(currentPageInt,true)
-                } else {
-                    loadDefaultData();
+            vm.getRows = function(){
+                switch (vm.activeStatus) {
+                    case 'paid':    return vm.paidBills;
+                    case 'unpaid':  return vm.unpaidBills;
+                    case 'overdue': return vm.overdueBills;
+                    default:        return vm.billHistory;
                 }
-            }
-        }
+            };
 
-        function updateCurrentPageOnSite() {
+            vm.visitTypePredicate = function(bill){
+                if (!vm.activeVisitType) return true;
+                var v = (bill && bill.visitType) ? String(bill.visitType).toLowerCase() : '';
+                return v === vm.activeVisitType;
+            };
+
+            vm.billHistory = [];
+            vm.paidBills = [];
+            vm.unpaidBills = [];
+            vm.overdueBills = [];
+
+            vm.currentPage = $stateParams.page || 0;
+            vm.pageSize = $stateParams.size || 10;
             vm.currentPageOnSite = parseInt(vm.currentPage) + 1;
-            console.log(vm.currentPage);
-        }
+            vm.page = vm.currentPageOnSite;
+            vm.totalPages = 1;
 
-        vm.owners = [
-            { ownerId: '1', firstName: 'George', lastName: 'Franklin' },
-            { ownerId: '2', firstName: 'Betty', lastName: 'Davis' },
-            { ownerId: '3', firstName: 'Eduardo', lastName: 'Rodriguez' },
-            { ownerId: '4', firstName: 'Harold', lastName: 'Davis' },
-            { ownerId: '5', firstName: 'Peter', lastName: 'McTavish' },
-            { ownerId: '6', firstName: 'Jean', lastName: 'Coleman' },
-            { ownerId: '7', firstName: 'Jeff', lastName: 'Black' },
-            { ownerId: '8', firstName: 'Maria', lastName: 'Escobito' },
-            { ownerId: '9', firstName: 'David', lastName: 'Schroeder' },
-            { ownerId: '10', firstName: 'Carlos', lastName: 'Esteban' }
-        ];
+            vm.baseURL = "api/gateway/bills/bills-pagination";
+            vm.baseURLforTotalNumberOfBillsByFiltering = "api/gateway/bills/bills-filtered-count";
+            vm.searchActive = false;
 
-        vm.ownersUUID = [
-            { ownerId: 'f470653d-05c5-4c45-b7a0-7d70f003d2ac', firstName: 'George', lastName: 'Franklin' },
-            { ownerId: 'e6c7398e-8ac4-4e10-9ee0-03ef33f0361a', firstName: 'Betty', lastName: 'Davis' },
-            { ownerId: '3f59dca2-903e-495c-90c3-7f4d01f3a2aa', firstName: 'Eduardo', lastName: 'Rodriguez' },
-            { ownerId: 'a6e0e5b0-5f60-45f0-8ac7-becd8b330486', firstName: 'Harold', lastName: 'Davis' },
-            { ownerId: 'c6a0fb9d-fc6f-4c21-95fc-4f5e7311d0e2', firstName: 'Peter', lastName: 'McTavish' },
-            { ownerId: 'b3d09eab-4085-4b2d-a121-78a0a2f9e501', firstName: 'Jean', lastName: 'Coleman' },
-            { ownerId: '5fe81e29-1f1d-4f9d-b249-8d3e0cc0b7dd', firstName: 'Jeff', lastName: 'Black' },
-            { ownerId: '48f9945a-4ee0-4b0b-9b44-3da829a0f0f7', firstName: 'Maria', lastName: 'Escobito' },
-            { ownerId: '9f6accd1-e943-4322-932e-199d93824317', firstName: 'David', lastName: 'Schroeder' },
-            { ownerId: '7c0d42c2-0c2d-41ce-bd9c-6ca67478956f', firstName: 'Carlos', lastName: 'Esteban' }
-        ];
+            loadDefaultData();
 
-
-        $http.get('api/gateway/vets').then(function (resp) {
-            vm.vetList = resp.data;
-            arr = resp.data;
-            // console.log(resp)
-        });
-
-        $http.get('api/gateway/owners').then(function (owners) {
-            vm.ownersInfoArray = owners.data;
-            // console.log(vm.ownersInfoArray)
-            vm.ownersInfoArray.forEach(function(owner) {
-                console.log(owner.ownerId);
-            });
-        });
-        // vm.getOwnerUUIDByName = function(customerId) {
-        //     const owner = vm.ownersInfoArray.find(function(owner) {
-        //         return owner.firstName === firstName && owner.lastName === lastName;
-        //     });
-        //
-        //     if (owner) {
-        //         return owner.ownerId;
-        //     }
-        //
-        //     return 'unknown-uuid';
-        // };
-
-        $scope.getOwnerUUIDByCustomerId = function(customerId) {
-            let foundOwner;
-            // Iterate through vm.owners to find a matching customerId
-            vm.owners.forEach(function(owner) {
-                if (owner.ownerId === customerId.toString()) {
-                    foundOwner = owner;
-                }
-            });
-            vm.ownersUUID.forEach(function(owner) {
-                if (owner.ownerId === customerId.toString()) {
-                    foundOwner = owner;
-                }
-            });
-            if (foundOwner) {
-                // Get the first and last name from the foundOwner
-                const firstName = foundOwner.firstName;
-                const lastName = foundOwner.lastName;
-
-                const ownerInfo = vm.ownersInfoArray.find(function(owner) {
-                    return owner.firstName === firstName && owner.lastName === lastName;
-                });
-                if (ownerInfo) {
-                    return ownerInfo.ownerId;
+            function loadTotalItemForDefaultData() {
+                return $http.get('api/gateway/bills/bills-count')
+                    .then(function (resp) { return resp.data; });
+            }
+            function loadDefaultData() {
+                if (!vm.searchActive){
+                    loadTotalItemForDefaultData().then(function (totalItems) {
+                        vm.totalItems = totalItems;
+                        vm.totalPages = Math.ceil(vm.totalItems / parseInt(vm.pageSize));
+                        $http.get(vm.baseURL + '?page=' + vm.currentPage + '&size=' + vm.pageSize)
+                            .then(function (resp) { vm.billHistory = resp.data; });
+                        updateCurrentPageOnSite();
+                    });
                 }
             }
-
-            return 'Unknown Owner';
-        };
-
-
-
-
-        vm.getOwnerInfoByCustomerId = function (customerId) {
-            const owner = vm.ownerIdToInfoMap[customerId];
-            return owner || {};
-        };
-
-        vm.getOwnerFullName = function (customerId) {
-            const owner = vm.ownerIdToInfoMap[customerId];
-            if (owner) {
-                return owner.firstName + ' ' + owner.lastName;
-            }
-            return 'Unknown Owner';
-        };
-
-        vm.customerNameMap = {};
-        vm.customerNameMap2 = {};
-
-        vm.owners.forEach(function (customer) {
-            // The customer's ownerId is used as the key, and their full name as the value
-            vm.customerNameMap[customer.ownerId] = customer.firstName + ' ' + customer.lastName;
-        });
-
-        vm.ownersUUID.forEach(function (customer) {
-            vm.customerNameMap2[customer.ownerId] = customer.firstName + ' ' + customer.lastName;
-        });
-
-        let eventSource = new EventSource("api/gateway/bills")
-        eventSource.addEventListener('message',function (event){
-            $scope.$apply(function (){
-                vm.billHistory.push(JSON.parse(event.data))
-            })
-        })
-        eventSource.onerror = (error)=>{
-            if(eventSource.readyState === 0){
-                eventSource.close()
-                console.log("Event source was closed by server successfully. " + error)
-            }else{
-                console.log("EventSource error: "+error)
-            }
-        }
-
-        let eventSourcePaid = new EventSource("api/gateway/bills/paid")
-        eventSourcePaid.addEventListener('message',function (event){
-            $scope.$apply(function (){
-                vm.paidBills.push(JSON.parse(event.data))
-            })
-        })
-
-        eventSourcePaid.onerror = (error)=>{
-            if(eventSourcePaid.readyState === 0){
-                eventSourcePaid.close()
-                console.log("Event source was closed by server successfully. " + error)
-            }else{
-                console.log("EventSource error: "+error)
-            }
-        }
-
-        let eventSourceUnpaid = new EventSource("api/gateway/bills/unpaid")
-        eventSourceUnpaid.addEventListener('message',function (event){
-            $scope.$apply(function (){
-                vm.unpaidBills.push(JSON.parse(event.data))
-            })
-        })
-
-        eventSourceUnpaid.onerror = (error)=>{
-            if(eventSourceUnpaid.readyState === 0){
-                eventSourceUnpaid.close()
-                console.log("Event source was closed by server successfully. " + error)
-            }else{
-                console.log("EventSource error: "+error)
-            }
-        }
-
-        let eventSourceOverdue = new EventSource("api/gateway/bills/overdue")
-        eventSourceOverdue.addEventListener('message',function (event){
-            $scope.$apply(function (){
-                vm.overdueBills.push(JSON.parse(event.data))
-            })
-        })
-
-        eventSourceOverdue.onerror = (error)=>{
-            if(eventSourceOverdue.readyState === 0){
-                eventSourceOverdue.close()
-                console.log("Event source was closed by server successfully. " + error)
-            }else{
-                console.log("EventSource error: "+error)
-            }
-        }
-
-        // Assuming that vm.owners is an array of owner objects
-        vm.getOwnerById = function(ownerId) {
-            // Find and return the owner with the given ownerId
-            for (var i = 0; i < vm.owners.length; i++) {
-                if (vm.owners[i].ownerId === ownerId) {
-                    return vm.owners[i];
+            vm.goNextPage = function () {
+                if (parseInt(vm.currentPage) + 1 < vm.totalPages) {
+                    vm.currentPage = (parseInt(vm.currentPage) + 1).toString();
+                    updateCurrentPageOnSite(); loadDefaultData();
                 }
+            };
+            vm.goPreviousPage = function () {
+                if (vm.currentPage - 1 >= 0) {
+                    vm.currentPage = (parseInt(vm.currentPage) - 1).toString();
+                    updateCurrentPageOnSite(); loadDefaultData();
+                }
+            };
+            function updateCurrentPageOnSite() {
+                vm.currentPageOnSite = parseInt(vm.currentPage) + 1;
+                vm.page = vm.currentPageOnSite;
             }
-            return null; // Handle if owner not found
-        };
 
-
-        $scope.getVetDetails = function(vetId) {
-            const vet = vm.vetList.find(function(vet) {
-                return vet.vetBillId === vetId;
+            var eventSource = new EventSource("api/gateway/bills");
+            eventSource.addEventListener('message', function (event) {
+                $scope.$apply(function () { vm.billHistory.push(JSON.parse(event.data)); });
             });
-            const vet2 = vm.vetList.find(function(vet) {
-                return vet.vetId === vetId;
+            eventSource.onerror = function(){ if (eventSource.readyState === 0) eventSource.close(); };
+
+            var eventSourcePaid = new EventSource("api/gateway/bills/paid");
+            eventSourcePaid.addEventListener('message', function (event) {
+                $scope.$apply(function () { vm.paidBills.push(JSON.parse(event.data)); });
             });
-            if (vet) {
-                return vet.firstName + ' ' + vet.lastName;
-            } else if (vet2) {
-                return vet2.firstName + ' ' + vet2.lastName;
-            } else {
-                return 'Unknown Vet';
-            }
-        };
+            eventSourcePaid.onerror = function(){ if (eventSourcePaid.readyState === 0) eventSourcePaid.close(); };
 
-        $scope.getCustomerDetails = function(customerId) {
-            const customerName = vm.customerNameMap[customerId];
-            const customerName2 = vm.customerNameMap2[customerId];
-            if (customerName) {
-                return customerName;
-            } else if (customerName2) {
-                return customerName2;
-            } else {
-                return 'Unknown Customer';
-            }
-        };
+            var eventSourceUnpaid = new EventSource("api/gateway/bills/unpaid");
+            eventSourceUnpaid.addEventListener('message', function (event) {
+                $scope.$apply(function () { vm.unpaidBills.push(JSON.parse(event.data)); });
+            });
+            eventSourceUnpaid.onerror = function(){ if (eventSourceUnpaid.readyState === 0) eventSourceUnpaid.close(); };
 
+            var eventSourceOverdue = new EventSource("api/gateway/bills/overdue");
+            eventSourceOverdue.addEventListener('message', function (event) {
+                $scope.$apply(function () { vm.overdueBills.push(JSON.parse(event.data)); });
+            });
+            eventSourceOverdue.onerror = function(){ if (eventSourceOverdue.readyState === 0) eventSourceOverdue.close(); };
 
-        $scope.deleteAllBills = function () {
-            let varIsConf = confirm('Are you sure you want to delete all the bills in the bill history');
-            if (varIsConf) {
+            vm.owners = [
+                { ownerId: '1', firstName: 'George', lastName: 'Franklin' },
+                { ownerId: '2', firstName: 'Betty', lastName: 'Davis' },
+                { ownerId: '3', firstName: 'Eduardo', lastName: 'Rodriguez' },
+                { ownerId: '4', firstName: 'Harold', lastName: 'Davis' },
+                { ownerId: '5', firstName: 'Peter', lastName: 'McTavish' },
+                { ownerId: '6', firstName: 'Jean', lastName: 'Coleman' },
+                { ownerId: '7', firstName: 'Jeff', lastName: 'Black' },
+                { ownerId: '8', firstName: 'Maria', lastName: 'Escobito' },
+                { ownerId: '9', firstName: 'David', lastName: 'Schroeder' },
+                { ownerId: '10', firstName: 'Carlos', lastName: 'Esteban' }
+            ];
+            vm.ownersUUID = [
+                { ownerId: 'f470653d-05c5-4c45-b7a0-7d70f003d2ac', firstName: 'George', lastName: 'Franklin' },
+                { ownerId: 'e6c7398e-8ac4-4e10-9ee0-03ef33f0361a', firstName: 'Betty', lastName: 'Davis' },
+                { ownerId: '3f59dca2-903e-495c-90c3-7f4d01f3a2aa', firstName: 'Eduardo', lastName: 'Rodriguez' },
+                { ownerId: 'a6e0e5b0-5f60-45f0-8ac7-becd8b330486', firstName: 'Harold', lastName: 'Davis' },
+                { ownerId: 'c6a0fb9d-fc6f-4c21-95fc-4f5e7311d0e2', firstName: 'Peter', lastName: 'McTavish' },
+                { ownerId: 'b3d09eab-4085-4b2d-a121-78a0a2f9e501', firstName: 'Jean', lastName: 'Coleman' },
+                { ownerId: '5fe81e29-1f1d-4f9d-b249-8d3e0cc0b7dd', firstName: 'Jeff', lastName: 'Black' },
+                { ownerId: '48f9945a-4ee0-4b0b-9b44-3da829a0f0f7', firstName: 'Maria', lastName: 'Escobito' },
+                { ownerId: '9f6accd1-e943-4322-932e-199d93824317', firstName: 'David', lastName: 'Schroeder' },
+                { ownerId: '7c0d42c2-0c2d-41ce-bd9c-6ca67478956f', firstName: 'Carlos', lastName: 'Esteban' }
+            ];
+
+            $http.get('api/gateway/vets').then(function (resp) { vm.vetList = resp.data; });
+            $http.get('api/gateway/owners').then(function (owners) { vm.ownersInfoArray = owners.data; });
+
+            $scope.getOwnerUUIDByCustomerId = function(customerId) {
+                let foundOwner;
+                vm.owners.forEach(function(o){ if (o.ownerId === String(customerId)) foundOwner = o; });
+                vm.ownersUUID.forEach(function(o){ if (o.ownerId === String(customerId)) foundOwner = o; });
+                if (foundOwner && vm.ownersInfoArray) {
+                    const match = vm.ownersInfoArray.find(function(o){
+                        return o.firstName === foundOwner.firstName && o.lastName === foundOwner.lastName;
+                    });
+                    if (match) return match.ownerId;
+                }
+                return customerId || 'Unknown Owner';
+            };
+
+            $scope.getVetDetails = function(vetId) {
+                if (!vm.vetList) return 'Unknown Vet';
+                const viaBillId = vm.vetList.find(function(v){ return v.vetBillId === vetId; });
+                const viaVetId  = vm.vetList.find(function(v){ return v.vetId === vetId; });
+                const v = viaBillId || viaVetId;
+                return v ? (v.firstName + ' ' + v.lastName) : 'Unknown Vet';
+            };
+
+            vm.customerNameMap = {}; vm.customerNameMap2 = {};
+            vm.owners.forEach(function (c) { vm.customerNameMap[c.ownerId] = c.firstName + ' ' + c.lastName; });
+            vm.ownersUUID.forEach(function (c) { vm.customerNameMap2[c.ownerId] = c.firstName + ' ' + c.lastName; });
+
+            $scope.getCustomerDetails = function(customerId) {
+                return vm.customerNameMap[customerId] || vm.customerNameMap2[customerId] || 'Unknown Customer';
+            };
+
+            $scope.deleteAllBills = function () {
+                var ok = confirm('Are you sure you want to delete all the bills in the bill history');
+                if (!ok) return;
                 $http.delete('api/gateway/bills')
-                    .then(successCallback, errorCallback)
+                    .then(function () {
+                        alert("bill history was deleted successfully");
+                        return $http.get('api/gateway/bills');
+                    })
+                    .then(function (resp) { vm.billHistory = resp.data; })
+                    .catch(function (err){ console.log(err); });
+            };
 
-                function successCallback(response) {
-                    $scope.errors = [];
-                    alert("bill history was deleted successfully");
-                    console.log(response, 'res');
-                    //refresh list
-                    $http.get('api/gateway/bills').then(function (resp) {
-                        vm.billHistory = resp.data;
-                        arr = resp.data;
-                    });
-                }
-                function errorCallback(error) {
-                    alert(data.errors);
-                    console.log(error, 'Could not receive data');
-                }
-
-            } else {
-                return;
-            }
-        }
-
-        $scope.deleteBill = function (billId) {
-            let varIsConf = confirm('You are about to delete billId ' + billId + '. Is it what you want to do ? ');
-            if (varIsConf) {
-
+            $scope.deleteBill = function (billId) {
+                var ok = confirm('You are about to delete billId ' + billId + '. Is it what you want to do ? ');
+                if (!ok) return;
                 $http.delete('api/gateway/bills/' + billId)
-                    .then(successCallback, errorCallback)
-
-                function successCallback(response) {
-                    $scope.errors = [];
-                    alert(billId + " bill was deleted successfully");
-                    console.log(response, 'res');
-                    //refresh list
-                    location.reload()
-                    $http.get('api/gateway/bills').then(function (resp) {
-                        vm.billHistory = resp.data;
-                        arr = resp.data;
-                    });
-                }
-
-                function errorCallback(error) {
-                    alert(data.errors);
-                    console.log(error, 'Could not receive data');
-                }
-            }
-        };
-
-    }]);
+                    .then(function () {
+                        alert(billId + " bill was deleted successfully");
+                        return $http.get('api/gateway/bills');
+                    })
+                    .then(function (resp) { vm.billHistory = resp.data; })
+                    .catch(function (err){ console.log(err); });
+            };
+        }
+    ]);

--- a/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.template.html
+++ b/api-gateway/src/main/resources/static/scripts/bill-history/bill-history.template.html
@@ -1,234 +1,141 @@
-<h2 class="titleOwner">Bill History</h2>
+<div class="bill-history-container">
+    <h2 class="titleOwner">Bill History</h2>
 
-<a ui-sref="billNew">
-    <button class="add-bill-button btn btn-success">Add Bill</button>
-</a>
-<br><br>
+    <div class="btn-toolbar mb-3 toolbar-gap" role="toolbar" aria-label="Bills toolbar">
+        <div class="btn-group" role="group">
+            <button class="btn btn-primary"
+                    ng-class="{'active': $ctrl.toolbar.open==='search'}"
+                    ng-click="$ctrl.togglePanel('search')">Search</button>
+        </div>
+        <div class="btn-group" role="group">
+            <button class="btn btn-primary"
+                    ng-class="{'active': $ctrl.toolbar.open==='filter'}"
+                    ng-click="$ctrl.togglePanel('filter')">Filter</button>
+        </div>
+        <div class="btn-group" role="group">
+            <a ui-sref="billNew" class="btn btn-success">New Bill</a>
+        </div>
+        <div class="btn-group" role="group">
+            <button class="btn btn-outline-danger" ng-click="deleteAllBills()">Delete All Bills</button>
+        </div>
+    </div>
 
-<button type="button" class="collapsible" data-section="Paid">Open Paid</button>
-<table class="content table table-striped">
-    <thead>
-    <tr>
-        <td>Bill ID</td>
-        <td>Owner Name</td>
-        <td>Owner Details</td>
-        <td>Vet Name</td>
-        <td>Visit Type</td>
-        <td>Amount</td>
-        <td>Status</td>
-        <td>Due Date</td>
-        <td>Date</td>
-        <td>Details</td>
-        <td>Delete</td>
+    <div class="card mb-3" ng-if="$ctrl.toolbar.open==='search'">
+        <div class="card-body d-flex gap-2 flex-wrap">
+            <input type="text" class="form-control" style="max-width:420px"
+                   placeholder="Search bills…"
+                   ng-model="$ctrl.searchQuery">
+            <button class="btn btn-primary">Apply</button>
+            <button class="btn btn-light" ng-click="$ctrl.searchQuery=''">Clear</button>
+        </div>
+    </div>
 
-    </tr>
-    </thead>
+    <div class="card mb-3" ng-if="$ctrl.toolbar.open==='filter'">
+        <div class="card-body">
+            <h5 class="mb-3">Filter Bills</h5>
+            <div class="d-flex flex-wrap align-items-end gap-3">
+                <div class="form-group">
+                    <label for="statusSel" class="form-label">Status</label>
+                    <select id="statusSel" class="form-select" style="min-width: 160px"
+                            ng-model="$ctrl.tempStatus">
+                        <option value="">Any</option>
+                        <option value="paid">Paid</option>
+                        <option value="unpaid">Unpaid</option>
+                        <option value="overdue">Overdue</option>
+                    </select>
+                </div>
 
-    <tr id="billIdPaid" ng-repeat="paidBill in $ctrl.paidBills | filter:$ctrl.query track by paidBill.billIdPaid">
-    <tr ng-repeat="paidBill in $ctrl.paidBills | filter:search:strict">
-        <td><a href="http://localhost:8080/#!/bills/details/{{paidBill.billId}}/owner/{{paidBill.customerId}}">{{paidBill.billId}}</a></td>
-        <td>{{ getCustomerDetails(paidBill.customerId) }}</td>
-    <td><a href="http://localhost:8080/#!/owners/details/{{ getOwnerUUIDByCustomerId(paidBill.customerId) }}">Owner details</a></td>
-        <td>{{ getVetDetails(paidBill.vetId) }}</td>
-        <td>{{paidBill.visitType}}</td>
-        <td>{{paidBill.amount}}</td>
-        <td>{{paidBill.billStatus}}</td>
-        <td>{{paidBill.dueDate}}</td>
-        <td>{{paidBill.date}}</td>
-        <td><a href="http://localhost:8080/#!/bills/details/{{paidBill.billId}}/owner/{{paidBill.customerId}}">Get Details</a></td>
-        <td><a class="btn btn-danger" href="javascript:void(0)" ng-click="deleteBill(paidBill.billId)">Delete Bill</a></td>
-    </tr>
-</table>
-<br><br>
-<button type="button" class="collapsible" data-section="Unpaid">Open Unpaid Bills</button>
-<table class="content table table-striped">
-    <thead>
-    <tr>
-        <td>Bill ID</td>
-        <td>Owner Name</td>
-        <td>Owner Details</td>
-        <td>Vet Name</td>
-        <td>Visit Type</td>
-        <td>Amount</td>
-        <td>Status</td>
-        <td>Due Date</td>
-        <td>Date</td>
-        <td>Details</td>
-        <td>Delete</td>
+                <div class="form-group">
+                    <label for="yearSel" class="form-label">Year</label>
+                    <select id="yearSel" class="form-select" style="min-width: 120px"
+                            ng-model="$ctrl.tempYear">
+                        <option value="">Any</option>
+                        <option ng-repeat="y in $ctrl.availableYears" ng-value="y">{{y}}</option>
+                    </select>
+                </div>
 
-    </tr>
-    </thead>
+                <div class="form-group">
+                    <label for="visitSel" class="form-label">Visit Type</label>
+                    <select id="visitSel" class="form-select" style="min-width: 180px"
+                            ng-model="$ctrl.tempVisitType">
+                        <option value="">Any</option>
+                        <option value="regular">Regular</option>
+                        <option value="emergency">Emergency</option>
+                    </select>
+                </div>
 
-    <tr id="billIdUnpaid" ng-repeat="unpaidBill in $ctrl.unpaidBills | filter:$ctrl.query track by unpaidBill.billIdUnpaid">
-    <tr ng-repeat="unpaidBill in $ctrl.unpaidBills | filter:search:strict">
-        <td><a href="http://localhost:8080/#!/bills/details/{{unpaidBill.billId}}/owner/{{unpaidBill.customerId}}">{{unpaidBill.billId}}</a></td>
-        <td>{{ getCustomerDetails(unpaidBill.customerId) }}</td>
-    <td><a href="http://localhost:8080/#!/owners/details/{{ getOwnerUUIDByCustomerId(unpaidBill.customerId) }}">Owner details</a></td>
-        <td>{{ getVetDetails(unpaidBill.vetId) }}</td>
-        <td>{{unpaidBill.visitType}}</td>
-        <td>{{unpaidBill.amount}}</td>
-        <td>{{unpaidBill.billStatus}}</td>
-        <td>{{unpaidBill.dueDate}}</td>
-        <td>{{unpaidBill.date}}</td>
-        <td><a href="http://localhost:8080/#!/bills/details/{{unpaidBill.billId}}/owner/{{unpaidBill.customerId}}">Get Details</a></td>
-        <td><a class="btn btn-danger" href="javascript:void(0)" ng-click="deleteBill(unpaidBill.billId)">Delete Bill</a></td>
-    </tr>
-</table>
+                <div class="ms-auto d-flex gap-2">
+                    <button class="btn btn-primary" ng-click="$ctrl.applyFilter()">Apply</button>
+                    <button class="btn btn-light" ng-click="$ctrl.resetFilter()">Reset</button>
+                </div>
+            </div>
+        </div>
+    </div>
 
-<br><br>
-<button type="button" class="collapsible" data-section="Overdue">Open Overdue Bills</button>
-<table class="content table table-striped">
-    <thead>
-    <tr>
-        <td>Bill ID</td>
-        <td>Owner Name</td>
-        <td>Owner Details</td>
-        <td>Vet Name</td>
-        <td>Visit Type</td>
-        <td>Amount</td>
-        <td>Status</td>
-        <td>Due Date</td>
-        <td>Date</td>
-        <td>Details</td>
-        <td>Delete</td>
-
-    </tr>
-    </thead>
-
-    <tr id="billIdOverdue" ng-repeat="overdueBill in $ctrl.overdueBills | filter:$ctrl.query track by overdueBill.billIdOverdue">
-    <tr ng-repeat="overdueBill in $ctrl.overdueBills | filter:search:strict">
-        <td><a href="http://localhost:8080/#!/bills/details/{{overdueBill.billId}}/owner/{{overdueBill.customerId}}">{{overdueBill.billId}}</a></td>
-        <td>{{ getCustomerDetails(overdueBill.customerId) }}</td>
-    <td><a href="http://localhost:8080/#!/owners/details/{{ getOwnerUUIDByCustomerId(overdueBill.customerId) }}">Owner details</a></td>
-        <td>{{ getVetDetails(overdueBill.vetId) }}</td>
-        <td>{{overdueBill.visitType}}</td>
-        <td>{{overdueBill.amount}}</td>
-        <td>{{overdueBill.billStatus}}</td>
-        <td>{{overdueBill.dueDate}}</td>
-        <td>{{overdueBill.date}}</td>
-        <td><a href="http://localhost:8080/#!/bills/details/{{overdueBill.billId}}/owner/{{overdueBill.customerId}}">Get Details</a></td>
-        <td><a class="btn btn-danger" href="javascript:void(0)" ng-click="deleteBill(overdueBill.billId)">Delete Bill</a></td>
-    </tr>
-</table>
-<br><br>
-<h3>All Bills</h3>
-<table class="table table-striped">
-    <thead>
-        <tr ng-repeat="bill in $ctrl.billHistory | startFrom: ($ctrl.currentPage - 1) * $ctrl.pageSize | limitTo: $ctrl.pageSize track by bill.billId">
-            <td>Bill ID</td>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <td>Bill Id</td>
             <td>Owner Name</td>
             <td>Owner Details</td>
             <td>Vet Name</td>
             <td>Visit Type</td>
-            <td>Amount</td>
+            <td class="text-end">Amount</td>
             <td>Status</td>
             <td>Due Date</td>
             <td>Date</td>
             <td>Details</td>
             <td>Delete</td>
         </tr>
-    </thead>
+        </thead>
+        <tbody>
+        <tr ng-repeat="bill in ($ctrl.getRows() | filter: $ctrl.visitTypePredicate) track by $index">
+            <td>{{bill.billId || bill.id}}</td>
 
-    <tbody class="bg-white border">
-    <tr>
-        <td class="bg-white border" ></td>
-        <td class="bg-white border">
-         <!--   <input ng-model="$ctrl.query.bill.owner.firstName" placeholder="Filter by Customer Name"> -->
-        </td>
-        <td class="bg-white border"></td>
-        <td class="bg-white border"></td>
-        <td class="bg-white border">
-            <input ng-model="search.visitType" placeholder="Filter by visit type">
-        </td>
-        <td class="bg-white border">
-            <input ng-model="search.amount" placeholder="Filter by amount">
-        </td>
-        <td class="bg-white border">
-            <input ng-model="search.billStatus" placeholder="Filter by status">
-        </td>
-        <td class="bg-white border">
-            <input ng-model="search.dueDate" placeholder="Filter by due date">
-        </td>
-        <td class="bg-white border">
-            <input ng-model="search.date" placeholder="Filter by date">
-        </td>
-        <td class="bg-white border"></td>
-        <td class="bg-white border"></td>
-    </tr>
-    <ul class="pagination">
-        <li ng-class="{disabled: $ctrl.currentPage === 1}">
-            <button class="btn btn-default" ng-click="$ctrl.goPreviousPage()">Previous</button>
-        </li>
-        <li class="page-item">
-            <a class="page-link text-dark" disabled>{{$ctrl.currentPageOnSite}}</a>
-        </li>
-        <li ng-class="{disabled: $ctrl.currentPage === $ctrl.totalPages}">
-            <button class="btn btn-default" ng-click="$ctrl.goNextPage()">Next</button>
-        </li>
-    </ul>
+            <td>{{ getCustomerDetails ? getCustomerDetails(bill.customerId) : (bill.owner || 'Unknown Owner') }}</td>
 
-    <tr id="billId" ng-repeat="bill in $ctrl.billHistory | filter:$ctrl.query track by bill.billId">
-    <tr ng-repeat="bill in $ctrl.billHistory | filter:search:strict">
-    <td><a href="http://localhost:8080/#!/bills/details/{{bill.billId}}/owner/{{bill.customerId}}">{{bill.billId}}</a></td>
-        <td>{{ getCustomerDetails(bill.customerId) }}</td>
+            <td>
+                <a class="btn btn-sm btn-outline-secondary"
+                   ui-sref="ownerDetails({ownerId: getOwnerUUIDByCustomerId ? getOwnerUUIDByCustomerId(bill.customerId) : bill.customerId})">
+                    View Owner
+                </a>
+            </td>
 
-    <td><a href="http://localhost:8080/#!/owners/details/{{ getOwnerUUIDByCustomerId(bill.customerId) }}">Owner details</a></td>
+            <td>{{ getVetDetails ? getVetDetails(bill.vetId) : (bill.vet || 'Unknown Vet') }}</td>
 
-<!--    <td><a href="http://localhost:8080/#!/owners/details/{{bill.customerId}}">Owner details</a></td>-->
-    <td>{{ getVetDetails(bill.vetId) }}</td>
-        <td>{{bill.visitType}}</td>
-        <td>{{bill.amount}}</td>
-        <td>{{bill.billStatus}}</td>
-        <td>{{bill.dueDate}}</td>
-        <td>{{bill.date}}</td>
-        <td><a href="http://localhost:8080/#!/bills/details/{{bill.billId}}/owner/{{bill.customerId}}">Get Details</a></td>
-        <td><a class="btn btn-danger" href="javascript:void(0)" ng-click="deleteBill(bill.billId)">Delete Bill</a></td>
-    </tr>
-    </tbody>
-</table>
+            <td>{{bill.visitType}}</td>
+            <td class="text-end">{{bill.amount | currency}}</td>
 
-<a class="btn btn-danger" href="javascript:void(0)" ng-click="deleteAllBills()">Delete All Bills</a>
+            <td>
+          <span class="badge"
+                ng-class="{'bg-success': ($ctrl.activeStatus=='paid') || ((bill.status||'').toLowerCase()=='paid'),
+                           'bg-secondary': ($ctrl.activeStatus=='unpaid') || ((bill.status||'').toLowerCase()=='unpaid'),
+                           'bg-danger': ($ctrl.activeStatus=='overdue') || ((bill.status||'').toLowerCase()=='overdue')}">
+            {{ ($ctrl.activeStatus || (bill.status || '')).toUpperCase() || '—' }}
+          </span>
+            </td>
 
-<style>
-    .content {
-        display: none;
-        overflow: hidden;
-    }
-    .collapsible {
-        background-color: #eee;
-        color: #444;
-        cursor: pointer;
-        padding: 10px;
-        border: none;
-        text-align: left;
-        font-size: 15px;
-        font-weight: bold;
-        text-decoration: underline;
-    }
+            <td>{{bill.dueDate || bill.due}}</td>
+            <td><code>{{bill.date}}</code></td>
 
-    .active, .collapsible:hover {
-        background-color: #ccc;
-    }
+            <td>
+                <a class="btn btn-sm btn-outline-primary"
+                   ui-sref="billDetails({billId: (bill.billId || bill.id)})">Details</a>
+            </td>
 
-</style>
+            <td>
+                <button class="btn btn-sm btn-outline-danger"
+                        ng-click="deleteBill(bill.billId || bill.id)">Delete</button>
+            </td>
+        </tr>
+        </tbody>
+    </table>
 
-<script>
-    var coll = document.getElementsByClassName("collapsible");
-    var i;
+    //comment
 
-    for (i = 0; i < coll.length; i++) {
-        coll[i].addEventListener("click", function() {
-            this.classList.toggle("active");
-            var content = this.nextElementSibling;
-            if (content.style.display === "block") {
-                content.style.display = "none";
-                this.textContent = "Open " + this.getAttribute("data-section") + " Bills";
-
-            } else {
-                content.style.display = "block";
-                this.textContent = "Close " + this.getAttribute("data-section") + " Bills";
-
-            }
-        });
-    }
-</script>
+    <div class="d-flex align-items-center gap-3">
+        <button class="btn btn-light" ng-click="$ctrl.goPreviousPage()">« Prev</button>
+        <span>Page {{$ctrl.page}} of {{$ctrl.totalPages}}</span>
+        <button class="btn btn-light" ng-click="$ctrl.goNextPage()">Next »</button>
+    </div>
+</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "champlain_petclinic",
+  "name": "champlain-petclinic",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/petclinic-frontend/src/features/bills/AdminBillsListTable.css
+++ b/petclinic-frontend/src/features/bills/AdminBillsListTable.css
@@ -3,7 +3,7 @@
   margin: 0 auto;
   padding: 20px;
   font-family: 'Arial', sans-serif;
-  overflow: visible;
+  overflow: visible; /* Allow the table to expand based on content */
 }
 
 .filter-search-container {
@@ -17,71 +17,66 @@
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
-.filter-section,
-.search-section {
+.filter-section, .search-section {
   margin-bottom: 20px;
 }
 
-.filter-section input,
-.filter-section select,
-.search-section input,
-.create-bill-form input,
+.filter-section input, 
+.filter-section select, 
+.search-section input, 
+.create-bill-form input, 
 .create-bill-form select {
   width: 100%;
   padding: 12px 15px;
   font-size: 16px;
-  margin-bottom: 15px;
+  margin-bottom: 10px;
   border: 1px solid #ccc;
-  border-radius: 6px;
+  border-radius: 4px;
 }
 
-.filter-section button,
-.search-section button,
+.filter-section button, 
+.search-section button, 
 .create-bill-form button {
   padding: 10px 20px;
   font-size: 16px;
   border: none;
-  border-radius: 6px;
+  border-radius: 4px;
   background-color: #009879;
   color: white;
   cursor: pointer;
   width: 150px;
   margin-top: 10px;
-  transition: background 0.3s ease;
 }
 
-.filter-section button:hover,
-.search-section button:hover,
+.filter-section button:hover, 
+.search-section button:hover, 
 .create-bill-form button:hover {
   background-color: #007f6a;
 }
 
-.filter-section button + button,
+/* Add spacing between filter and clear buttons */
+.filter-section button + button, 
 .create-bill-form button + button {
   margin-left: 10px;
 }
 
+/* New section for filter buttons to align them next to each other */
 .filter-buttons {
   display: flex;
   justify-content: flex-start;
-  gap: 10px;
+  gap: 10px; /* Adds spacing between the filter and clear buttons */
   margin-top: 10px;
 }
 
 .create-bill-form {
   display: flex;
   flex-direction: column;
-  max-width: 800px;
+  max-width: 1200px;
   margin: 20px auto;
-  padding: 20px;
-  background-color: #ffffff;
+  padding: 10px;
+  background-color: #f9f9f9;
   border-radius: 8px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-}
-
-.create-bill-form h3 {
-  margin-bottom: 15px;
-  color: #009879;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 .create-bill-button-container {
@@ -94,12 +89,11 @@
   padding: 10px 20px;
   font-size: 16px;
   border: none;
-  border-radius: 6px;
+  border-radius: 5px;
   background-color: #009879;
   color: white;
   cursor: pointer;
   margin-top: 20px;
-  transition: background 0.3s ease;
 }
 
 .create-bill-button:hover {
@@ -122,8 +116,7 @@
 .table thead tr {
   background-color: #009879;
   color: #ffffff;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  text-align: left;
 }
 
 .table tbody tr {
@@ -138,14 +131,10 @@
   border-bottom: 2px solid #009879;
 }
 
-.table tr:hover {
-  background-color: #f9f9f9;
-}
-
 .btn {
   padding: 10px 20px;
   border: none;
-  border-radius: 6px;
+  border-radius: 5px;
   cursor: pointer;
   font-size: 16px;
 }
@@ -174,7 +163,7 @@
 .confirm-dialog {
   background: white;
   padding: 20px;
-  border-radius: 6px;
+  border-radius: 5px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   text-align: center;
 }
@@ -183,7 +172,7 @@
   margin: 0 10px;
   padding: 10px 20px;
   border: none;
-  border-radius: 6px;
+  border-radius: 5px;
   cursor: pointer;
 }
 
@@ -217,25 +206,4 @@
   display: flex;
   justify-content: space-around;
   margin-bottom: 20px;
-}
-
-.status-badge {
-  padding: 5px 10px;
-  border-radius: 20px;
-  font-size: 14px;
-  font-weight: bold;
-  color: white;
-}
-
-.status-paid {
-  background-color: #28a745;
-}
-
-.status-unpaid {
-  background-color: #ffc107;
-  color: black;
-}
-
-.status-overdue {
-  background-color: #dc3545;
 }

--- a/petclinic-frontend/src/features/carts/api/addToCartFromProducts.ts
+++ b/petclinic-frontend/src/features/carts/api/addToCartFromProducts.ts
@@ -26,16 +26,16 @@ export function useAddToCart(): UseAddToCartReturnType {
 
     try {
       const cartId = await fetchUserCart(user.userId);
-      if (!cartId) {
-        throw new Error('Cart not found');
-      }
+      if (!cartId) throw new Error('Cart not found');
 
-      const endpoint = `http://localhost:8080/api/v2/gateway/carts/${cartId}/${productId}`;
-      await axiosInstance.post(endpoint);
-      return true; // Return true if successful
+      // was http://localhost:8080/api/v2/gateway/carts/${cartId}/${productId}
+      await axiosInstance.post(`/carts/${cartId}/${productId}`, undefined, {
+        useV2: true,
+      });
+      return true;
     } catch (error) {
       console.error('Error adding product to cart:', error);
-      return false; // Return false if an error occurs
+      return false;
     }
   };
 

--- a/petclinic-frontend/src/features/carts/api/addToWishlistFromProducts.ts
+++ b/petclinic-frontend/src/features/carts/api/addToWishlistFromProducts.ts
@@ -24,22 +24,26 @@ export function useAddToWishlist(): UseAddToWishlistReturnType {
   ): Promise<boolean> => {
     if (!user?.userId) {
       console.error('User is not authenticated');
-      return false; // Return false when user is not authenticated
+      return false;
     }
 
     try {
       const cartId = await fetchUserCart(user.userId);
       if (!cartId) {
         console.error('Cart not found');
-        return false; // Return false if cart is not found
+        return false;
       }
 
-      const endpoint = `http://localhost:8080/api/v2/gateway/carts/${cartId}/products/${productId}/quantity/${quantity}`;
-      await axiosInstance.post(endpoint);
-      return true; // Return true when product is successfully added to wishlist
+      // was http://localhost:8080/api/v2/gateway/carts/${cartId}/products/${productId}/quantity/${quantity}
+      await axiosInstance.post(
+        `/carts/${cartId}/products/${productId}/quantity/${quantity}`,
+        undefined,
+        { useV2: true }
+      );
+      return true;
     } catch (error) {
       console.error('Error adding product to wishlist:', error);
-      return false; // Return false if there's an error
+      return false;
     }
   };
 

--- a/petclinic-frontend/src/features/carts/api/getCart.ts
+++ b/petclinic-frontend/src/features/carts/api/getCart.ts
@@ -1,13 +1,17 @@
 import axiosInstance from '@/shared/api/axiosInstance.ts';
 
+type CartIdResponse = { cartId: string };
+
 export const fetchCartIdByCustomerId = async (
   userId: string
 ): Promise<string | null> => {
   try {
-    const response = await axiosInstance.get(
-      `http://localhost:8080/api/v2/gateway/carts/customer/${userId}`
+    // was http://localhost:8080/api/v2/gateway/carts/customer/${userId}
+    const { data } = await axiosInstance.get<CartIdResponse>(
+      `/carts/customer/${userId}`,
+      { useV2: true }
     );
-    return response.data.cartId;
+    return data.cartId;
   } catch (error) {
     console.error('Error fetching cart ID:', error);
     return null;

--- a/petclinic-frontend/src/features/carts/api/getImage.ts
+++ b/petclinic-frontend/src/features/carts/api/getImage.ts
@@ -1,14 +1,14 @@
 import axiosInstance from '@/shared/api/axiosInstance';
 import { ImageModel } from '../models/ImageModel';
+
 export async function getImage(imageId: string): Promise<ImageModel> {
   try {
-    const response = await axiosInstance.get(
-      `http://localhost:8080/api/v2/gateway/images/${imageId}`,
-      {
-        responseType: 'json',
-      }
-    );
-    return response.data;
+    // was http://localhost:8080/api/v2/gateway/images/${imageId}
+    const { data } = await axiosInstance.get<ImageModel>(`/images/${imageId}`, {
+      responseType: 'json',
+      useV2: true,
+    });
+    return data;
   } catch (error) {
     throw new Error('Error fetching image');
   }

--- a/petclinic-frontend/src/features/carts/components/UserCart.css
+++ b/petclinic-frontend/src/features/carts/components/UserCart.css
@@ -410,8 +410,6 @@
 
 .cart-header-title {
   margin-top: 20px;
-}
-
 /* If the overlay is an actual <img> with matching src or alt */
 .Wishlist-items img[src*="out-of-stock" i],
 .Wishlist-items img[alt*="out of stock" i],
@@ -426,3 +424,4 @@
   background-image: none !important;
   content: normal; 
 }
+


### PR DESCRIPTION
**JIRA:** 
https://champlainsaintlambert.atlassian.net/browse/CPC-1550
## Context:
The ticket aims to improve clarity towards the selected Inventory. Previously, we saw the inventory’s ID when we selected inventory instead of it’s name, which is absolutely unecessary and pretty confusing. Now for any inventory that is selected, you can see it’s respective name and know exactly what Inventory you have selected when the data gets really numerous to handle.
## Does this PR change the .vscode folder in petclinic-frontend?:
No.
## Changes
The files changed were InventoryProducts.tsx I added a component inventoryName and used a useEffect method to map the name of the inventory by matching it to it’s respective InventoryId. I also added an error catcher than says it couldn’t fetch the details right if an error occured. I then simply replaced the InventoryID by InventoryName between the <span> tag.
## Does this use the v2 API?:
No.
## Does this add a new communication between services?:
No.
## Before and After UI (Required for UI-impacting PRs)
The previous UI used to display an InventoryID. When the inventory was selected, it looked like this: 

<img width="1403" height="827" alt="oldui" src="https://github.com/user-attachments/assets/3f466eae-499a-4692-990d-8f55e69f7f7d" />

After my changes, it now looks like this. Depending on the selected inventory, you'll have the right name assigned to it.

<img width="1793" height="847" alt="newui" src="https://github.com/user-attachments/assets/6d62f271-6939-4485-abd9-af70c1e0ebf5" />