### PR TITLE
bug(CART-CPC-1687): remove API call in navbar caused by cart icon

### DIFF
--- a/petclinic-frontend/src/features/carts/api/cartEvent.ts
+++ b/petclinic-frontend/src/features/carts/api/cartEvent.ts
@@ -1,10 +1,52 @@
+// cartEvent.ts
 export const CART_CHANGED = 'cart:changed';
 
+const CART_COUNT_KEY = 'cart:count';
+const CART_ID_KEY = 'cart:id';
+
 export function notifyCartChanged(): void {
+  // same-tab listeners
   window.dispatchEvent(new Event(CART_CHANGED));
+  // cross-tab listeners
   try {
     localStorage.setItem('cart:changed', String(Date.now()));
   } catch {
-    // ignore write failures (private mode, etc.)
+    // private mode etc — ignore
   }
+}
+
+/** Read / write cartId in localStorage */
+export function getCartIdFromLS(): string | null {
+  try {
+    return localStorage.getItem(CART_ID_KEY);
+  } catch {
+    return null;
+  }
+}
+export function setCartIdInLS(id: string): void {
+  try {
+    localStorage.setItem(CART_ID_KEY, id);
+  } catch { /* ignore */ }
+}
+
+/** Read / write cart count in localStorage (single source of truth for navbar) */
+export function getCartCountFromLS(): number {
+  try {
+    const raw = localStorage.getItem(CART_COUNT_KEY);
+    const n = raw ? Number(raw) : 0;
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+export function setCartCountInLS(n: number): void {
+  try {
+    localStorage.setItem(CART_COUNT_KEY, String(Math.max(0, Math.trunc(n))));
+  } catch { /* ignore */ }
+  notifyCartChanged();
+}
+
+/** Convenience: add a delta (can be negative) */
+export function bumpCartCountInLS(delta: number): void {
+  setCartCountInLS(getCartCountFromLS() + delta);
 }

--- a/petclinic-frontend/src/features/carts/api/getCart.ts
+++ b/petclinic-frontend/src/features/carts/api/getCart.ts
@@ -1,4 +1,4 @@
-import axiosInstance from '@/shared/api/axiosInstance.ts';
+import axiosInstance from '@/shared/api/axiosInstance';
 
 type CartIdResponse = { cartId: string };
 


### PR DESCRIPTION
**JIRA:** [link to jira ticket](https://champlainsaintlambert.atlassian.net/browse/CPC-1687)

---

## Context:
What is the ticket about and why are we doing this change.

---

## Does this PR change the .vscode folder in petclinic-frontend?:
No.

---

## Changes
- **AppNavBar.tsx**
  - Removed all direct cart API calls.  
  - Added support for reading cart ID and count from localStorage (`cart:id`, `cart:count`).  
  - Subscribes to both a custom `CART_CHANGED` event (same-tab) and browser `storage` events (cross-tab).  
  - Simplified logout: clears localStorage keys instead of making an API call.  

- **UserCart.tsx**
  - On initial cart fetch, persists `cart:id` and `cart:count` into localStorage.  
  - Cart actions (quantity change, delete, clear, checkout, wishlist moves) now bump or reset the localStorage count.  
  - Ensures navbar stays in sync across tabs.  

- **cartEvent.ts**
  - Introduced helpers:  
    - `getCartIdFromLS`, `setCartIdInLS`  
    - `getCartCountFromLS`, `setCartCountInLS`, `bumpCartCountInLS`  
  - `notifyCartChanged()` now also updates localStorage with a `cart:changed` timestamp for cross-tab sync.  

- **addToCartFromProducts.ts**
  - After adding a product, sets `cart:id` and increments the cart count in localStorage.  
  - Still uses `notifyCartChanged()` to broadcast updates.  

- **getCart.ts**
  - Fixed import path for `axiosInstance`.
  
---

## Does this use the v2 API?:
Yes, this is unchanged. Cart page and product actions use the v2 gateway but the navbar no longer calls any API

---

## Does this add a new communication between services?:
No. This actually removes unnecessary API calls from the navbar.

---
## Before and After UI (Required for UI-impacting PRs)
- **Before:**  Navbar triggered `/carts/**` API requests on page load; could show errors.
<img width="2487" height="960" alt="image" src="https://github.com/user-attachments/assets/5b8b0012-c941-4c72-9ed4-7d48a2db2e4c" />
- **After:** Navbar badge updates instantly using localStorage, no API calls.  
<img width="2481" height="1069" alt="image" src="https://github.com/user-attachments/assets/baf9a08a-bce9-41fe-85dc-ef7dee8814cb" />
---
