### PR TITLE
bug(AUTH-CPC-1598): Homepage contact band buttons are misplaced

### DIFF
--- a/petclinic-frontend/src/pages/FAQ/FAQ.tsx
+++ b/petclinic-frontend/src/pages/FAQ/FAQ.tsx
@@ -1,10 +1,10 @@
-// src/pages/FAQ.tsx
 import { Container, Row, Col, Accordion, Form, Button } from 'react-bootstrap';
 import { NavBar } from '@/layouts/AppNavBar';
 import { AppFooter } from '@/layouts/AppFooter';
 import useFaqSearch from '@/features/faq/hooks/useFaqSearch';
 
 import './FAQ.css';
+import Reveal from '@/features/home/components/Reveal';
 
 export default function FAQ(): JSX.Element {
   const { query, setQuery, results } = useFaqSearch();
@@ -42,10 +42,12 @@ export default function FAQ(): JSX.Element {
               defaultActiveKey={results[0]?.id}
             >
               {results.map(item => (
-                <Accordion.Item eventKey={item.id} id={item.id} key={item.id}>
-                  <Accordion.Header>{item.question}</Accordion.Header>
-                  <Accordion.Body>{item.answer}</Accordion.Body>
-                </Accordion.Item>
+                <Reveal key={item.id} delay={results.indexOf(item) * 50}>
+                  <Accordion.Item eventKey={item.id} id={item.id} key={item.id}>
+                    <Accordion.Header>{item.question}</Accordion.Header>
+                    <Accordion.Body>{item.answer}</Accordion.Body>
+                  </Accordion.Item>
+                </Reveal>
               ))}
               {results.length === 0 && (
                 <div className="text-center text-muted py-4">

--- a/petclinic-frontend/src/pages/Home/Home.tsx
+++ b/petclinic-frontend/src/pages/Home/Home.tsx
@@ -212,14 +212,17 @@ export default function Home(): JSX.Element {
           aria-label="Contact"
         >
           <Row className="align-items-center g-3">
-            <Reveal delay={80}>
-              <Col lg>
+            <Col lg>
+              <Reveal delay={80}>
                 <h3 className="mb-1">Have questions or need help?</h3>
                 <p className="text-muted mb-0">
                   Our team is just a message away.
                 </p>
-              </Col>
-              <Col lg="auto" className="d-flex gap-2">
+              </Reveal>
+            </Col>
+
+            <Col xs="auto" className="d-flex gap-2 ms-lg-auto">
+              <Reveal delay={100}>
                 <Button
                   variant="outline-secondary"
                   onClick={() => navigate('/contact')}
@@ -232,8 +235,8 @@ export default function Home(): JSX.Element {
                 >
                   Book Appointment
                 </Button>
-              </Col>
-            </Reveal>
+              </Reveal>
+            </Col>
           </Row>
         </section>
       </Container>


### PR DESCRIPTION
**JIRA:** [link](https://champlainsaintlambert.atlassian.net/browse/CPC-1598)

## Context:

This ticket simple fixes the slight styling issue with the home page where the contact band had misplaced components. This was simply a bug that I thought needed to be addressed in this specific sprint. I also took this opportunity to spice up the FAQ page with a small additional animation.

## Does this PR change the .vscode folder in petclinic-frontend?:

No changes to `.vscode`.

## Changes

- **Home:** Fixed the contact band by fixing column seperation and adding better bootstrap classes + xs.
- **FAQ:** Added more animation using the Reveal component created in a separate ticket.

## Does this use the v2 API?:

No changes to any API calls.

## Does this add a new communication between services?:

No. Reuses existing endpoints; no new service-to-service calls. (No C4 L2 updates required.)

## Before and After UI (Required for UI-impacting PRs)

**Before:**

<img width="1362" height="205" alt="Before" src="https://github.com/user-attachments/assets/3afef8ff-b379-4faa-b032-2a04227a2d5d" />

**After:**

<img width="1322" height="115" alt="After" src="https://github.com/user-attachments/assets/c00e59c4-1400-4448-a9ae-cb663ffbf9ba" />
