### PR TITLE
feat(VISIT-CPC-1421):  Add visit booking with vet availability and time slot selection

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/TimeSlotDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/TimeSlotDTO.java
@@ -1,0 +1,17 @@
+package com.petclinic.bffapigateway.dtos.Visits;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeSlotDTO {
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private boolean available;
+}
+

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitRequestDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Visits/VisitRequestDTO.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
@@ -15,7 +16,7 @@ import java.time.LocalDateTime;
 @Builder
 public class VisitRequestDTO {
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime visitDate;
     private String description;
     private String petId;

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v2/VisitController.java
@@ -2,8 +2,10 @@ package com.petclinic.bffapigateway.presentationlayer.v2;
 
 import com.petclinic.bffapigateway.domainclientlayer.VisitsServiceClient;
 import com.petclinic.bffapigateway.dtos.Auth.Role;
+import com.petclinic.bffapigateway.dtos.Vets.VetResponseDTO;
 import com.petclinic.bffapigateway.dtos.Visits.Emergency.EmergencyRequestDTO;
 import com.petclinic.bffapigateway.dtos.Visits.Emergency.EmergencyResponseDTO;
+import com.petclinic.bffapigateway.dtos.Visits.TimeSlotDTO;
 import com.petclinic.bffapigateway.dtos.Visits.VisitRequestDTO;
 import com.petclinic.bffapigateway.dtos.Visits.VisitResponseDTO;
 import com.petclinic.bffapigateway.dtos.Visits.reviews.ReviewRequestDTO;
@@ -53,7 +55,7 @@ public class VisitController {
     }
 
 
-    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.OWNER})
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.OWNER, Roles.VET, Roles.RECEPTIONIST})
     @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<VisitResponseDTO>> addVisit(@RequestBody Mono<VisitRequestDTO> visitRequestDTO) {
         return visitsServiceClient.addVisit(visitRequestDTO)
@@ -282,4 +284,36 @@ public class VisitController {
                         .contentType(MediaType.APPLICATION_OCTET_STREAM)
                         .body(csvData));
     }
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.RECEPTIONIST, Roles.OWNER, Roles.VET})
+    @GetMapping(value = "/availability/vets", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Flux<VetResponseDTO>> getAllVetsForAvailability() {
+        return ResponseEntity.ok().body(visitsServiceClient.getAllVetsForAvailability());
+    }
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.RECEPTIONIST, Roles.OWNER, Roles.VET})
+    @GetMapping(value = "/availability/vets/{vetId}/slots", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Flux<TimeSlotDTO>> getAvailableTimeSlots(
+            @PathVariable String vetId,
+            @RequestParam String date) {
+        return ResponseEntity.ok().body(visitsServiceClient.getAvailableTimeSlots(vetId, date));
+    }
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.RECEPTIONIST, Roles.OWNER, Roles.VET})
+    @GetMapping(value = "/availability/vets/{vetId}/dates", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Flux<String>> getAvailableDates(
+            @PathVariable String vetId,
+            @RequestParam String startDate,
+            @RequestParam String endDate) {
+        return ResponseEntity.ok().body(visitsServiceClient.getAvailableDates(vetId, startDate, endDate));
+    }
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN, Roles.RECEPTIONIST, Roles.OWNER, Roles.VET})
+    @GetMapping(value = "/availability/vets/{vetId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<VetResponseDTO>> getVeterinarianAvailability(@PathVariable String vetId) {
+        return visitsServiceClient.getVeterinarianAvailability(vetId)
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+
 }

