### PR TITLE
bug(CART-CPC-1420): fix hardcoded EventSource URL for archived visits

### DIFF
--- a/petclinic-frontend/src/features/visits/VisitListTable.tsx
+++ b/petclinic-frontend/src/features/visits/VisitListTable.tsx
@@ -147,10 +147,8 @@ export default function VisitListTable(): JSX.Element {
     }
 
     const archivedEventSource = new EventSource(
-      'http://localhost:8080/api/v2/gateway/visits/archived',
-      {
-        withCredentials: true,
-      }
+      `${import.meta.env.VITE_BACKEND_URL}v2/gateway/visits/archived`,
+      { withCredentials: true }
     );
 
     archivedEventSource.onmessage = event => {


### PR DESCRIPTION
**JIRA:**[ link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1420)
## Context:
Fix a hard-coded backend URL used by the archived visits SSE stream in VisitListTable.tsx.
The code was pointing to http://localhost:8080/..., which works only in local dev and breaks in other environments (staging/prod). We now build the URL from VITE_BACKEND_URL, so it works across environments. I did it becuase during my previous merge it caused this bug so im fixing it with another branch

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>
No changes to .vscode.

## Changes
Replace hard-coded SSE URL:

Before:
new EventSource('http://localhost:8080/api/v2/gateway/visits/archived', { withCredentials: true })

After:
 const archivedEventSource = new EventSource(
      `${import.meta.env.VITE_BACKEND_URL}v2/gateway/visits/archived`{ withCredentials: true } );
## Does this use the v2 API?:
es. The SSE endpoint remains /v2/gateway/visits/archived.
Note: We can’t use the Axios interceptor for EventSource, so the path includes /v2/gateway explicitly while the domain/base comes from VITE_BACKEND_URL.
## Does this add a new communication between services?:
No. It only corrects the target URL of an existing SSE stream. No C4 updates required.## Before and After UI (Required for UI-impacting PRs)

## Dev notes (Optional)
## Linked pull requests (Optional)
