### PR TITLE
feat(VIST-CPC-1590): Fix error handling for scheduling visit

### DIFF
--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/visit/VisitControllerUnitTest.java
@@ -190,7 +190,7 @@ public class VisitControllerUnitTest {
     void whenAddVisit_asAdmin_thenReturnCreatedVisitDTO() {
         // Arrange
         VisitRequestDTO newVisitRequestDTO = VisitRequestDTO.builder()
-                .visitDate(LocalDateTime.of(2023, 10, 10, 10, 0))
+                .visitDate(LocalDateTime.of(2030, 10, 10, 10, 0))
                 .description("Routine check-up")
                 .petId("P001")
                 .practitionerId("PR001")

--- a/petclinic-frontend/src/features/visits/models/AddingVisit.tsx
+++ b/petclinic-frontend/src/features/visits/models/AddingVisit.tsx
@@ -55,7 +55,11 @@ const AddingVisit: React.FC = (): JSX.Element => {
   const validate = (): boolean => {
     const newErrors: { [key: string]: string } = {};
     if (!visit.petId) newErrors.petId = 'Pet ID is required';
-    if (!visit.visitStartDate) newErrors.visitDate = 'Visit date is required';
+    if (!visit.visitStartDate) {
+      newErrors.visitStartDate = 'Visit date is required';
+    } else if (visit.visitStartDate <= new Date()) {
+      newErrors.visitStartDate = 'Visit date must be in the future';
+    }
     if (!visit.description) newErrors.description = 'Description is required';
     if (!visit.practitionerId)
       newErrors.practitionerId = 'Practitioner ID is required';
@@ -124,6 +128,7 @@ const AddingVisit: React.FC = (): JSX.Element => {
           value={formatDate(visit.visitStartDate)}
           onChange={handleChange}
           required
+          min={formatDate(new Date())}
         />
         {errors.visitStartDate && (
           <span className="error">{errors.visitStartDate}</span>


### PR DESCRIPTION
**JIRA:** [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1590)
## Context:
This ticket is about implementing error handling for every field in the adding a visit form. It was implemented in the BE and FE. The test was also modified to work with the new error handling. 
## Does this PR change the .vscode folder in petclinic-frontend?:
No

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
Added error handling in the V2 controller.
Made it impossible to schedule a visit the same day as you are taking it.
## Does this use the v2 API?:
Yes because the addVisit method doesn't exist in the BFF
## Does this add a new communication between services?:
No
## Before and After UI (Required for UI-impacting PRs)
No UI was changed
## Dev notes (Optional)
None
## Linked pull requests (Optional)
None