### PR TITLE
feat(CUST-CPC-1638): add username for owner

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -780,11 +780,6 @@ public class BFFApiGatewayController {
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
-    @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
-    @GetMapping(value = "users/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<UserDetails> getUserById(@PathVariable String userId, @CookieValue("Bearer") String auth) {
-        return authServiceClient.getUserById(auth, userId);
-    }
 
     @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
     @DeleteMapping(value = "users/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v1/UserControllerV1.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v1/UserControllerV1.java
@@ -1,0 +1,45 @@
+package com.petclinic.bffapigateway.presentationlayer.v1;
+
+import com.petclinic.bffapigateway.domainclientlayer.AuthServiceClient;
+import com.petclinic.bffapigateway.dtos.Auth.UserDetails;
+import com.petclinic.bffapigateway.utils.Security.Annotations.IsUserSpecific;
+import com.petclinic.bffapigateway.utils.Security.Annotations.SecuredEndpoint;
+import com.petclinic.bffapigateway.utils.Security.Variables.Roles;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.springframework.validation.annotation.Validated;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@Validated
+@RequestMapping("api/gateway/users")
+public class UserControllerV1 {
+
+    private final AuthServiceClient authServiceClient;
+
+    @SecuredEndpoint(allowedRoles = {Roles.OWNER, Roles.ADMIN})
+    @GetMapping("/{userId}")
+    public Mono<ResponseEntity<UserDetails>> getUserById(@PathVariable String userId, @CookieValue("Bearer") String token) {
+        return authServiceClient.getUserById(token, userId)
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+
+    @IsUserSpecific(idToMatch = {"userId"}, bypassRoles = {Roles.ADMIN})
+    @PatchMapping("/{userId}/username")
+    public Mono<ResponseEntity<String>> updateUsername(
+            @PathVariable String userId,
+            @RequestBody @NotBlank @Size(min = 3, max = 50) @Pattern(regexp = "^[a-zA-Z0-9_]+$", message = "Username can only contain letters, numbers, and underscores") String username,
+            @CookieValue("Bearer") String token) {
+        return authServiceClient.updateUsername(userId, username, token)
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+}

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -3009,30 +3009,6 @@ private VetAverageRatingDTO buildVetAverageRatingDTO(){
                 .hasSize(1);
     }
 
-    @Test
-    public void getUserById_ValidUserId_ShouldReturnUser() {
-        UserDetails userDetails = UserDetails.builder()
-                .userId("validUserId")
-                .username("validUsername")
-                .email("validEmail")
-                .build();
-
-        when(authServiceClient.getUserById(anyString(), anyString()))
-                .thenReturn(Mono.just(userDetails));
-
-        client.get()
-                .uri("/api/gateway/users/validUserId")
-                .cookie("Bearer", "validToken")
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(UserDetails.class)
-                .value(u -> {
-                    assertNotNull(u);
-                    assertEquals(userDetails.getUserId(), u.getUserId());
-                    assertEquals(userDetails.getUsername(), u.getUsername());
-                    assertEquals(userDetails.getEmail(), u.getEmail());
-                });
-    }
 
     @Test
     void deleteUserById_ValidUserId_ShouldDeleteUser() {

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/V1/UserControllerV1Test.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/V1/UserControllerV1Test.java
@@ -1,0 +1,133 @@
+package com.petclinic.bffapigateway.presentationlayer.V1;
+
+import com.petclinic.bffapigateway.presentationlayer.v1.UserControllerV1;
+import com.petclinic.bffapigateway.domainclientlayer.AuthServiceClient;
+import com.petclinic.bffapigateway.utils.Security.Filters.JwtTokenFilter;
+import com.petclinic.bffapigateway.utils.Security.Filters.RoleFilter;
+import com.petclinic.bffapigateway.utils.Security.Filters.IsUserFilter;
+import com.petclinic.bffapigateway.dtos.Auth.UserDetails;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringRunner.class)
+@WebFluxTest(
+        controllers = {UserControllerV1.class},
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {JwtTokenFilter.class, RoleFilter.class, IsUserFilter.class}
+        )
+)
+@AutoConfigureWebTestClient
+class UserControllerV1Test {
+
+    @Autowired
+    private WebTestClient client;
+
+    @MockBean
+    private AuthServiceClient authServiceClient;
+
+    @Test
+    void whenGetUserById_thenReturnUserDetails() {
+        String userId = "test-user-id";
+        String token = "test-token";
+        
+        UserDetails userDetails = UserDetails.builder()
+                .userId(userId)
+                .username("testuser")
+                .email("test@example.com")
+                .build();
+
+        when(authServiceClient.getUserById(token, userId))
+                .thenReturn(Mono.just(userDetails));
+
+        client.get()
+                .uri("/api/gateway/users/{userId}", userId)
+                .cookie("Bearer", token)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(UserDetails.class)
+                .value(user -> {
+                    assertEquals(userId, user.getUserId());
+                    assertEquals("testuser", user.getUsername());
+                    assertEquals("test@example.com", user.getEmail());
+                });
+
+        verify(authServiceClient).getUserById(token, userId);
+    }
+
+    @Test
+    void whenGetUserById_thenReturnNotFound() {
+        String userId = "non-existent-user";
+        String token = "test-token";
+
+        when(authServiceClient.getUserById(token, userId))
+                .thenReturn(Mono.empty());
+
+        client.get()
+                .uri("/api/gateway/users/{userId}", userId)
+                .cookie("Bearer", token)
+                .exchange()
+                .expectStatus().isNotFound();
+
+        verify(authServiceClient).getUserById(token, userId);
+    }
+
+    @Test
+    void whenUpdateUsername_thenReturnUpdatedUsername() {
+        String userId = "test-user-id";
+        String newUsername = "newusername";
+        String token = "test-token";
+
+        when(authServiceClient.updateUsername(userId, newUsername, token))
+                .thenReturn(Mono.just(newUsername));
+
+        client.patch()
+                .uri("/api/gateway/users/{userId}/username", userId)
+                .cookie("Bearer", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(newUsername))
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .value(username -> assertEquals(newUsername, username));
+
+        verify(authServiceClient).updateUsername(userId, newUsername, token);
+    }
+
+    @Test
+    void whenUpdateUsername_thenReturnNotFound() {
+        String userId = "non-existent-user";
+        String newUsername = "newusername";
+        String token = "test-token";
+
+        when(authServiceClient.updateUsername(userId, newUsername, token))
+                .thenReturn(Mono.empty());
+
+        client.patch()
+                .uri("/api/gateway/users/{userId}/username", userId)
+                .cookie("Bearer", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(newUsername))
+                .exchange()
+                .expectStatus().isNotFound();
+
+        verify(authServiceClient).updateUsername(userId, newUsername, token);
+    }
+}

--- a/petclinic-frontend/src/features/customers/api/getUserDetails.ts
+++ b/petclinic-frontend/src/features/customers/api/getUserDetails.ts
@@ -1,0 +1,11 @@
+import { AxiosResponse } from 'axios';
+import axiosInstance from '@/shared/api/axiosInstance';
+import { UserDetailsModel } from '../models/UserDetailsModel';
+
+export const getUserDetails = async (
+  userId: string
+): Promise<AxiosResponse<UserDetailsModel>> => {
+  return await axiosInstance.get<UserDetailsModel>(`/users/${userId}`, {
+    useV2: false,
+  });
+};

--- a/petclinic-frontend/src/features/customers/api/updateUsername.ts
+++ b/petclinic-frontend/src/features/customers/api/updateUsername.ts
@@ -1,0 +1,18 @@
+import { AxiosResponse } from 'axios';
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export const updateUsername = async (
+  userId: string,
+  username: string
+): Promise<AxiosResponse<string>> => {
+  return await axiosInstance.patch<string>(
+    `/users/${userId}/username`,
+    username,
+    {
+      useV2: false,
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    }
+  );
+};

--- a/petclinic-frontend/src/features/customers/components/AddPetModal.tsx
+++ b/petclinic-frontend/src/features/customers/components/AddPetModal.tsx
@@ -28,6 +28,8 @@ const AddPetModal: React.FC<AddPetModalProps> = ({
     isActive: 'true',
     weight: '',
   });
+  const [dateInputValue, setDateInputValue] = useState<string>('');
+  const [isDateInputFocused, setIsDateInputFocused] = useState<boolean>(false);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [petTypes, setPetTypes] = useState<PetTypeModel[]>([]);
@@ -48,6 +50,7 @@ const AddPetModal: React.FC<AddPetModalProps> = ({
     };
     if (isOpen) {
       fetchPetTypes();
+      setDateInputValue(pet.birthDate.toISOString().split('T')[0]);
     }
   }, [isOpen]);
 
@@ -58,7 +61,16 @@ const AddPetModal: React.FC<AddPetModalProps> = ({
   ): void => {
     const { name, type, value } = e.target;
     if (type === 'date') {
-      setPet({ ...pet, [name]: new Date(value) });
+      setDateInputValue(value);
+
+      if (value && value.length === 10) {
+        const dateValue = new Date(value);
+        if (!isNaN(dateValue.getTime())) {
+          setPet({ ...pet, [name]: dateValue });
+        }
+      } else if (value === '') {
+        setPet({ ...pet, [name]: new Date() });
+      }
     } else {
       setPet({ ...pet, [name]: value });
     }
@@ -104,6 +116,8 @@ const AddPetModal: React.FC<AddPetModalProps> = ({
       isActive: 'true',
       weight: '',
     });
+    setDateInputValue('');
+    setIsDateInputFocused(false);
     setErrors({});
     setIsSubmitting(false);
     onClose();
@@ -168,8 +182,17 @@ const AddPetModal: React.FC<AddPetModalProps> = ({
             <input
               type="date"
               name="birthDate"
-              value={pet.birthDate.toISOString().split('T')[0]}
+              value={
+                isDateInputFocused
+                  ? dateInputValue
+                  : dateInputValue ||
+                    (pet.birthDate && !isNaN(pet.birthDate.getTime())
+                      ? pet.birthDate.toISOString().split('T')[0]
+                      : new Date().toISOString().split('T')[0])
+              }
               onChange={handleChange}
+              onFocus={() => setIsDateInputFocused(true)}
+              onBlur={() => setIsDateInputFocused(false)}
               disabled={isSubmitting}
             />
           </div>

--- a/petclinic-frontend/src/features/customers/components/UpdateCustomerForm.tsx
+++ b/petclinic-frontend/src/features/customers/components/UpdateCustomerForm.tsx
@@ -2,16 +2,20 @@ import * as React from 'react';
 import { FormEvent, useEffect, useState } from 'react';
 import { getOwner } from '../api/getOwner';
 import { updateOwner } from '../api/updateOwner';
+import { getUserDetails } from '../api/getUserDetails';
+import { updateUsername } from '../api/updateUsername';
 import { OwnerRequestModel } from '@/features/customers/models/OwnerRequestModel.ts';
 import { OwnerResponseModel } from '@/features/customers/models/OwnerResponseModel.ts';
+import { UserDetailsModel } from '@/features/customers/models/UserDetailsModel';
 import { useNavigate } from 'react-router-dom';
 import { AppRoutePaths } from '@/shared/models/path.routes';
 import { useUser } from '@/context/UserContext';
+import { validateUsername } from '../utils/validation';
 import './UpdateCustomerForm.css';
 
 const UpdateCustomerForm: React.FC = (): JSX.Element => {
   const navigate = useNavigate();
-  const { user } = useUser();
+  const { user, setUser } = useUser();
   const [owner, setOwner] = useState<OwnerRequestModel>({
     firstName: '',
     lastName: '',
@@ -20,13 +24,19 @@ const UpdateCustomerForm: React.FC = (): JSX.Element => {
     province: '',
     telephone: '',
   });
+  const [userDetails, setUserDetails] = useState<UserDetailsModel | null>(null);
+  const [username, setUsername] = useState<string>('');
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
   useEffect(() => {
-    const fetchOwnerData = async (): Promise<void> => {
+    const fetchData = async (): Promise<void> => {
       try {
-        const response = await getOwner(user.userId);
-        const ownerData: OwnerResponseModel = response.data;
+        const [ownerResponse, userResponse] = await Promise.all([
+          getOwner(user.userId),
+          getUserDetails(user.userId),
+        ]);
+
+        const ownerData: OwnerResponseModel = ownerResponse.data;
         setOwner({
           firstName: ownerData.firstName,
           lastName: ownerData.lastName,
@@ -35,19 +45,39 @@ const UpdateCustomerForm: React.FC = (): JSX.Element => {
           province: ownerData.province,
           telephone: ownerData.telephone,
         });
+
+        const userData: UserDetailsModel = userResponse.data;
+        setUserDetails(userData);
+        setUsername(userData.username);
       } catch (error) {
-        console.error('Error fetching owner data:', error);
+        console.error('Error fetching data:', error);
+        setUserDetails({
+          userId: user.userId,
+          username: 'Unknown',
+          email: '',
+          roles: [],
+          verified: false,
+          disabled: false,
+        });
+        setUsername('Unknown');
       }
     };
 
-    fetchOwnerData().catch(error =>
-      console.error('Error in fetchOwnerData:', error)
-    );
+    fetchData();
   }, [user.userId]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const { name, value } = e.target;
     setOwner({ ...owner, [name]: value });
+  };
+
+  const handleUsernameChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    setUsername(e.target.value);
+    if (errors.username) {
+      setErrors(prev => ({ ...prev, username: '' }));
+    }
   };
 
   const validate = (): boolean => {
@@ -58,6 +88,12 @@ const UpdateCustomerForm: React.FC = (): JSX.Element => {
     if (!owner.city) newErrors.city = 'City is required';
     if (!owner.province) newErrors.province = 'Province is required';
     if (!owner.telephone) newErrors.telephone = 'Telephone is required';
+
+    const usernameError = validateUsername(username);
+    if (usernameError) {
+      newErrors.username = usernameError;
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -69,11 +105,18 @@ const UpdateCustomerForm: React.FC = (): JSX.Element => {
     if (!validate()) return;
 
     try {
-      const response = await updateOwner(user.userId, owner);
-      if (response.status === 200) {
-        navigate(AppRoutePaths.Home);
-      } else {
+      await updateOwner(user.userId, owner);
+
+      if (userDetails && username !== userDetails.username) {
+        await updateUsername(user.userId, username);
+
+        setUser({
+          ...user,
+          username: username,
+        });
       }
+
+      navigate(AppRoutePaths.Home);
     } catch (error) {
       console.error('Error:', error);
     }
@@ -83,6 +126,15 @@ const UpdateCustomerForm: React.FC = (): JSX.Element => {
     <div className="update-customer-form">
       <h1>Edit Profile</h1>
       <form onSubmit={handleSubmit}>
+        <label>Username: </label>
+        <input
+          type="text"
+          name="username"
+          value={username}
+          onChange={handleUsernameChange}
+        />
+        {errors.username && <span className="error">{errors.username}</span>}
+        <br />
         <label>First Name: </label>
         <input
           type="text"

--- a/petclinic-frontend/src/features/customers/models/UserDetailsModel.ts
+++ b/petclinic-frontend/src/features/customers/models/UserDetailsModel.ts
@@ -1,0 +1,8 @@
+export interface UserDetailsModel {
+  userId: string;
+  username: string;
+  email: string;
+  roles: string[];
+  verified: boolean;
+  disabled: boolean;
+}

--- a/petclinic-frontend/src/features/customers/utils/validation.ts
+++ b/petclinic-frontend/src/features/customers/utils/validation.ts
@@ -1,0 +1,15 @@
+export const validateUsername = (username: string): string | null => {
+  if (!username.trim()) {
+    return 'Username is required';
+  }
+  if (username.length < 3) {
+    return 'Username must be at least 3 characters long';
+  }
+  if (username.length > 50) {
+    return 'Username must be less than 50 characters';
+  }
+  if (!/^[a-zA-Z0-9_]+$/.test(username)) {
+    return 'Username can only contain letters, numbers, and underscores';
+  }
+  return null;
+};


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1638
## Context:
This ticket adds username functionality for pet owners. Owners can now see and edit their usernames in their profile, and admins can view/edit usernames when looking at customer details.

## Does this PR change the .vscode folder in petclinic-frontend?:
No
## Changes
Backend: 
- Added UserControllerV1 with endpoints to get and update usernames
- Added tests for new api agteway endpoints

Frontend: 
- Added username field to owner profile and edit profile pages
- Added username display and editing in customer details section for admin
- Added username validation
- Updated user context to show username changes immediately

## Does this use the v2 API?:
No
## Does this add a new communication between services?:
No
## Before and After UI (Required for UI-impacting PRs)
**Owner:**
<img width="1374" height="900" alt="image" src="https://github.com/user-attachments/assets/31e73fce-2eef-4408-8515-7c050d8274f9" />
**Admin:**
<img width="1344" height="890" alt="image" src="https://github.com/user-attachments/assets/9f8abaf6-cc8e-4fe4-82d4-a1b99b846946" />
**Update form:**
<img width="1388" height="917" alt="image" src="https://github.com/user-attachments/assets/3e2e51aa-210f-4d2c-8205-c6dd5464f4d7" />

## Dev notes (Optional)

## Linked pull requests (Optional)
Not applicable