### PR TITLE
Bug(INVT-CPC-1601): Fix Get All Types In Angular Frontend

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v1/InventoryControllerV1.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v1/InventoryControllerV1.java
@@ -99,7 +99,7 @@ public class InventoryControllerV1 {
 
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.INVENTORY_MANAGER})
-    @GetMapping(value = "{inventoryId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{inventoryId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<InventoryResponseDTO>> getInventoryById(@PathVariable String inventoryId) {
         return inventoryServiceClient.getInventoryById(inventoryId)
                 .map(product -> ResponseEntity.status(HttpStatus.OK).body(product))

--- a/api-gateway/src/main/resources/static/scripts/Inventory-form/inventory-form.controller.js
+++ b/api-gateway/src/main/resources/static/scripts/Inventory-form/inventory-form.controller.js
@@ -6,7 +6,7 @@ angular.module('inventoryForm')
         console.log("State params: " + $stateParams)
         $scope.inventoryTypeFormSearch = "";
         $scope.inventoryTypeOptions = ["New Type"] //get all form the inventory type repository but dont remove the New Type
-        $http.get("api/gateway/inventories/type").then(function (resp) {
+        $http.get("api/gateway/inventories/types").then(function (resp) {
             //Includes all types inside the array
             resp.data.forEach(function (type) {
                 $scope.inventoryTypeOptions.push(type.type);

--- a/api-gateway/src/main/resources/static/scripts/inventory-update-form/inventory-update-form.js
+++ b/api-gateway/src/main/resources/static/scripts/inventory-update-form/inventory-update-form.js
@@ -6,7 +6,7 @@ angular.module('inventoryUpdateForm', ['ui.router'])
 
             .state('updateInventory', {
                     parent: 'app',
-                    url: '/inventories/:inventoryId/:method',
+                    url: '/inventories/:inventoryId/edit',
                     template: '<inventory-update-form></inventory-update-form>'
                 }
             )

--- a/petclinic-frontend/src/features/inventories/InventoriesListTable.tsx
+++ b/petclinic-frontend/src/features/inventories/InventoriesListTable.tsx
@@ -544,7 +544,7 @@ export default function InventoriesListTable(): JSX.Element {
                     <button
                       onClick={e => {
                         e.stopPropagation();
-                        navigate(`inventory/${inventory.inventoryId}/edit`);
+                        navigate(`/inventories/${inventory.inventoryId}/edit`);
                       }}
                       className="btn btn-warning"
                     >

--- a/petclinic-frontend/src/shared/models/path.routes.ts
+++ b/petclinic-frontend/src/shared/models/path.routes.ts
@@ -1,7 +1,7 @@
 export enum AppRoutePaths {
   Default = '/',
   MoveInventoryProducts = 'inventories/:inventoryId/products/:productId/move',
-  EditInventory = 'inventories/inventory/:inventoryId/edit',
+  EditInventory = 'inventories/:inventoryId/edit',
   EditInventoryProducts = 'inventories/:inventoryId/products/:productId/edit',
   LowStockProducts = '/products/lowstock',
   AddSupplyToInventory = 'inventories/:inventoryId/products/add',


### PR DESCRIPTION
JIRA: link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1601)

Context:

The ticket is about allowing when you add an inventory to be able to choose an inventory type. It was needed because in the Angular FE it was not possible to fetch the endpoint to get all types in the add inventory form. It was also necessary to fix the update inventory endpoint in the react FE because the url was not following the conventions.

Does this PR change the .vscode folder in petclinic-frontend?:
No.

Reviewers need to check for any changes to the .vscode folder and add a comment about it to their review comments.

Changes

1. Change the url in inventory-form-controller.js to $http.get("api/gateway/inventories/types")
2. Change the url of EditInventory = 'inventories/inventory/:inventoryId/edit' to EditInventory = 'inventories/:inventoryId/edit' in path.route.ts

Does this use the v2 API?:
No.

Does this add a new communication between services?:
No.

Before and After UI (Required for UI-impacting PRs)

Before in the Angular FE: 
<img width="1919" height="976" alt="Screenshot 2025-09-28 125858" src="https://github.com/user-attachments/assets/6abf25a5-01af-495f-853a-54cc40e8811e" />

After in the Angular FE:
<img width="1919" height="981" alt="Screenshot 2025-09-28 131541" src="https://github.com/user-attachments/assets/319cbdf6-14fa-4b9b-b803-b97861c398eb" />

Before in the React for the update form(2 times the word inventory in the url): 

<img width="1919" height="522" alt="Screenshot 2025-09-28 140309" src="https://github.com/user-attachments/assets/6ddfe420-be76-466d-845b-c6ccb0e2369e" />

After in the React (cleaner url):

<img width="1919" height="566" alt="image" src="https://github.com/user-attachments/assets/cea091da-1e42-46ab-a6d0-9bc38275039e" />




Dev notes (Optional)
Specific technical changes that should be noted