### PR TITLE
Fixed delete method/added negative delete test

### DIFF
--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillControllerUnitTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillControllerUnitTest.java
@@ -427,4 +427,20 @@ class BillControllerUnitTest {
     }
 
 
+    @Test
+    void whenDeletingNonExistentBill_thenReturnNotFound() {
+        String invalidBillId = "NON_EXISTENT_ID";
+
+        // Mock the service to throw NotFoundException
+        Mockito.when(billService.deleteBill(invalidBillId))
+                .thenReturn(Mono.error(new NotFoundException("Bill not found")));
+
+        client.delete()
+                .uri("/bills/{billId}", invalidBillId)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("Bill not found");
+    }
+
 }

--- a/petclinic-frontend/src/features/bills/api/deleteBill.tsx
+++ b/petclinic-frontend/src/features/bills/api/deleteBill.tsx
@@ -10,7 +10,7 @@ interface ErrorResponse {
 export async function deleteBill(bill: Bill): Promise<AxiosResponse> {
   try {
     const response: AxiosResponse = await axiosInstance.delete(
-      `bills/${bill.billId}`,
+      `/bills/${bill.billId}`,
       {
         useV2: false,
       }


### PR DESCRIPTION
Link to Jira ticket: https://champlainsaintlambert.atlassian.net/browse/CPC-1568

### Context:
-----------------------------------------------------------------------------------------------------------------------------------------------
What/Why: This ticket is about fixing the delete method so it can allow the deletion of bills and adding one negative delete test. This needed to be fixed because not being able to delete bills causes an overflow of data, it also keeps the page nicer and organized. The negative delete test needed to be added just to test when deleting a bill that does not exists it would return not found.

### Does this change affect the .vscode folder in the front-end:
-----------------------------------------------------------------------------------------------------------------------------------------------
No

### Changes:
-----------------------------------------------------------------------------------------------------------------------------------------------
Changed the Uri in the pet-clinic front-end application in the DeleteBill.tsx to match the Uri from the bill controller class. Added one negative delete test for returning a bill not found.

### Does This use the v2 API:
-----------------------------------------------------------------------------------------------------------------------------------------------
No

### Does this add a new communication between services:
-----------------------------------------------------------------------------------------------------------------------------------------------
No

### Before/After Ui changes:
-----------------------------------------------------------------------------------------------------------------------------------------------
N/A