### PR TITLE
bug(AUTH): Revert dockerfile

### DIFF
--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,20 +1,13 @@
-FROM gradle:7.4-jdk17 AS builder
+FROM gradle:7.4 as builder
 WORKDIR /usr/src/app
-COPY build.gradle settings.gradle ./
 COPY src ./src
-RUN gradle bootJar --no-daemon
-RUN ls -l build/libs && mv build/libs/*.jar build/libs/application.jar
+COPY build.gradle .
+RUN ["gradle", "bootJar"]
 
-
-FROM gcr.io/distroless/java17-debian11 AS final
-WORKDIR /app
-ENV JAVA_TOOL_OPTIONS=" \
-    -XX:+UseG1GC \
-    -XX:MaxRAMPercentage=75.0 \
-    -XX:+UseStringDeduplication \
-    -XX:MaxMetaspaceSize=256m \
-    -Xss512k \
-    "
-COPY --from=builder /usr/src/app/build/libs/application.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+
+FROM openjdk:17
+ARG JAR_FILE=build/libs/*.jar
+COPY --from=builder /usr/src/app/${JAR_FILE} app.jar
+#RUN apk --no-cache add curl
+ENTRYPOINT ["java", "-jar","/app.jar"]


### PR DESCRIPTION
**JIRA:** link to jira ticket
none
## Context:
prod is broken

## Does this PR change the .vscode folder in petclinic-frontend?:

## Changes
reverting back to an old instance of the dockerfile of auth-service

## Does this use the v2 API?:
no

## Does this add a new communication between services?:
no

## Before and After UI (Required for UI-impacting PRs)
no

## Dev notes (Optional)
no

## Linked pull requests (Optional)
no