### PR TITLE
Removed the unused emailing services in docker-compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -119,22 +119,6 @@ services:
       - stack.env
     restart: unless-stopped
 
-  emailing-service:
-    image: emailing-service
-    pull_policy: never
-    container_name: emailing-service-container
-    build:
-      context: ./emailing-service
-      dockerfile: emailing-service/Dockerfile
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-      - DEFAULT_CONNECTION=Server=emailing-service-mysql-db;Port=3306;Database=MyAppDb;User=root;Password=Your_password123;
-    env_file:
-      - stack.env
-    restart: unless-stopped
-    depends_on:
-      - emailing-service-mysql-db
-
   products-service:
     build: products-service
     hostname: products-service
@@ -176,19 +160,7 @@ services:
       timeout: 5s
       retries: 10
 
-  emailing-service-mysql-db:
-    image: mysql:8.0
-    container_name: emailing-service-mysql-db
-    platform: linux/amd64
-    environment:
-      - MYSQL_ROOT_PASSWORD=Your_password123
-      - MYSQL_DATABASE=MyAppDb
-      - SPRING_PROFILES_ACTIVE=docker
-    ports:
-      - "3308:3306"
-    volumes:
-      - emailing-service-mysql-db-data:/var/lib/mysql
-    restart: unless-stopped
+
 
   postgres-vet:
     image: postgres
@@ -318,4 +290,3 @@ volumes:
   mongo-carts-data:
   mongo-carts-config:
   postgres-vet-data:
-  emailing-service-mysql-db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,22 +93,7 @@ services:
     env_file:
       - mailer.env
 
-  emailing-service:
-    image: emailing-service
-    container_name: emailing-service-container
-    build:
-      context: ./emailing-service
-      dockerfile: emailing-service/Dockerfile
-    #ports:
-    # - "5000:5115" # Used for testing without gateway
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-      - DEFAULT_CONNECTION=Server=emailing-service-mysql-db;Port=3306;Database=MyAppDb;User=root;Password=Your_password123;
-    depends_on:
-      - emailing-service-mysql-db
-    #  - api-gateway
-    env_file:
-      - mailer.env
+
 
   products-service:
     build: products-service
@@ -364,13 +349,4 @@ services:
     depends_on:
       - mongo-carts
       - cart-service
-  emailing-service-mysql-db:
-    image: mysql:8.0
-    container_name: emailing-service-mysql-db
-    platform: linux/amd64
-    environment:
-      - MYSQL_ROOT_PASSWORD=Your_password123
-      - MYSQL_DATABASE=MyAppDb
-      - SPRING_PROFILES_ACTIVE=docker
-    ports:
-      - "3308:3306"
+

--- a/docker-compose_no_FE.yml
+++ b/docker-compose_no_FE.yml
@@ -125,17 +125,7 @@ services:
       - 5013:80
     environment:
       - PMA_ARBITRARY=1
-
-  phpmyadmin-emailing-service:
-    image: phpmyadmin/phpmyadmin
-    container_name: phpmyadmin-emailing-service
-    restart: always
-    ports:
-      - "5019:80"
-    environment:
-      - PMA_HOST=emailing-service-mysql-db
-      - MYSQL_ROOT_PASSWORD=Your_password123
-
+      -
   # vet mongo container
   mongo-vet:
     image: mongo
@@ -355,29 +345,4 @@ services:
       - mongo-carts
       - cart-service
 
-  emailing-service:
-    image: emailing-service
-    container_name: emailing-service-container
-    build:
-      context: ./emailing-service
-      dockerfile: emailing-service/Dockerfile
-    #  ports:
-    #    - "5000:5115" # Used for testing without gateway
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-      - DEFAULT_CONNECTION=Server=emailing-service-mysql-db;Port=3306;Database=MyAppDb;User=root;Password=Your_password123;
-    depends_on:
-      - emailing-service-mysql-db
-      - api-gateway
-    env_file:
-      - mailer.env
-  emailing-service-mysql-db:
-    image: mysql:8.0
-    container_name: emailing-service-mysql-db
-    platform: linux/amd64
-    environment:
-      - MYSQL_ROOT_PASSWORD=Your_password123
-      - MYSQL_DATABASE=MyAppDb
-      - SPRING_PROFILES_ACTIVE=docker
-    ports:
-      - "3308:3306"
+


### PR DESCRIPTION
**JIRA:** [Link](https://champlainsaintlambert.atlassian.net/browse/CPC-1609?atlOrigin=eyJpIjoiZjM2OTNjNjA5NjY1NDljOWFhNDVkZWQ5YWYyZGYxNDYiLCJwIjoiaiJ9)
## Context:
The Emailing service was being worked on when i did the ticket to remove unused services from the docker-compose, but now that they are done I am able to remove it.
## Does this PR change the .vscode folder in petclinic-frontend?:
no

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
I changed the docker-compose and the docker-compose_no_FE

- I removed all instances of the emailing service in the docker-composes

## Does this use the v2 API?:
no
## Does this add a new communication between services?:

## Before and After UI (Required for UI-impacting PRs)
no ui change
## Dev notes (Optional)
Docker-compose much cleaner
## Linked pull requests (Optional)
Pull request links