--- a/petclinic-frontend/src/features/visits/api/getAvailableSlots .ts
+++ b/petclinic-frontend/src/features/visits/api/getAvailableSlots .ts
@@ -14,7 +14,7 @@ export const getAvailableSlots = async (
   return await axiosInstance.get<TimeSlot[]>(
     `/visits/availability/vets/${vetId}/slots`,
     {
-      useV2: true,
+      useV2: false,
       params: { date },
     }
   );

--- a/petclinic-frontend/src/features/visits/api/getAvailableSlots .ts
+++ b/petclinic-frontend/src/features/visits/api/getAvailableSlots .ts
@@ -1,0 +1,21 @@
+import { AxiosResponse } from 'axios';
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export interface TimeSlot {
+  startTime: string;
+  endTime: string;
+  available: boolean;
+}
+
+export const getAvailableSlots = async (
+  vetId: string,
+  date: string
+): Promise<AxiosResponse<TimeSlot[]>> => {
+  return await axiosInstance.get<TimeSlot[]>(
+    `/visits/availability/vets/${vetId}/slots`,
+    {
+      useV2: true,
+      params: { date },
+    }
+  );
+};

--- a/petclinic-frontend/src/features/visits/api/getVets.ts
+++ b/petclinic-frontend/src/features/visits/api/getVets.ts
@@ -11,7 +11,7 @@ export interface VetResponse {
 export const getAvailableVets = async (): Promise<VetResponse[]> => {
   const response = await axiosInstance.get('/vets', {
     responseType: 'text',
-    useV2: true,
+    useV2: false,
   });
 
   const data = response.data;

--- a/petclinic-frontend/src/features/visits/api/getVets.ts
+++ b/petclinic-frontend/src/features/visits/api/getVets.ts
@@ -1,0 +1,46 @@
+import axiosInstance from '@/shared/api/axiosInstance';
+
+export interface VetResponse {
+  vetId: string;
+  firstName: string;
+  lastName: string;
+  active: boolean;
+  specialties?: Array<{ specialtyId: string; name: string }>;
+}
+
+export const getAvailableVets = async (): Promise<VetResponse[]> => {
+  const response = await axiosInstance.get('/vets', {
+    responseType: 'text',
+    useV2: true,
+  });
+
+  const data = response.data;
+
+  if (typeof data === 'string') {
+    try {
+      const parsed = JSON.parse(data);
+      if (Array.isArray(parsed)) {
+        return parsed as VetResponse[];
+      }
+    } catch (err) {}
+
+    return response.data
+      .split('data:')
+      .map((payLoad: string) => {
+        try {
+          if (payLoad.trim() === '') return null;
+          return JSON.parse(payLoad);
+        } catch (err) {
+          console.error("Can't parse vet payload:", err);
+          return null;
+        }
+      })
+      .filter((d: VetResponse | null): d is VetResponse => d !== null);
+  }
+
+  if (Array.isArray(data)) {
+    return data as VetResponse[];
+  }
+
+  return [];
+};

--- a/petclinic-frontend/src/features/visits/models/AddingVisit.tsx
+++ b/petclinic-frontend/src/features/visits/models/AddingVisit.tsx
@@ -1,62 +1,227 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FormEvent, useState } from 'react';
+import { FormEvent, useState, useEffect } from 'react';
 import './EditVisit.css';
-import { VisitRequestModel } from '@/features/visits/models/VisitRequestModel';
 import { Status } from '@/features/visits/models/Status';
 import { addVisit } from '@/features/visits/api/addVisit';
+import { getAvailableVets, VetResponse } from '@/features/visits/api/getVets';
+import { getAvailableSlots, TimeSlot } from '../api/getAvailableSlots ';
+import { VisitRequestModel } from '@/features/visits/models/VisitRequestModel';
 
 interface ApiError {
   message: string;
 }
+
+// Add vetId and vetName to TimeSlot for tracking
+interface TimeSlotWithVet extends TimeSlot {
+  vetId?: string;
+  vetName?: string;
+}
+
 type VisitType = {
-  visitStartDate: Date;
   description: string;
   petId: string;
   practitionerId: string;
+  selectedDate: string;
+  selectedTimeSlot: string;
+  assignedVetId: string;
   status: Status;
 };
 
 const AddingVisit: React.FC = (): JSX.Element => {
   const [visit, setVisit] = useState<VisitType>({
-    visitStartDate: new Date(),
     description: '',
     petId: '',
-    practitionerId: '',
+    practitionerId: 'no-preference',
+    selectedDate: '',
+    selectedTimeSlot: '',
+    assignedVetId: '',
     status: 'UPCOMING' as Status,
   });
 
+  const [vets, setVets] = useState<VetResponse[]>([]);
+  const [timeSlots, setTimeSlots] = useState<TimeSlotWithVet[]>([]);
+  const [loadingVets, setLoadingVets] = useState<boolean>(true);
+  const [loadingSlots, setLoadingSlots] = useState<boolean>(false);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [successMessage, setSuccessMessage] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [showNotification, setShowNotification] = useState<boolean>(false);
 
   const navigate = useNavigate();
+  //fetch vets
+  useEffect(() => {
+    const fetchVets = async (): Promise<void> => {
+      try {
+        setLoadingVets(true);
+        const vetsResponse = await getAvailableVets();
+        const activeVets = Array.isArray(vetsResponse)
+          ? vetsResponse.filter(vet => vet.active)
+          : [];
+        setVets(activeVets);
+      } catch (error) {
+        const apiError = error as ApiError;
+        setErrorMessage(`Error loading vets: ${apiError.message}`);
+      } finally {
+        setLoadingVets(false);
+      }
+    };
 
-  const formatDate = (date: Date): string => {
-    const pad = (n: number): string => n.toString().padStart(2, '0');
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
-  };
+    fetchVets();
+  }, []);
 
+  // Fetch time slots when vet AND date are selected
+  useEffect(() => {
+    const fetchTimeSlots = async (): Promise<void> => {
+      // Need date to fetch slots
+      if (!visit.selectedDate) {
+        setTimeSlots([]);
+        return;
+      }
+
+      try {
+        setLoadingSlots(true);
+        setErrorMessage('');
+
+        // Specific vet selected - fetch only their slots
+        if (visit.practitionerId !== 'no-preference') {
+          const response = await getAvailableSlots(
+            visit.practitionerId,
+            visit.selectedDate
+          );
+
+          const vet = vets.find(v => v.vetId === visit.practitionerId);
+          const slotsWithVet: TimeSlotWithVet[] = response.data.map(slot => ({
+            ...slot,
+            vetId: visit.practitionerId,
+            vetName: vet ? `Dr. ${vet.firstName} ${vet.lastName}` : 'Unknown',
+          }));
+
+          setTimeSlots(slotsWithVet);
+
+          if (response.data.length === 0) {
+            setErrorMessage('No available slots for this vet on this date');
+          }
+        }
+        // "No Preference" - fetch slots from ALL vets and combine
+        else {
+          const allSlots: TimeSlotWithVet[] = [];
+
+          // Fetch slots from each vet
+          const slotPromises = vets.map(async vet => {
+            try {
+              const response = await getAvailableSlots(
+                vet.vetId,
+                visit.selectedDate
+              );
+              // Add vet info to each slot
+              return response.data.map(slot => ({
+                ...slot,
+                vetId: vet.vetId,
+                vetName: `Dr. ${vet.firstName} ${vet.lastName}`,
+              }));
+            } catch (error) {
+              console.error(
+                `Error fetching slots for vet ${vet.vetId}:`,
+                error
+              );
+              return [];
+            }
+          });
+
+          const results = await Promise.all(slotPromises);
+
+          // Flatten all slots
+          results.forEach(vetSlots => {
+            allSlots.push(...vetSlots);
+          });
+
+          // Remove duplicate time slots - keep only available ones
+          const uniqueSlots = allSlots.reduce((acc, slot) => {
+            const existingSlot = acc.find(s => s.startTime === slot.startTime);
+
+            if (!existingSlot) {
+              acc.push(slot);
+            } else if (slot.available && !existingSlot.available) {
+              const index = acc.indexOf(existingSlot);
+              acc[index] = slot;
+            }
+
+            return acc;
+          }, [] as TimeSlotWithVet[]);
+
+          // Sort by time
+          uniqueSlots.sort(
+            (a, b) =>
+              new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+          );
+
+          setTimeSlots(uniqueSlots);
+
+          if (uniqueSlots.length === 0) {
+            setErrorMessage(
+              'No available slots from any veterinarian on this date'
+            );
+          }
+        }
+      } catch (error) {
+        console.error('Error fetching time slots:', error);
+        const apiError = error as ApiError;
+        setErrorMessage(`Error loading time slots: ${apiError.message}`);
+        setTimeSlots([]);
+      } finally {
+        setLoadingSlots(false);
+      }
+    };
+
+    fetchTimeSlots();
+  }, [visit.practitionerId, visit.selectedDate, vets]);
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
   ): void => {
     const { name, value } = e.target;
     setVisit(prevVisit => ({
       ...prevVisit,
-      [name]: name === 'visitStartDate' ? new Date(value) : value, // Convert string to Date object for visitDate
+      [name]: value,
     }));
+    if (errors[name]) {
+      setErrors(prev => ({ ...prev, [name]: '' }));
+    }
+
+    if (name === 'selectedDate' || name === 'practitionerId') {
+      setVisit(prev => ({
+        ...prev,
+        selectedTimeSlot: '',
+        assignedVetId: '',
+      }));
+    }
+  };
+
+  const handleTimeSlotSelect = (slot: TimeSlotWithVet): void => {
+    setVisit(prev => ({
+      ...prev,
+      selectedTimeSlot: slot.startTime,
+      assignedVetId: slot.vetId || '',
+    }));
+    if (errors.selectedTimeSlot) {
+      setErrors(prev => ({ ...prev, selectedTimeSlot: '' }));
+    }
   };
 
   const validate = (): boolean => {
     const newErrors: { [key: string]: string } = {};
     if (!visit.petId) newErrors.petId = 'Pet ID is required';
-    if (!visit.visitStartDate) newErrors.visitDate = 'Visit date is required';
-    if (!visit.description) newErrors.description = 'Description is required';
-    if (!visit.practitionerId)
-      newErrors.practitionerId = 'Practitioner ID is required';
-    if (!visit.status) newErrors.status = 'Status is required';
+    if (!visit.description.trim())
+      newErrors.description = 'Description is required';
+    if (!visit.selectedDate) newErrors.selectedDate = 'Please select a date';
+    if (!visit.selectedTimeSlot)
+      newErrors.selectedTimeSlot = 'Please select a time slot';
+    if (!visit.assignedVetId) {
+      newErrors.assignedVetId = 'No vet assigned to this time slot';
+    }
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -75,18 +240,15 @@ const AddingVisit: React.FC = (): JSX.Element => {
     event.preventDefault();
     if (!validate()) return;
 
-    setIsLoading(true);
+    setIsSubmitting(true);
     setErrorMessage('');
     setSuccessMessage('');
 
     const formattedVisit: VisitRequestModel = {
-      visitDate: visit.visitStartDate
-        .toISOString()
-        .slice(0, 16)
-        .replace('T', ' '),
+      visitDate: visit.selectedTimeSlot,
       description: visit.description,
       petId: visit.petId,
-      practitionerId: visit.practitionerId,
+      practitionerId: visit.assignedVetId,
       status: visit.status,
     };
 
@@ -94,77 +256,244 @@ const AddingVisit: React.FC = (): JSX.Element => {
       await addVisit(formattedVisit); // Pass the Date object directly
       setSuccessMessage('Visit added successfully!');
       setShowNotification(true);
-      setTimeout(() => setShowNotification(false), 3000);
-      navigate('/visits');
       setVisit({
-        visitStartDate: new Date(),
         description: '',
         petId: '',
-        practitionerId: '',
+        practitionerId: 'no-preference',
+        assignedVetId: '',
+        selectedDate: '',
+        selectedTimeSlot: '',
         status: 'UPCOMING' as Status,
-        //visitEndDate: new Date(),
       });
+      setTimeout(() => {
+        navigate('/visits');
+      }, 2000);
     } catch (error) {
       const apiError = error as ApiError;
       setErrorMessage(`Error adding visit: ${apiError.message}`);
     } finally {
-      setIsLoading(false);
+      setIsSubmitting(false);
     }
   };
+
+  const formatTimeSlot = (isoString: string): string => {
+    const date = new Date(isoString);
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  };
+
+  const getMorningSlots = (): TimeSlotWithVet[] => {
+    return timeSlots.filter(slot => {
+      const hour = new Date(slot.startTime).getHours();
+      return hour < 12 && slot.available;
+    });
+  };
+
+  const getAfternoonSlots = (): TimeSlotWithVet[] => {
+    return timeSlots.filter(slot => {
+      const hour = new Date(slot.startTime).getHours();
+      return hour >= 12 && slot.available;
+    });
+  };
+
+  if (loadingVets) {
+    return (
+      <div className="profile-edit">
+        <h1>Schedule Visit For Your Pet</h1>
+        <div className="loading">Loading veterinarians...</div>
+      </div>
+    );
+  }
+
+  const morningSlots = getMorningSlots();
+  const afternoonSlots = getAfternoonSlots();
 
   return (
     <div className="profile-edit">
       <h1>Schedule Visit For Your Pet</h1>
       <form onSubmit={handleSubmit}>
-        <label>Pet ID: </label>
-        <input
-          type="text"
-          name="petId"
-          value={visit.petId}
-          onChange={handleChange}
-        />
-        {errors.petId && <span className="error">{errors.petId}</span>}
-        <br />
-        <label>Visit Date: </label>
-        <input
-          type="datetime-local"
-          name="visitStartDate"
-          value={formatDate(visit.visitStartDate)}
-          onChange={handleChange}
-          required
-        />
-        {errors.visitStartDate && (
-          <span className="error">{errors.visitStartDate}</span>
+        <div className="form-group">
+          <label htmlFor="petId">
+            Pet ID: <span className="required">*</span>
+          </label>
+          <input
+            type="text"
+            id="petId"
+            name="petId"
+            value={visit.petId}
+            onChange={handleChange}
+            placeholder="Enter pet ID"
+          />
+          {errors.petId && <span className="error">{errors.petId}</span>}
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="description">
+            Description: <span className="required">*</span>
+          </label>
+          <textarea
+            id="description"
+            name="description"
+            value={visit.description}
+            onChange={handleChange}
+            placeholder="Describe the reason for the visit..."
+            rows={4}
+          />
+          {errors.description && (
+            <span className="error">{errors.description}</span>
+          )}
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="practitionerId">Veterinarian Preference:</label>
+          <select
+            id="practitionerId"
+            name="practitionerId"
+            value={visit.practitionerId}
+            onChange={handleChange}
+          >
+            <option value="no-preference">
+              No Preference (Show All Available Times)
+            </option>
+            {vets.map(vet => (
+              <option key={vet.vetId} value={vet.vetId}>
+                Dr. {vet.firstName} {vet.lastName}
+                {vet.specialties &&
+                  vet.specialties.length > 0 &&
+                  ` (${vet.specialties.map(s => s.name).join(', ')})`}
+              </option>
+            ))}
+          </select>
+          <small className="help-text">
+            {visit.practitionerId === 'no-preference'
+              ? 'Showing available slots from all veterinarians'
+              : 'Showing slots only for selected veterinarian'}
+          </small>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="selectedDate">
+            Date: <span className="required">*</span>
+          </label>
+          <input
+            type="date"
+            id="selectedDate"
+            name="selectedDate"
+            value={visit.selectedDate}
+            onChange={handleChange}
+            min={new Date().toISOString().split('T')[0]}
+          />
+          {errors.selectedDate && (
+            <span className="error">{errors.selectedDate}</span>
+          )}
+        </div>
+
+        {visit.selectedDate && (
+          <div className="form-group">
+            <label>Available Time Slots: </label>
+
+            {loadingSlots ? (
+              <div className="loading-slots">
+                {visit.practitionerId === 'no-preference'
+                  ? 'Loading available times from all veterinarians...'
+                  : 'Loading available times...'}
+              </div>
+            ) : timeSlots.length === 0 ? (
+              <div className="no-slots">
+                No available time slots for this date. Please select another
+                date.
+              </div>
+            ) : (
+              <>
+                {/* Morning Slots */}
+                {morningSlots.length > 0 && (
+                  <div className="time-section">
+                    <h4>Morning</h4>
+                    <div className="time-slots-grid">
+                      {morningSlots.map((slot, index) => (
+                        <button
+                          key={index}
+                          type="button"
+                          className={`time-slot ${
+                            visit.selectedTimeSlot === slot.startTime
+                              ? 'selected'
+                              : ''
+                          }`}
+                          onClick={() => handleTimeSlotSelect(slot)}
+                          title={slot.vetName}
+                        >
+                          <div className="slot-time">
+                            {formatTimeSlot(slot.startTime)}
+                          </div>
+                          {visit.practitionerId === 'no-preference' && (
+                            <div className="slot-vet">{slot.vetName}</div>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Afternoon Slots */}
+                {afternoonSlots.length > 0 && (
+                  <div className="time-section">
+                    <h4>Afternoon</h4>
+                    <div className="time-slots-grid">
+                      {afternoonSlots.map((slot, index) => (
+                        <button
+                          key={index}
+                          type="button"
+                          className={`time-slot ${
+                            visit.selectedTimeSlot === slot.startTime
+                              ? 'selected'
+                              : ''
+                          }`}
+                          onClick={() => handleTimeSlotSelect(slot)}
+                          title={slot.vetName}
+                        >
+                          <div className="slot-time">
+                            {formatTimeSlot(slot.startTime)}
+                          </div>
+                          {visit.practitionerId === 'no-preference' && (
+                            <div className="slot-vet">{slot.vetName}</div>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+
+            {errors.selectedTimeSlot && (
+              <span className="error">{errors.selectedTimeSlot}</span>
+            )}
+          </div>
         )}
-        <br />
-        <label>Description: </label>
-        <input
-          type="text"
-          name="description"
-          value={visit.description}
-          onChange={handleChange}
-        />
-        {errors.description && (
-          <span className="error">{errors.description}</span>
+
+        {/* Show assigned vet when "No Preference" */}
+        {visit.practitionerId === 'no-preference' && visit.assignedVetId && (
+          <div className="assigned-vet-info">
+            ✓ You will see:{' '}
+            {
+              timeSlots.find(s => s.startTime === visit.selectedTimeSlot)
+                ?.vetName
+            }
+          </div>
         )}
-        <br />
-        <label>Practitioner ID: </label>
-        <input
-          type="text"
-          name="practitionerId"
-          value={visit.practitionerId}
-          onChange={handleChange}
-        />
-        {errors.practitionerId && (
-          <span className="error">{errors.practitionerId}</span>
-        )}
-        <br />
-        <button className="cancel" type="button" onClick={handleCancel}>
-          Cancel
-        </button>
-        <button type="submit" disabled={isLoading}>
-          {isLoading ? 'Adding...' : 'Add'}
-        </button>
+
+        {/* Buttons */}
+        <div className="button-group">
+          <button className="cancel" type="button" onClick={handleCancel}>
+            Cancel
+          </button>
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Adding...' : 'Add'}
+          </button>
+        </div>
       </form>
       {showNotification && <div className="notification">{successMessage}</div>}
       {errorMessage && <div className="error">{errorMessage}</div>}

--- a/petclinic-frontend/src/features/visits/models/EditVisit.css
+++ b/petclinic-frontend/src/features/visits/models/EditVisit.css
@@ -72,3 +72,79 @@
 .profile-edit button.cancel:hover {
   background-color: darkred;
 }
+
+.help-text {
+  display: block;
+  margin-top: 5px;
+  font-size: 0.85em;
+  color: #666;
+  font-style: italic;
+}
+
+
+.time-slot {
+  padding: 10px 15px;
+  border: 2px solid #3498db;
+  background-color: white;
+  color: #3498db;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+  text-align: center;
+}
+
+.slot-time {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.slot-vet {
+  font-size: 0.75em;
+  color: #7f8c8d;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.time-slot:hover {
+  background-color: #3498db;
+  color: white;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.time-slot:hover .slot-vet {
+  color: rgba(255,255,255,0.9);
+}
+
+.time-slot.selected {
+  background-color: #2ecc71;
+  border-color: #2ecc71;
+  color: white;
+  font-weight: bold;
+}
+
+.time-slot.selected .slot-vet {
+  color: rgba(255,255,255,0.95);
+}
+
+
+.assigned-vet-info {
+  background-color: #d4edda;
+  border: 1px solid #c3e6cb;
+  color: #155724;
+  padding: 12px 16px;
+  border-radius: 4px;
+  margin-top: 15px;
+  font-weight: 500;
+}
+
+.error-message {
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  color: #721c24;
+  padding: 12px 16px;
+  border-radius: 4px;
+  margin-top: 15px;
+}

--- a/petclinic-frontend/src/features/visits/models/OwnerBookingVisit.tsx
+++ b/petclinic-frontend/src/features/visits/models/OwnerBookingVisit.tsx
@@ -1,66 +1,219 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FormEvent, useState } from 'react';
+import { FormEvent, useState, useEffect } from 'react';
 import { useUser } from '@/context/UserContext';
 import './EditVisit.css';
 import { VisitRequestModel } from '@/features/visits/models/VisitRequestModel';
 import { Status } from '@/features/visits/models/Status';
 import { addVisit } from '@/features/visits/api/addVisit';
+import { getAvailableVets, VetResponse } from '@/features/visits/api/getVets';
+import { getAvailableSlots, TimeSlot } from '../api/getAvailableSlots ';
 
 interface ApiError {
   message: string;
 }
+
+interface TimeSlotWithVet extends TimeSlot {
+  vetId?: string;
+  vetName?: string;
+}
+
 type OwnerVisitType = {
-  visitStartDate: Date;
   description: string;
   petId: string;
   practitionerId: string;
+  selectedDate: string;
+  selectedTimeSlot: string;
+  assignedVetId: string;
   status: Status;
 };
 
 const OwnerBookingVisit: React.FC = (): JSX.Element => {
   const { user } = useUser();
   const [visit, setVisit] = useState<OwnerVisitType>({
-    visitStartDate: new Date(),
     description: '',
     petId: '',
-    practitionerId: '',
+    practitionerId: 'no-preference',
+    selectedDate: '',
+    selectedTimeSlot: '',
+    assignedVetId: '',
     status: 'UPCOMING' as Status,
   });
 
+  const [vets, setVets] = useState<VetResponse[]>([]);
+  const [timeSlots, setTimeSlots] = useState<TimeSlotWithVet[]>([]);
+  const [loadingVets, setLoadingVets] = useState<boolean>(true);
+  const [loadingSlots, setLoadingSlots] = useState<boolean>(false);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [successMessage, setSuccessMessage] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [showNotification, setShowNotification] = useState<boolean>(false);
 
   const navigate = useNavigate();
 
-  const formatDate = (date: Date): string => {
-    const pad = (n: number): string => n.toString().padStart(2, '0');
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
-  };
+  useEffect(() => {
+    const fetchVets = async (): Promise<void> => {
+      try {
+        setLoadingVets(true);
+        const vetsResponse = await getAvailableVets();
+        const activeVets = Array.isArray(vetsResponse)
+          ? vetsResponse.filter(vet => vet.active)
+          : [];
+        setVets(activeVets);
+      } catch (error) {
+        const apiError = error as ApiError;
+        setErrorMessage(`Error loading vets: ${apiError.message}`);
+      } finally {
+        setLoadingVets(false);
+      }
+    };
+
+    fetchVets();
+  }, []);
+
+  useEffect(() => {
+    const fetchTimeSlots = async (): Promise<void> => {
+      if (!visit.selectedDate) {
+        setTimeSlots([]);
+        return;
+      }
+
+      try {
+        setLoadingSlots(true);
+        setErrorMessage('');
+
+        if (visit.practitionerId !== 'no-preference') {
+          const response = await getAvailableSlots(
+            visit.practitionerId,
+            visit.selectedDate
+          );
+
+          const vet = vets.find(v => v.vetId === visit.practitionerId);
+          const slotsWithVet: TimeSlotWithVet[] = response.data.map(slot => ({
+            ...slot,
+            vetId: visit.practitionerId,
+            vetName: vet ? `Dr. ${vet.firstName} ${vet.lastName}` : 'Unknown',
+          }));
+
+          setTimeSlots(slotsWithVet);
+
+          if (response.data.length === 0) {
+            setErrorMessage('No available slots for this vet on this date');
+          }
+        } else {
+          const allSlots: TimeSlotWithVet[] = [];
+
+          const slotPromises = vets.map(async vet => {
+            try {
+              const response = await getAvailableSlots(
+                vet.vetId,
+                visit.selectedDate
+              );
+              return response.data.map(slot => ({
+                ...slot,
+                vetId: vet.vetId,
+                vetName: `Dr. ${vet.firstName} ${vet.lastName}`,
+              }));
+            } catch (error) {
+              console.error(
+                `Error fetching slots for vet ${vet.vetId}:`,
+                error
+              );
+              return [];
+            }
+          });
+
+          const results = await Promise.all(slotPromises);
+
+          results.forEach(vetSlots => {
+            allSlots.push(...vetSlots);
+          });
+
+          const uniqueSlots = allSlots.reduce((acc, slot) => {
+            const existingSlot = acc.find(s => s.startTime === slot.startTime);
+
+            if (!existingSlot) {
+              acc.push(slot);
+            } else if (slot.available && !existingSlot.available) {
+              const index = acc.indexOf(existingSlot);
+              acc[index] = slot;
+            }
+
+            return acc;
+          }, [] as TimeSlotWithVet[]);
+
+          uniqueSlots.sort(
+            (a, b) =>
+              new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+          );
+
+          setTimeSlots(uniqueSlots);
+
+          if (uniqueSlots.length === 0) {
+            setErrorMessage(
+              'No available slots from any veterinarian on this date'
+            );
+          }
+        }
+      } catch (error) {
+        console.error('Error fetching time slots:', error);
+        const apiError = error as ApiError;
+        setErrorMessage(`Error loading time slots: ${apiError.message}`);
+        setTimeSlots([]);
+      } finally {
+        setLoadingSlots(false);
+      }
+    };
+
+    fetchTimeSlots();
+  }, [visit.practitionerId, visit.selectedDate, vets]);
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
   ): void => {
     const { name, value } = e.target;
     setVisit(prevVisit => ({
       ...prevVisit,
-      [name]: name === 'visitStartDate' ? new Date(value) : value,
+      [name]: value,
     }));
+    if (errors[name]) {
+      setErrors(prev => ({ ...prev, [name]: '' }));
+    }
+
+    if (name === 'selectedDate' || name === 'practitionerId') {
+      setVisit(prev => ({
+        ...prev,
+        selectedTimeSlot: '',
+        assignedVetId: '',
+      }));
+    }
+  };
+
+  const handleTimeSlotSelect = (slot: TimeSlotWithVet): void => {
+    setVisit(prev => ({
+      ...prev,
+      selectedTimeSlot: slot.startTime,
+      assignedVetId: slot.vetId || '',
+    }));
+    if (errors.selectedTimeSlot) {
+      setErrors(prev => ({ ...prev, selectedTimeSlot: '' }));
+    }
   };
 
   const validate = (): boolean => {
     const newErrors: { [key: string]: string } = {};
     if (!visit.petId) newErrors.petId = 'Pet ID is required';
-    if (!visit.visitStartDate)
-      newErrors.visitStartDate = 'Visit date is required';
     if (!visit.description.trim())
       newErrors.description = 'Description is required';
-    if (!visit.practitionerId)
-      newErrors.practitionerId = 'Practitioner ID is required';
-    if (!visit.status) newErrors.status = 'Status is required';
+    if (!visit.selectedDate) newErrors.selectedDate = 'Please select a date';
+    if (!visit.selectedTimeSlot)
+      newErrors.selectedTimeSlot = 'Please select a time slot';
+    if (!visit.assignedVetId) {
+      newErrors.assignedVetId = 'No vet assigned to this time slot';
+    }
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -69,7 +222,7 @@ const OwnerBookingVisit: React.FC = (): JSX.Element => {
     if (window.history.length > 1) {
       navigate(-1);
     } else {
-      navigate('/visits');
+      navigate('customer/visits');
     }
   };
 
@@ -79,18 +232,15 @@ const OwnerBookingVisit: React.FC = (): JSX.Element => {
     event.preventDefault();
     if (!validate()) return;
 
-    setIsLoading(true);
+    setIsSubmitting(true);
     setErrorMessage('');
     setSuccessMessage('');
 
     const formattedVisit: VisitRequestModel = {
-      visitDate: visit.visitStartDate
-        .toISOString()
-        .slice(0, 16)
-        .replace('T', ' '),
+      visitDate: visit.selectedTimeSlot,
       description: visit.description,
       petId: visit.petId,
-      practitionerId: visit.practitionerId,
+      practitionerId: visit.assignedVetId,
       status: visit.status,
       ownerId: user.userId,
       jwtToken:
@@ -103,68 +253,233 @@ const OwnerBookingVisit: React.FC = (): JSX.Element => {
       await addVisit(formattedVisit);
       setSuccessMessage('Visit added successfully!');
       setShowNotification(true);
-      setTimeout(() => setShowNotification(false), 5000);
-      navigate('/customer/visits');
+      setVisit({
+        description: '',
+        petId: '',
+        practitionerId: 'no-preference',
+        assignedVetId: '',
+        selectedDate: '',
+        selectedTimeSlot: '',
+        status: 'UPCOMING' as Status,
+      });
+      setTimeout(() => {
+        navigate('/customer/visits');
+      }, 2000);
     } catch (error) {
       const apiError = error as ApiError;
       setErrorMessage(`Error adding visits: ${apiError.message}`);
     } finally {
-      setIsLoading(false);
+      setIsSubmitting(false);
     }
   };
+
+  const formatTimeSlot = (isoString: string): string => {
+    const date = new Date(isoString);
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  };
+
+  const getMorningSlots = (): TimeSlotWithVet[] => {
+    return timeSlots.filter(slot => {
+      const hour = new Date(slot.startTime).getHours();
+      return hour < 12 && slot.available;
+    });
+  };
+
+  const getAfternoonSlots = (): TimeSlotWithVet[] => {
+    return timeSlots.filter(slot => {
+      const hour = new Date(slot.startTime).getHours();
+      return hour >= 12 && slot.available;
+    });
+  };
+
+  if (loadingVets) {
+    return (
+      <div className="profile-edit">
+        <h1>Schedule Visit For Your Pet</h1>
+        <div className="loading">Loading veterinarians...</div>
+      </div>
+    );
+  }
+
+  const morningSlots = getMorningSlots();
+  const afternoonSlots = getAfternoonSlots();
 
   return (
     <div className="profile-edit">
       <h1>Schedule Visit For Your Pet</h1>
       <form onSubmit={handleSubmit}>
-        <label>Pet ID: </label>
-        <input
-          type="text"
-          name="petId"
-          value={visit.petId}
-          onChange={handleChange}
-        />
-        {errors.petId && <span className="error">{errors.petId}</span>}
-        <br />
-        <label>Visit Date: </label>
-        <input
-          type="datetime-local"
-          name="visitStartDate"
-          value={formatDate(visit.visitStartDate)}
-          onChange={handleChange}
-          required
-        />
-        {errors.visitStartDate && (
-          <span className="error">{errors.visitStartDate}</span>
+        <div className="form-group">
+          <label htmlFor="petId">Pet ID: </label>
+          <input
+            type="text"
+            id="petId"
+            name="petId"
+            value={visit.petId}
+            onChange={handleChange}
+            placeholder="Enter pet ID"
+          />
+          {errors.petId && <span className="error">{errors.petId}</span>}
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="description">Description: </label>
+          <textarea
+            id="description"
+            name="description"
+            value={visit.description}
+            onChange={handleChange}
+            placeholder="Describe the reason for the visit..."
+            rows={4}
+          />
+          {errors.description && (
+            <span className="error">{errors.description}</span>
+          )}
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="practitionerId">Veterinarian Preference: </label>
+          <select
+            id="practitionerId"
+            name="practitionerId"
+            value={visit.practitionerId}
+            onChange={handleChange}
+          >
+            <option value="no-preference">
+              No Preference (Show All Available Times)
+            </option>
+            {vets.map(vet => (
+              <option key={vet.vetId} value={vet.vetId}>
+                Dr. {vet.firstName} {vet.lastName}
+                {vet.specialties &&
+                  vet.specialties.length > 0 &&
+                  ` (${vet.specialties.map(s => s.name).join(', ')})`}
+              </option>
+            ))}
+          </select>
+          <small className="help-text">
+            {visit.practitionerId === 'no-preference'
+              ? 'Showing available slots from all veterinarians'
+              : 'Showing slots only for selected veterinarian'}
+          </small>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="selectedDate">Date: </label>
+          <input
+            type="date"
+            id="selectedDate"
+            name="selectedDate"
+            value={visit.selectedDate}
+            onChange={handleChange}
+            min={new Date().toISOString().split('T')[0]}
+          />
+          {errors.selectedDate && (
+            <span className="error">{errors.selectedDate}</span>
+          )}
+        </div>
+
+        {visit.selectedDate && (
+          <div className="form-group">
+            <label>Available Time Slots: </label>
+
+            {loadingSlots ? (
+              <div className="loading-slots">
+                {visit.practitionerId === 'no-preference'
+                  ? 'Loading available times from all veterinarians...'
+                  : 'Loading available times...'}
+              </div>
+            ) : timeSlots.length === 0 ? (
+              <div className="no-slots">
+                No available time slots for this date. Please select another
+                date.
+              </div>
+            ) : (
+              <>
+                {morningSlots.length > 0 && (
+                  <div className="time-section">
+                    <h4>Morning</h4>
+                    <div className="time-slots-grid">
+                      {morningSlots.map((slot, index) => (
+                        <button
+                          key={index}
+                          type="button"
+                          className={`time-slot ${
+                            visit.selectedTimeSlot === slot.startTime
+                              ? 'selected'
+                              : ''
+                          }`}
+                          onClick={() => handleTimeSlotSelect(slot)}
+                          title={slot.vetName}
+                        >
+                          <div className="slot-time">
+                            {formatTimeSlot(slot.startTime)}
+                          </div>
+                          {visit.practitionerId === 'no-preference' && (
+                            <div className="slot-vet">{slot.vetName}</div>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {afternoonSlots.length > 0 && (
+                  <div className="time-section">
+                    <h4>Afternoon</h4>
+                    <div className="time-slots-grid">
+                      {afternoonSlots.map((slot, index) => (
+                        <button
+                          key={index}
+                          type="button"
+                          className={`time-slot ${
+                            visit.selectedTimeSlot === slot.startTime
+                              ? 'selected'
+                              : ''
+                          }`}
+                          onClick={() => handleTimeSlotSelect(slot)}
+                          title={slot.vetName}
+                        >
+                          <div className="slot-time">
+                            {formatTimeSlot(slot.startTime)}
+                          </div>
+                          {visit.practitionerId === 'no-preference' && (
+                            <div className="slot-vet">{slot.vetName}</div>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+
+            {errors.selectedTimeSlot && (
+              <span className="error">{errors.selectedTimeSlot}</span>
+            )}
+          </div>
         )}
-        <br />
-        <label>Description: </label>
-        <input
-          type="text"
-          name="description"
-          value={visit.description}
-          onChange={handleChange}
-        />
-        {errors.description && (
-          <span className="error">{errors.description}</span>
+
+        {/* Show assigned vet when "No Preference" */}
+        {visit.practitionerId === 'no-preference' && visit.assignedVetId && (
+          <div className="assigned-vet-info">
+            ✓ You will see:{' '}
+            {
+              timeSlots.find(s => s.startTime === visit.selectedTimeSlot)
+                ?.vetName
+            }
+          </div>
         )}
-        <br />
-        <label>Practitioner ID: </label>
-        <input
-          type="text"
-          name="practitionerId"
-          value={visit.practitionerId}
-          onChange={handleChange}
-        />
-        {errors.practitionerId && (
-          <span className="error">{errors.practitionerId}</span>
-        )}
-        <br />
+
+        <div className="button-group"></div>
         <button className="cancel" type="button" onClick={handleCancel}>
           Cancel
         </button>
-        <button type="submit" disabled={isLoading}>
-          {isLoading ? 'Adding...' : 'Add'}
+        <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Adding...' : 'Add'}
         </button>
       </form>
       {showNotification && <div className="notification">{successMessage}</div>}

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/Availability/AvailabilityService.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/Availability/AvailabilityService.java
@@ -1,0 +1,15 @@
+package com.petclinic.visits.visitsservicenew.BusinessLayer.Availability;
+
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetDTO;
+import com.petclinic.visits.visitsservicenew.PresentationLayer.TimeSlotDTO;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+
+public interface AvailabilityService {
+    Flux<VetDTO> getAllVets();
+    Mono<VetDTO> getVeterinarianAvailability(String vetId);
+    Flux<TimeSlotDTO> getAvailableTimeSlotsForDate(String vetId, LocalDate date);
+    Flux<LocalDate> getAvailableDatesForVet(String vetId, LocalDate startDate, LocalDate endDate);
+}

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/Availability/AvailabilityServiceImpl.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/BusinessLayer/Availability/AvailabilityServiceImpl.java
@@ -1,0 +1,163 @@
+package com.petclinic.visits.visitsservicenew.BusinessLayer.Availability;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petclinic.visits.visitsservicenew.DataLayer.Visit;
+import com.petclinic.visits.visitsservicenew.DataLayer.VisitRepo;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetDTO;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetsClient;
+import com.petclinic.visits.visitsservicenew.Exceptions.NotFoundException;
+import com.petclinic.visits.visitsservicenew.PresentationLayer.TimeSlotDTO;
+import com.petclinic.visits.visitsservicenew.Utils.WorkHourParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.TextStyle;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AvailabilityServiceImpl implements AvailabilityService {
+
+    private final VetsClient vetsClient;
+    private final VisitRepo visitRepo;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Flux<VetDTO> getAllVets() {
+        return vetsClient.getAllVets();
+    }
+
+    @Override
+    public Mono<VetDTO> getVeterinarianAvailability(String vetId) {
+
+        return vetsClient.getVetByVetId(vetId)
+                .switchIfEmpty(Mono.error(new NotFoundException("No veterinarian found with vetId: " + vetId)));
+    }
+
+    @Override
+    public Flux<TimeSlotDTO> getAvailableTimeSlotsForDate(String vetId, LocalDate date) {
+
+        return vetsClient.getVetByVetId(vetId)
+                .switchIfEmpty(Mono.error(new NotFoundException("No veterinarian found with vetId: " + vetId)))
+                .flatMapMany(vet -> {
+                    // Parse workHoursJson to get the map of days to hour slots
+                    Map<String, List<String>> workHoursMap = parseWorkHoursJson(vet.getWorkHoursJson());
+
+                    if (workHoursMap == null || workHoursMap.isEmpty()) {
+                        return Flux.empty();
+                    }
+
+                    // Get the day of week
+                    DayOfWeek dayOfWeek = date.getDayOfWeek();
+                    String dayName = dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ENGLISH);
+
+                    // Get work hours for this specific day
+                    List<String> workHoursList = workHoursMap.get(dayName);
+
+                    if (workHoursList == null || workHoursList.isEmpty()) {
+                        return Flux.empty();
+                    }
+
+                    // Convert work hour enums to time slots
+                    return Flux.fromIterable(workHoursList)
+                            .map(workHourEnum -> {
+                                LocalTime startTime = WorkHourParser.getStartTime(workHourEnum);
+                                LocalTime endTime = WorkHourParser.getEndTime(workHourEnum);
+
+                                return new TimeSlotDTO(
+                                        LocalDateTime.of(date, startTime),
+                                        LocalDateTime.of(date, endTime),
+                                        true
+                                );
+                            })
+                            .collectList()
+                            .flatMapMany(slots -> markBookedSlots(slots, vetId, date));
+                });
+    }
+
+    @Override
+    public Flux<LocalDate> getAvailableDatesForVet(String vetId, LocalDate startDate, LocalDate endDate) {
+
+        return vetsClient.getVetByVetId(vetId)
+                .switchIfEmpty(Mono.error(new NotFoundException("No veterinarian found with vetId: " + vetId)))
+                .flatMapMany(vet -> {
+                    // Parse workHoursJson
+                    Map<String, List<String>> workHoursMap = parseWorkHoursJson(vet.getWorkHoursJson());
+
+                    if (workHoursMap == null || workHoursMap.isEmpty()) {
+                        return Flux.empty();
+                    }
+
+                    // Get all days the vet works (keys in the workHours map)
+                    List<String> workingDayNames = List.copyOf(workHoursMap.keySet());
+
+                    // Convert day names to DayOfWeek enums
+                    List<DayOfWeek> workingDays = workingDayNames.stream()
+                            .map(dayName -> DayOfWeek.valueOf(dayName.toUpperCase()))
+                            .toList();
+
+                    // Generate dates that match working days
+                    return Flux.fromStream(
+                            startDate.datesUntil(endDate.plusDays(1))
+                                    .filter(date -> workingDays.contains(date.getDayOfWeek()))
+                    );
+                });
+    }
+
+
+    private Map<String, List<String>> parseWorkHoursJson(String workHoursJson) {
+        if (workHoursJson == null || workHoursJson.isBlank()) {
+            return Map.of();
+        }
+
+        try {
+            return objectMapper.readValue(
+                    workHoursJson,
+                    new TypeReference<Map<String, List<String>>>() {}
+            );
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+
+
+    private Flux<TimeSlotDTO> markBookedSlots(List<TimeSlotDTO> slots, String vetId, LocalDate date) {
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.atTime(23, 59, 59);
+
+        return visitRepo.findByPractitionerIdAndVisitDateBetween(vetId, startOfDay, endOfDay)
+                .collectList()
+                .flatMapMany(existingVisits -> {
+                    // Mark slots as unavailable if they conflict with existing visits
+                    for (TimeSlotDTO slot : slots) {
+                        for (Visit visit : existingVisits) {
+                            if (isSlotBooked(slot, visit)) {
+                                slot.setAvailable(false);
+                                break;
+                            }
+                        }
+                    }
+                    return Flux.fromIterable(slots);
+                });
+    }
+
+
+    private boolean isSlotBooked(TimeSlotDTO slot, Visit visit) {
+        LocalDateTime visitTime = visit.getVisitDate();
+
+        // Check if visit time falls within this slot
+        return !visitTime.isBefore(slot.getStartTime()) &&
+                visitTime.isBefore(slot.getEndTime());
+    }
+}

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/Visit.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/Visit.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import org.springframework.data.annotation.Id;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.LocalDateTime;
 
 /**
@@ -21,7 +23,7 @@ public class Visit {
 
     private String visitId;
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     LocalDateTime visitDate;
 
     private String description;
@@ -32,7 +34,7 @@ public class Visit {
 
     private Status status;
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     LocalDateTime visitEndDate;
 
 

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/VisitRepo.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DataLayer/VisitRepo.java
@@ -32,4 +32,5 @@ public interface VisitRepo extends ReactiveMongoRepository<Visit, String> {
 
     Flux<Visit> findVisitsByDescriptionContainingIgnoreCase(String Description);
 
+    Flux<Visit> findByPractitionerIdAndVisitDateBetween(String practitionerId, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DomainClientLayer/VetDTO.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DomainClientLayer/VetDTO.java
@@ -33,6 +33,7 @@ public class VetDTO {
     private String imageId;
     private String resume;
     private Set<Workday> workday;
+    private String workHoursJson;
     private boolean active;
     private Set<SpecialtyDTO> specialties;
 

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DomainClientLayer/VetsClient.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/DomainClientLayer/VetsClient.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
@@ -28,6 +29,24 @@ public class VetsClient {
                 .build();
 
     }
+    /**
+     * Get all vets
+     * @return Flux of all veterinarians
+     */
+    public Flux<VetDTO> getAllVets() {
+        return webClient
+                .get()
+                .uri(vetClientServiceBaseURL)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, error ->
+                        Mono.error(new IllegalArgumentException("Error fetching vets"))
+                )
+                .onStatus(HttpStatusCode::is5xxServerError, error ->
+                        Mono.error(new IllegalArgumentException("Server error fetching vets"))
+                )
+                .bodyToFlux(VetDTO.class);
+    }
+
 
     /**
      * We are accessing the vet-service/src/main/java/com/petclinic/vet/servicelayer/VetServiceImpl.java --  getVetByVetId()

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/AvailabilityController.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/AvailabilityController.java
@@ -1,0 +1,67 @@
+package com.petclinic.visits.visitsservicenew.PresentationLayer;
+
+
+import com.petclinic.visits.visitsservicenew.BusinessLayer.Availability.AvailabilityService;
+import com.petclinic.visits.visitsservicenew.DomainClientLayer.VetDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/v1/availability")
+@RequiredArgsConstructor
+@Slf4j
+public class AvailabilityController {
+
+    private final AvailabilityService availabilityService;
+    
+    /**
+     * Get ALL vets
+     * GET /api/v1/availability/vets
+     */
+    @GetMapping(value = "/vets", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Flux<VetDTO> getAllVetsForAvailability() {
+        return availabilityService.getAllVets();
+    }
+
+    /**
+     * Get vet's weekly availability schedule
+     * GET /api/v1/availability/vets/{vetId}
+     */
+    @GetMapping(value = "/vets/{vetId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<VetDTO> getVeterinarianAvailability(@PathVariable String vetId) {
+        return availabilityService.getVeterinarianAvailability(vetId);
+    }
+
+    /**
+     * Get available time slots for a specific vet on a specific date
+     * GET /api/v1/availability/vets/{vetId}/slots?date=2025-10-08
+     */
+    @GetMapping(value = "/vets/{vetId}/slots", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Flux<TimeSlotDTO> getAvailableTimeSlots(
+            @PathVariable String vetId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) String date) {
+        LocalDate localDate = LocalDate.parse(date);
+        return availabilityService.getAvailableTimeSlotsForDate(vetId, localDate);
+    }
+
+    /**
+     * Get available dates for a vet within a date range
+     * GET /api/v1/availability/vets/{vetId}/dates?startDate=2025-10-01&endDate=2025-10-31
+     */
+    @GetMapping(value = "/vets/{vetId}/dates", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Flux<LocalDate> getAvailableDates(
+            @PathVariable String vetId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) String startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) String endDate) {
+        LocalDate start = LocalDate.parse(startDate);
+        LocalDate end = LocalDate.parse(endDate);
+        return availabilityService.getAvailableDatesForVet(vetId, start, end);
+    }
+}

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/TimeSlotDTO.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/TimeSlotDTO.java
@@ -1,0 +1,16 @@
+package com.petclinic.visits.visitsservicenew.PresentationLayer;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeSlotDTO {
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private boolean available;
+}

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitRequestDTO.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/PresentationLayer/VisitRequestDTO.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.LocalDateTime;
 //Finished
 @Data
@@ -14,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 public class VisitRequestDTO {
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime visitDate;
     private String description;
     private String petId;

--- a/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/Utils/WorkHourParser.java
+++ b/visits-service-new/src/main/java/com/petclinic/visits/visitsservicenew/Utils/WorkHourParser.java
@@ -1,0 +1,22 @@
+package com.petclinic.visits.visitsservicenew.Utils;
+
+import java.time.LocalTime;
+
+/**
+ * Utility class to parse WorkHour enum strings from vets-service
+ * Example: "Hour_8_9" -> start: 08:00, end: 09:00
+ */
+public class WorkHourParser {
+
+    public static LocalTime getStartTime(String workHourEnum) {
+        String[] parts = workHourEnum.replace("Hour_", "").split("_");
+        int startHour = Integer.parseInt(parts[0]);
+        return LocalTime.of(startHour, 0);
+    }
+
+    public static LocalTime getEndTime(String workHourEnum) {
+        String[] parts = workHourEnum.replace("Hour_", "").split("_");
+        int endHour = Integer.parseInt(parts[1]);
+        return LocalTime.of(endHour, 0);
+    }
+}


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CPC-1421

Context:
This ticket implements a appointment booking system where users can select veterinarians and view their available time slots before scheduling visits. Previously, users had to manually enter date/time without knowing if the vet was available, leading to booking conflicts and poor user experience. This change provides real-time availability checking, displays morning/afternoon time slots, and allows "No Preference" to show all available times across all vets.

Does this PR change the .vscode folder in petclinic-frontend?:
If the PR changes the .vscode folder, explain why in detail because it should not.
Be sure to include cgerard321 as a reviewer.

No.
Reviewers need to check for any changes to the
.vscode folder and add a comment about it to their review comments.

Changes:
- Created `AvailabilityController with REST endpoints:
  - GET /api/v1/availability/vets - Get all vets for availability
  - GET /api/v1/availability/vets/{vetId} - Get specific vet availability
  - GET /api/v1/availability/vets/{vetId}/slots?date=YYYY-MM-DD - Get time slots for a vet on a date
  - GET /api/v1/availability/vets/{vetId}/dates?startDate=X&endDate=Y - Get available dates for a vet
- Created AvailabilityService interface and AvailabilityServiceImpl with business logic
- Added WorkHourParser utility to parse vet working hours
- Created TimeSlotDTO to represent time slots with start/end times and availability status
- Enhanced VetsClient to fetch all vets and specific vet details
- Updated VisitsServiceClient to call availability endpoints from visits-service
- Added availability endpoints to VisitController (v2):
  - /api/v2/gateway/visits/availability/vets
  - /api/v2/gateway/visits/availability/vets/{vetId}
  - /api/v2/gateway/visits/availability/vets/{vetId}/slots
  - /api/v2/gateway/visits/availability/vets/{vetId}/dates
- Added TimeSlotDTO in api-gateway DTOs
- Created getVets.ts API helper with SSE format handling for fetching veterinarians
- Created getAvailableSlots.ts API helper for fetching time slots
- Updated AddingVisit.tsx:
  - Added vet dropdown with specialties display
  - Replaced manual datetime input with date picker + time slot selection
  - Added "No Preference" option that aggregates slots from all vets
  - Implemented Morning/Afternoon time slot sections
  - Added visual feedback for selected time slots
  - Auto-assigns vet based on selected time slot when "No Preference" is chosen
- Updated OwnerBookingVisit.tsx with identical functionality for customer-facing booking
- Added CSS for time slot grid, selection states, and responsive design

Does this use the v2 API?:
If the PR uses the v2 API, explain why

No

Does this add a new communication between services?:
Yes, this adds new communication between:
- api-gateway → visits-service-new (availability endpoints)
- visits-service-new → vet-service (fetching vet details and work hours)
The C4 diagram already accurately reflects these relationships.

Before and After UI (Required for UI-impacting PRs)

Before:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/603331dd-f0a1-4d02-9e79-a3cf82e783e9" />

After:
<img width="601" height="863" alt="Screenshot 2025-10-05 173328" src="https://github.com/user-attachments/assets/d8e1a241-7bf3-4fa2-bfc7-1103baa6028e" />

Dev notes (Optional)
Specific technical changes that should be noted
Linked pull requests (Optional)
None