### PR TITLE
feat(CUST-CPC-1611): Delete Pet

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/PetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/PetController.java
@@ -83,7 +83,7 @@ public class PetController {
         return customersServiceClient.getPetsByOwnerId(ownerId);
     }
 
-    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.VET})
+    //@SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.VET})
     @DeleteMapping(value = "/{petId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<PetResponseDTO>> deletePet(@PathVariable String petId) {
         return Mono.just(petId)

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/PetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/PetController.java
@@ -4,6 +4,7 @@ import com.petclinic.bffapigateway.domainclientlayer.CustomersServiceClient;
 import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerRequestDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetRequestDTO;
 import com.petclinic.bffapigateway.dtos.Pets.PetResponseDTO;
+import com.petclinic.bffapigateway.exceptions.ForbiddenAccessException;
 import com.petclinic.bffapigateway.exceptions.InvalidInputException;
 import com.petclinic.bffapigateway.utils.Security.Annotations.IsUserSpecific;
 import com.petclinic.bffapigateway.utils.Security.Annotations.SecuredEndpoint;
@@ -17,6 +18,9 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import com.petclinic.bffapigateway.domainclientlayer.AuthServiceClient;
+
+import java.util.List;
 
 import static reactor.core.publisher.Mono.just;
 
@@ -27,6 +31,7 @@ import static reactor.core.publisher.Mono.just;
 @Validated
 public class PetController {
     private final CustomersServiceClient customersServiceClient;
+    private final AuthServiceClient authServiceClient;
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.VET})
     @PutMapping(value = "/{petId}")
