### PR TITLE
bug(VIST-CPC-1697): fix the infinite loop in visits view

### DIFF
--- a/petclinic-frontend/src/features/visits/visits/VisitByVisitId.tsx
+++ b/petclinic-frontend/src/features/visits/visits/VisitByVisitId.tsx
@@ -20,8 +20,9 @@ export default function VisitDetails(): JSX.Element {
           console.error('Error fetching visit:', error);
         });
     }
-  });
-  [visitId];
+  },
+  [visitId]
+);
 
   if (!visit) {
     return <div>Loading...</div>;


### PR DESCRIPTION
**JIRA:** link to jira ticket
## Context:
When opening a visit view page, an infinite loop of requests is initiated. This is caused by a malformed useEffect hook.

## Does this PR change the .vscode folder in petclinic-frontend?:
No it does not.

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
- Moved the visitId dependency inside of the useEffect hook (it was placed outside of it)

## Does this use the v2 API?:
No

## Does this add a new communication between services?:
No

## Before and After UI (Required for UI-impacting PRs)
N/A

## Dev notes (Optional)
Specific technical changes that should be noted
## Linked pull requests (Optional)
Pull request links