### PR TITLE
feat(VETS-CPC-1090): Remove empty photo album section from vet page f…

### DIFF
--- a/petclinic-frontend/src/pages/Vet/VetDetails.tsx
+++ b/petclinic-frontend/src/pages/Vet/VetDetails.tsx
@@ -749,43 +749,48 @@ export default function VetDetails(): JSX.Element {
                 )}
             </section>
 
-            <section className="album-photos">
-              <h2>Album Photos</h2>
-              {albumPhotos.length > 0 ? (
-                <div className="album-photo-grid">
-                  {albumPhotos.map((photo, index) => (
-                    <div
-                      key={index}
-                      className="album-photo-card"
-                      onClick={() =>
-                        openPhotoModal(
-                          `data:${photo.imgType};base64,${photo.data}`
-                        )
-                      }
-                    >
-                      <img
-                        src={`data:${photo.imgType};base64,${photo.data}`} // Construct the image URL from data and type
-                        alt={`Album Photo ${index + 1}`}
-                        className="album-photo-thumbnail"
-                      />
-                      {!isInventoryManager && !isOwner && !isReceptionist && (
-                        <button
-                          className="delete-photo-button"
-                          onClick={e => {
-                            e.stopPropagation(); // This prevents the modal from opening
-                            handleDeleteAlbumPhoto(photo.id); // Pass the photo ID for deletion
-                          }}
-                        >
-                          Delete Image
-                        </button>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p>No album photos available</p>
-              )}
-            </section>
+            {/* Only show album photos section if:
+                1. There are photos to display, OR
+                2. User is admin (not inventory manager, owner, or receptionist) */}
+            {(albumPhotos.length > 0 || (!isInventoryManager && !isOwner && !isReceptionist)) && (
+              <section className="album-photos">
+                <h2>Album Photos</h2>
+                {albumPhotos.length > 0 ? (
+                  <div className="album-photo-grid">
+                    {albumPhotos.map((photo, index) => (
+                      <div
+                        key={index}
+                        className="album-photo-card"
+                        onClick={() =>
+                          openPhotoModal(
+                            `data:${photo.imgType};base64,${photo.data}`
+                          )
+                        }
+                      >
+                        <img
+                          src={`data:${photo.imgType};base64,${photo.data}`} // Construct the image URL from data and type
+                          alt={`Album Photo ${index + 1}`}
+                          className="album-photo-thumbnail"
+                        />
+                        {!isInventoryManager && !isOwner && !isReceptionist && (
+                          <button
+                            className="delete-photo-button"
+                            onClick={e => {
+                              e.stopPropagation(); // This prevents the modal from opening
+                              handleDeleteAlbumPhoto(photo.id); // Pass the photo ID for deletion
+                            }}
+                          >
+                            Delete Image
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p>No album photos available</p>
+                )}
+              </section>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
…or regular users

**JIRA:** [Jira Ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1090)
## Context:
The VetDetails.tsx component was modified to conditionally render the "Album Photos" section based on user role and photo availability. Previously, this section was always visible, showing either the photos or a "No album photos available" message. Now, the section is completely hidden for regular users (owners, inventory managers, and receptionists) when no
photos exist, improving the user interface by removing empty content. 

## Does this PR change the .vscode folder in petclinic-frontend?:
No

## Changes
Changes to VetDetails.tsx (Front-end):
- Wrapped the section in a conditional check: (albumPhotos.length > 0 || (!isInventoryManager && !isOwner && !isReceptionist)).

## Does this use the v2 API?:
No

## Does this add a new communication between services?:
No

## Before and After UI (Required for UI-impacting PRs)
Before:
<img width="1440" height="755" alt="Screenshot 2025-09-28 at 4 07 36 PM" src="https://github.com/user-attachments/assets/f92df193-f8cc-46aa-b927-681429b9da01" />

After:
<img width="1440" height="754" alt="Screenshot 2025-09-28 at 5 27 47 PM" src="https://github.com/user-attachments/assets/bbc7bdaa-c553-4f89-bbed-572ea697c4b9" />