@@ -85,13 +90,39 @@ public class PetController {
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.OWNER, Roles.VET})
     @DeleteMapping(value = "/{petId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<PetResponseDTO>> deletePet(@PathVariable String petId) {
+    public Mono<ResponseEntity<PetResponseDTO>> deletePet(
+            @PathVariable String petId,
+            @CookieValue("Bearer") String jwtToken) {
+
         return Mono.just(petId)
                 .filter(id -> id.length() == 36)
                 .switchIfEmpty(Mono.error(new InvalidInputException("Provided pet id is invalid: " + petId)))
-                .flatMap(customersServiceClient::deletePetByPetIdV2)
+                .flatMap(validPetId -> {
+                    // First get the pet to check ownership
+                    return customersServiceClient.getPetByPetId(validPetId)
+                            .flatMap(pet -> {
+                                // Validate token and get user info
+                                return authServiceClient.validateToken(jwtToken)
+                                        .flatMap(tokenResponse -> {
+                                            String userId = tokenResponse.getBody().getUserId();
+                                            List<String> roles = tokenResponse.getBody().getRoles();
+
+                                            // Check if user has ADMIN or VET role (bypass ownership check)
+                                            boolean isAdminOrVet = roles.contains("ADMIN") || roles.contains("VET");
+
+                                            if (isAdminOrVet || pet.getOwnerId().equals(userId)) {
+                                                // User is authorized to delete this pet
+                                                return customersServiceClient.deletePetByPetIdV2(validPetId);
+                                            } else {
+                                                // User is not authorized to delete this pet
+                                                return Mono.error(new ForbiddenAccessException("You are not allowed to delete this pet"));
+                                            }
+                                        });
+                            });
+                })
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
     }
+
 
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/PetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/PetController.java
@@ -83,7 +83,7 @@ public class PetController {
         return customersServiceClient.getPetsByOwnerId(ownerId);
     }
 
-    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.OWNER})
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.OWNER, Roles.VET})
     @DeleteMapping(value = "/{petId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<PetResponseDTO>> deletePet(@PathVariable String petId) {
         return Mono.just(petId)

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/PetController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/PetController.java
@@ -83,7 +83,7 @@ public class PetController {
         return customersServiceClient.getPetsByOwnerId(ownerId);
     }
 
-    //@SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.VET})
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.OWNER})
     @DeleteMapping(value = "/{petId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<PetResponseDTO>> deletePet(@PathVariable String petId) {
         return Mono.just(petId)

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/PetControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/PetControllerIntegrationTest.java
@@ -41,6 +41,7 @@ class PetControllerIntegrationTest {
         mockServerConfigAuthService.registerValidateTokenForAdminEndpoint();
         mockServerConfigAuthService.registerValidateTokenForVetEndpoint();
         mockServerConfigAuthService.registerValidateTokenForOwnerEndpoint();
+        mockServerConfigCustomersService.registerGetPetByIdEndpoint();
     }
 
     @AfterAll
@@ -58,6 +59,7 @@ class PetControllerIntegrationTest {
                 .petTypeId("1")
                 .isActive("true")
                 .weight("1.3")
+                .ownerId("e6c7398e-8ac4-4e10-9ee0-03ef33f0361a")
                 .build();
 
         Mono<PetResponseDTO> result = webTestClient.delete()
@@ -119,6 +121,7 @@ class PetControllerIntegrationTest {
                 .petTypeId("1")
                 .isActive("true")
                 .weight("1.3")
+                .ownerId("e6c7398e-8ac4-4e10-9ee0-03ef33f0361a")
                 .build();
 
         Mono<PetResponseDTO> result = webTestClient.delete()

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/PetControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/PetControllerIntegrationTest.java
@@ -40,6 +40,7 @@ class PetControllerIntegrationTest {
         mockServerConfigAuthService = new MockServerConfigAuthService();
         mockServerConfigAuthService.registerValidateTokenForAdminEndpoint();
         mockServerConfigAuthService.registerValidateTokenForVetEndpoint();
+        mockServerConfigAuthService.registerValidateTokenForOwnerEndpoint();
     }
 
     @AfterAll
@@ -110,7 +111,7 @@ class PetControllerIntegrationTest {
     }
 
     @Test
-    void whenDeletePet_asVet_withValidPetId_thenReturnPetResponseDTO() throws ParseException {
+    void whenDeletePet_asOwner_withValidPetId_thenReturnPetResponseDTO() throws ParseException {
         PetResponseDTO pet = PetResponseDTO.builder()
                 .petId("53163352-8398-4513-bdff-b7715c056d1d")
                 .name("Buddy")
@@ -122,7 +123,7 @@ class PetControllerIntegrationTest {
 
         Mono<PetResponseDTO> result = webTestClient.delete()
                 .uri("/api/v2/gateway/pets/{petId}", pet.getPetId())
-                .cookie("Bearer", jwtTokenForValidVet)
+                .cookie("Bearer", jwtTokenForValidOwnerId)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk()
@@ -147,12 +148,12 @@ class PetControllerIntegrationTest {
     }
 
     @Test
-    void whenDeletePet_asVet_withInvalidPetId_thenReturnInvalidInputException() {
+    void whenDeletePet_asOwner_withInvalidPetId_thenReturnInvalidInputException() {
         String invalidPetId = "invalid-pet-id";
 
         Mono<InvalidInputException> result = webTestClient.delete()
                 .uri("/api/v2/gateway/pets/{petId}", invalidPetId)
-                .cookie("Bearer", jwtTokenForValidVet)
+                .cookie("Bearer", jwtTokenForValidOwnerId)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isEqualTo(422)

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/PetControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/PetControllerIntegrationTest.java
@@ -112,6 +112,70 @@ class PetControllerIntegrationTest {
                 .verifyComplete();
     }
 
+
+    @Test
+    void whenDeletePet_asVet_withValidPetId_thenReturnPetResponseDTO() throws ParseException {
+        PetResponseDTO pet = PetResponseDTO.builder()
+                .petId("53163352-8398-4513-bdff-b7715c056d1d")
+                .name("Buddy")
+                .birthDate(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").parse("1999-11-01T00:00:00.000+00:00"))
+                .petTypeId("1")
+                .isActive("true")
+                .weight("1.3")
+                .ownerId("e6c7398e-8ac4-4e10-9ee0-03ef33f0361a")
+                .build();
+
+        Mono<PetResponseDTO> result = webTestClient.delete()
+                .uri("/api/v2/gateway/pets/{petId}", pet.getPetId())
+                .cookie("Bearer", jwtTokenForValidVet)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .returnResult(PetResponseDTO.class)
+                .getResponseBody()
+                .single();
+
+        StepVerifier
+                .create(result)
+                .expectNextMatches(petResponseDTO -> {
+                    assertNotNull(petResponseDTO);
+                    assertThat(petResponseDTO.getPetId()).isEqualTo(pet.getPetId());
+                    assertThat(petResponseDTO.getName()).isEqualTo(pet.getName());
+                    assertThat(petResponseDTO.getBirthDate()).isEqualTo(pet.getBirthDate());
+                    assertThat(petResponseDTO.getPetTypeId()).isEqualTo(pet.getPetTypeId());
+                    assertThat(petResponseDTO.getIsActive()).isEqualTo(pet.getIsActive());
+                    assertThat(petResponseDTO.getWeight()).isEqualTo(pet.getWeight());
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void whenDeletePet_asVet_withInvalidPetId_thenReturnInvalidInputException() {
+        String invalidPetId = "invalid-pet-id";
+
+        Mono<InvalidInputException> result = webTestClient.delete()
+                .uri("/api/v2/gateway/pets/{petId}", invalidPetId)
+                .cookie("Bearer", jwtTokenForValidVet)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(422)
+                .returnResult(InvalidInputException.class)
+                .getResponseBody()
+                .single();
+
+        StepVerifier
+                .create(result)
+                .expectNextMatches(errorResponse -> {
+                    assertNotNull(errorResponse);
+                    assertThat(errorResponse.getMessage()).isEqualTo("Provided pet id is invalid: " + invalidPetId);
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+
     @Test
     void whenDeletePet_asOwner_withValidPetId_thenReturnPetResponseDTO() throws ParseException {
         PetResponseDTO pet = PetResponseDTO.builder()

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigCustomersService.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v2/mockservers/MockServerConfigCustomersService.java
@@ -150,6 +150,21 @@ public class MockServerConfigCustomersService {
                 );
     }
 
+    public void registerGetPetByIdEndpoint() {
+        mockServerClient_CustomersService
+                .when(
+                        request()
+                                .withMethod("GET")
+                                .withPath("/pet/53163352-8398-4513-bdff-b7715c056d1d")
+                )
+                .respond(
+                        response()
+                                .withStatusCode(200)
+                                .withBody(json("{\"petId\":\"53163352-8398-4513-bdff-b7715c056d1d\",\"name\":\"Buddy\",\"birthDate\":\"1999-11-01T00:00:00.000+00:00\",\"petTypeId\":\"1\",\"isActive\":\"true\",\"weight\":\"1.3\",\"ownerId\":\"e6c7398e-8ac4-4e10-9ee0-03ef33f0361a\"}"))
+                                .withHeader("Content-Type", "application/json")
+                );
+    }
+
     public void stopMockServer() {
         if(clientAndServer != null)
             this.clientAndServer.stop();

--- a/docker-compose_no_FE.yml
+++ b/docker-compose_no_FE.yml
@@ -175,6 +175,7 @@ services:
       - 5013:80
     environment:
       - PMA_ARBITRARY=1
+      - 
   # vet mongo container
   mongo-vet:
     image: mongo

--- a/docker-compose_no_FE.yml
+++ b/docker-compose_no_FE.yml
@@ -175,7 +175,6 @@ services:
       - 5013:80
     environment:
       - PMA_ARBITRARY=1
-  
   # vet mongo container
   mongo-vet:
     image: mongo
@@ -394,5 +393,3 @@ services:
     depends_on:
       - mongo-carts
       - cart-service
-
-

--- a/docker-compose_no_FE.yml
+++ b/docker-compose_no_FE.yml
@@ -175,7 +175,6 @@ services:
       - 5013:80
     environment:
       - PMA_ARBITRARY=1
-      -
   # vet mongo container
   mongo-vet:
     image: mongo

--- a/docker-compose_no_FE.yml
+++ b/docker-compose_no_FE.yml
@@ -175,7 +175,7 @@ services:
       - 5013:80
     environment:
       - PMA_ARBITRARY=1
-      - 
+  
   # vet mongo container
   mongo-vet:
     image: mongo

--- a/petclinic-frontend/src/features/customers/api/deletePet.ts
+++ b/petclinic-frontend/src/features/customers/api/deletePet.ts
@@ -1,15 +1,6 @@
-import { AxiosResponse } from 'axios';
 import axiosInstance from '@/shared/api/axiosInstance';
-import { PetResponseModel } from '@/features/customers/models/PetResponseModel.ts';
 
-export const deletePet = async (
-  ownerId: string,
-  petId: string
-): Promise<AxiosResponse<PetResponseModel>> => {
-  return await axiosInstance.delete<PetResponseModel>(
-    `/owners/${ownerId}/pets/${petId}`,
-    {
-      useV2: true,
-    }
-  );
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const deletePet = async (petId: string) => {
+  return await axiosInstance.delete(`/pets/${petId}`, { useV2: true });
 };

--- a/petclinic-frontend/src/features/customers/components/UpdatePetForm.tsx
+++ b/petclinic-frontend/src/features/customers/components/UpdatePetForm.tsx
@@ -109,7 +109,7 @@ const UpdatePetForm: React.FC = (): JSX.Element => {
   const handleDelete = async (): Promise<void> => {
     if (petId && ownerId) {
       try {
-        const response = await deletePet(ownerId, petId);
+        const response = await deletePet(petId);
         if (response.status === 200) {
           navigate(`/customers/${response.data.ownerId}`);
         }

--- a/petclinic-frontend/src/pages/Customer/ProfilePage.css
+++ b/petclinic-frontend/src/pages/Customer/ProfilePage.css
@@ -268,6 +268,24 @@ h1 {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
+.customers-delete-pet-button {
+  background-color: #e42a16;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: all 0.3s ease;
+}
+
+.customers-delete-pet-button:hover {
+  background-color: #e42a16;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
 .pets-list {
   display: grid;
   gap: 15px;

--- a/petclinic-frontend/src/pages/Customer/ProfilePage.tsx
+++ b/petclinic-frontend/src/pages/Customer/ProfilePage.tsx
@@ -12,6 +12,7 @@ import { AppRoutePaths } from '@/shared/models/path.routes.ts';
 import { useNavigate } from 'react-router-dom';
 import axiosInstance from '@/shared/api/axiosInstance';
 import { getPetTypeName } from '@/features/customers/utils/petTypeMapping';
+import { deletePet } from '@/features/customers/api/deletePet';
 
 const ProfilePage = (): JSX.Element => {
   const { user } = useUser();
@@ -116,6 +117,33 @@ const ProfilePage = (): JSX.Element => {
     }
   };
 
+  const handleDeletePet = async (petId: string): Promise<void> => {
+    const confirmed = window.confirm(
+      'Are you sure you want to delete this pet? This action cannot be undone.'
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await deletePet(petId);
+
+      if (owner) {
+        setOwner({
+          ...owner,
+          pets: owner.pets?.filter(pet => pet.petId !== petId) || [],
+        });
+      }
+
+      // eslint-disable-next-line no-console
+      console.log('Pet deleted successfully');
+    } catch (error) {
+      console.error('Error deleting pet:', error);
+      alert('Failed to delete pet. Please try again.');
+    }
+  };
+
   if (error) {
     return <p>{error}</p>;
   }
@@ -181,6 +209,12 @@ const ProfilePage = (): JSX.Element => {
                           years
                         </span>
                       </div>
+                      <button
+                        className="customers-delete-pet-button"
+                        onClick={() => handleDeletePet(pet.petId)}
+                      >
+                        Delete Pet
+                      </button>
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
**JIRA:** link to jira ticket
https://champlainsaintlambert.atlassian.net/jira/software/c/projects/CPC/boards/14?label=CUST&selectedIssue=CPC-1611

## Context:
This PR addresses the issue that an owner cannot delete his pet or his pet information. In the Owner Profile tab he is now able to go in the pet section and easily delete his pet.


## Does this PR change the .vscode folder in petclinic-frontend?:
No it does not.

## Changes
- Added a button on the front end and the code that goes with it to be able to delete your own pet.

## Does this use the v2 API?:
Yes it does since a V1 version of delete pet existed but was deprecated

## Does this add a new communication between services?:
No it does not.

## Before and After UI (Required for UI-impacting PRs)
<img width="2548" height="921" alt="Capture" src="https://github.com/user-attachments/assets/1148a1c1-4179-4ae5-97c8-57c533c72344" />
<img width="2543" height="920" alt="Capture1" src="https://github.com/user-attachments/assets/4ab575b5-a684-4826-8563-aa5872e33aee" />
