### PR TITLE
bug(CART-CPC-1711): Add admin access to certain endpoints in CartControllerV1

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v1/CartControllerV1.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v1/CartControllerV1.java
@@ -87,7 +87,7 @@ public class CartControllerV1 {
         return cartServiceClient.getAllCarts();
     }
 
-    @SecuredEndpoint(allowedRoles = {Roles.OWNER})
+    @SecuredEndpoint(allowedRoles = {Roles.OWNER, Roles.ADMIN})
     @GetMapping("/{cartId}")
     public Mono<ResponseEntity<CartResponseDTO>> getCartById(@PathVariable String cartId) {
         return mapToOkOrNotFound(cartServiceClient.getCartByCartId(cartId));
@@ -135,7 +135,7 @@ public class CartControllerV1 {
         return mapToOkOrNotFound(cartServiceClient.checkoutCart(cartId));
     }
 
-    @SecuredEndpoint(allowedRoles = {Roles.OWNER})
+    @SecuredEndpoint(allowedRoles = {Roles.OWNER, Roles.ADMIN})
     @GetMapping("/customer/{customerId}")
     public Mono<ResponseEntity<CartResponseDTO>> getCartByCustomerId(@PathVariable String customerId) {
         return mapToOkOrNotFound(cartServiceClient.getCartByCustomerId(customerId));

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v1/CartControllerV1.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/v1/CartControllerV1.java
@@ -176,6 +176,7 @@ public class CartControllerV1 {
                 .map(ResponseEntity::ok)
                 .onErrorResume(this::handleAddProductErrors);
     }
+
     @SecuredEndpoint(allowedRoles = {Roles.OWNER})
     @PostMapping("/{cartId}/wishlist/moveAll")
     public Mono<ResponseEntity<CartResponseDTO>> moveAllWishlistToCart(

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v1/Cart/CartControllerV1UnitTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/v1/Cart/CartControllerV1UnitTest.java
@@ -690,4 +690,42 @@ public class CartControllerV1UnitTest {
 
         verify(cartServiceClient, times(1)).removeProductFromCart(cartId, productId);
     }
+
+    // New tests for moveAllWishlistToCart endpoint
+    @Test
+    @DisplayName("POST /api/gateway/carts/{cartId}/wishlist/moveAll - Should move all wishlist items to cart successfully")
+    void moveAllWishlistToCart_withValidId_shouldReturnUpdatedCart() {
+        // Arrange
+        String cartId = "cart-123";
+        CartResponseDTO updatedCart = buildCartResponseDTO();
+        when(cartServiceClient.moveAllWishlistToCart(cartId))
+                .thenReturn(Mono.just(updatedCart));
+
+        // Act & Assert
+        webTestClient.post()
+                .uri(baseCartURL + "/" + cartId + "/wishlist/moveAll")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(CartResponseDTO.class)
+                .isEqualTo(updatedCart);
+
+        verify(cartServiceClient, times(1)).moveAllWishlistToCart(cartId);
+    }
+
+    @Test
+    @DisplayName("POST /api/gateway/carts/{cartId}/wishlist/moveAll - Should return 404 when cart not found")
+    void moveAllWishlistToCart_withNonExistingCartId_shouldReturnNotFound() {
+        // Arrange
+        String cartId = "non-existent-cart";
+        when(cartServiceClient.moveAllWishlistToCart(cartId))
+                .thenReturn(Mono.empty());
+
+        // Act & Assert
+        webTestClient.post()
+                .uri(baseCartURL + "/" + cartId + "/wishlist/moveAll")
+                .exchange()
+                .expectStatus().isNotFound();
+
+        verify(cartServiceClient, times(1)).moveAllWishlistToCart(cartId);
+    }
 }

--- a/petclinic-frontend/src/features/carts/components/CartTable.tsx
+++ b/petclinic-frontend/src/features/carts/components/CartTable.tsx
@@ -90,7 +90,9 @@ export default function CartListTable(): JSX.Element {
   const fetchCarts = useCallback(async (): Promise<void> => {
     try {
       setLoading(true);
-      const { data } = await axiosInstance.get<CartModel[] | string | Record<string, unknown>>('/carts', {
+      const { data } = await axiosInstance.get<
+        CartModel[] | string | Record<string, unknown>
+      >('/carts', {
         useV2: false,
       });
       const normalized = cartExtractor(data);

--- a/petclinic-frontend/src/features/carts/components/CartTable.tsx
+++ b/petclinic-frontend/src/features/carts/components/CartTable.tsx
@@ -90,7 +90,7 @@ export default function CartListTable(): JSX.Element {
   const fetchCarts = useCallback(async (): Promise<void> => {
     try {
       setLoading(true);
-      const { data } = await axiosInstance.get<unknown>('/carts', {
+      const { data } = await axiosInstance.get<CartModel[] | string | Record<string, unknown>>('/carts', {
         useV2: false,
       });
       const normalized = cartExtractor(data);

--- a/petclinic-frontend/src/features/carts/components/CartTable.tsx
+++ b/petclinic-frontend/src/features/carts/components/CartTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import './CartTable.css';
 import { ProductModel } from '../models/ProductModel';
@@ -15,29 +15,108 @@ export default function CartListTable(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
-  const getAllCarts = async (): Promise<void> => {
+  const cartExtractor = useMemo(
+    () =>
+      (payload: unknown): CartModel[] => {
+        if (Array.isArray(payload)) {
+          return payload as CartModel[];
+        }
+
+        if (typeof payload === 'string') {
+          const trimmed = payload.trim();
+          if (trimmed.length === 0) {
+            return [];
+          }
+
+          if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+            try {
+              const parsed = JSON.parse(trimmed) as unknown;
+              return Array.isArray(parsed)
+                ? (parsed as CartModel[])
+                : parsed
+                  ? [parsed as CartModel]
+                  : [];
+            } catch {
+              // fall through to event-stream parsing
+            }
+          }
+
+          const chunks = trimmed
+            .split(/\r?\n/)
+            .map(line => line.trim())
+            .filter(line => line.startsWith('data:'))
+            .map(line => line.slice(5).trim())
+            .filter(Boolean);
+
+          const carts: CartModel[] = [];
+          let parseFailed = false;
+
+          for (const chunk of chunks) {
+            try {
+              carts.push(JSON.parse(chunk) as CartModel);
+            } catch {
+              parseFailed = true;
+            }
+          }
+
+          if (parseFailed) {
+            console.warn('Failed to parse some cart stream chunks.');
+          }
+
+          if (carts.length > 0) {
+            return carts;
+          }
+        }
+
+        if (payload && typeof payload === 'object') {
+          const possibleArrays = [
+            (payload as { carts?: unknown }).carts,
+            (payload as { content?: unknown }).content,
+            (payload as { data?: unknown }).data,
+          ];
+
+          for (const candidate of possibleArrays) {
+            if (Array.isArray(candidate)) {
+              return candidate as CartModel[];
+            }
+          }
+        }
+
+        return [];
+      },
+    []
+  );
+
+  const fetchCarts = useCallback(async (): Promise<void> => {
     try {
-      const { data } = await axiosInstance.get<CartModel[]>('/carts', {
+      setLoading(true);
+      const { data } = await axiosInstance.get<unknown>('/carts', {
         useV2: false,
       });
-      setCarts(data);
+      const normalized = cartExtractor(data);
+
+      if (!Array.isArray(data) && normalized.length === 0) {
+        console.warn('Unexpected carts payload shape. Received:', data);
+      }
+
+      setCarts(normalized);
     } catch (err) {
       console.error('Error fetching carts:', err);
       setError('Failed to fetch carts');
     } finally {
       setLoading(false);
     }
-  };
+  }, [cartExtractor]);
 
   useEffect(() => {
-    getAllCarts();
-  }, []);
+    void fetchCarts();
+  }, [fetchCarts]);
 
   const handleDelete = async (cartId: string): Promise<void> => {
     if (!window.confirm('Are you sure you want to delete this cart?')) return;
     try {
       await axiosInstance.delete(`/carts/${cartId}`, { useV2: false });
-      await getAllCarts(); // refresh list
+      await fetchCarts(); // refresh list
     } catch (err) {
       console.error('Error deleting cart:', err);
       setError('Failed to delete cart');

--- a/petclinic-frontend/src/layouts/AppNavBar.tsx
+++ b/petclinic-frontend/src/layouts/AppNavBar.tsx
@@ -15,6 +15,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import { Navbar, Nav, NavDropdown, Container } from 'react-bootstrap';
 import { FaShoppingCart } from 'react-icons/fa'; // Importing the shopping cart icon
 import './AppNavBar.css';
+import { isAxiosError } from 'axios';
 
 //  listen for cart changes broadcast by the app
 import { CART_CHANGED } from '../features/carts/api/cartEvent';
@@ -32,9 +33,11 @@ interface ProductAPIResponse {
 export function NavBar(): JSX.Element {
   const { user } = useUser();
   const navigate = useNavigate();
+  const isAdmin = IsAdmin();
   const isInventoryManager = IsInventoryManager();
   const isVet = IsVet();
   const isReceptionist = IsReceptionist();
+  const isOwner = IsOwner();
   const [navbarOpen, setNavbarOpen] = useState(false);
   const [cartId, setCartId] = useState<string | null>(null);
   const [cartItemCount, setCartItemCount] = useState<number>(0); // State for cart item count
@@ -62,24 +65,32 @@ export function NavBar(): JSX.Element {
     in future sprints for better performance and separation of concerns.
   */
   useEffect(() => {
+    if (!user.userId || !isOwner) {
+      setCartId(null);
+      return;
+    }
+
     const fetchCartId = async (): Promise<void> => {
-      if (user.userId && !isInventoryManager && !isVet && !isReceptionist) {
-        try {
-          const id = await fetchCartIdByCustomerId(user.userId);
-          setCartId(id);
-        } catch (error) {
-          console.error('Error fetching cart ID:', error);
+      try {
+        const id = await fetchCartIdByCustomerId(user.userId);
+        setCartId(id);
+      } catch (error) {
+        if (isAxiosError(error) && error.response?.status === 404) {
+          setCartId(null);
+          return;
         }
+
+        console.error('Error fetching cart ID:', error);
       }
     };
 
-    fetchCartId();
-  }, [user.userId, isInventoryManager, isVet, isReceptionist]);
+    void fetchCartId();
+  }, [user.userId, isOwner]);
 
   // NEW: uses lightweight /count endpoint when available, falls back to full cart;
   // also listens for "cart:changed" (same tab) and "storage" (cross-tab) to refresh automatically.
   const fetchCartItemCount = useCallback(async (): Promise<void> => {
-    if (!cartId) {
+    if (!cartId || !isOwner) {
       setCartItemCount(0);
       return;
     }
@@ -118,10 +129,10 @@ export function NavBar(): JSX.Element {
       console.error('Error fetching cart item count:', error);
       setCartItemCount(0);
     }
-  }, [cartId]);
+  }, [cartId, isOwner]);
 
   useEffect(() => {
-    if (!cartId) {
+    if (!cartId || !isOwner) {
       setCartItemCount(0);
       return;
     }
@@ -155,7 +166,7 @@ export function NavBar(): JSX.Element {
       );
       window.removeEventListener('storage', onStorage);
     };
-  }, [cartId, fetchCartItemCount]);
+  }, [cartId, fetchCartItemCount, isOwner]);
 
   return (
     <Navbar bg="light" expand="lg" className="navbar">
@@ -176,14 +187,14 @@ export function NavBar(): JSX.Element {
             </Nav.Link>
             {user.userId && (
               <>
-                {(IsAdmin() || IsVet()) && (
+                {(isAdmin || isVet) && (
                   <Nav.Link as={Link} to={AppRoutePaths.Vet}>
                     Veterinarians
                   </Nav.Link>
                 )}
-                {(IsAdmin() || IsVet() || isReceptionist) && (
+                {(isAdmin || isVet || isReceptionist) && (
                   <NavDropdown title="Customers" id="owners-dropdown">
-                    {(IsAdmin() || IsVet()) && (
+                    {(isAdmin || isVet) && (
                       <NavDropdown.Item
                         as={Link}
                         to={AppRoutePaths.AllCustomers}
@@ -191,7 +202,7 @@ export function NavBar(): JSX.Element {
                         Customers List
                       </NavDropdown.Item>
                     )}
-                    {(IsAdmin() || isReceptionist) && (
+                    {(isAdmin || isReceptionist) && (
                       <NavDropdown.Item
                         as={Link}
                         to={AppRoutePaths.AddingCustomer}
@@ -201,7 +212,7 @@ export function NavBar(): JSX.Element {
                     )}
                   </NavDropdown>
                 )}
-                {IsAdmin() && (
+                {isAdmin && (
                   <NavDropdown title="Users" id="users-dropdown">
                     <NavDropdown.Item as={Link} to={AppRoutePaths.AllUsers}>
                       Users List
@@ -211,15 +222,15 @@ export function NavBar(): JSX.Element {
                     </NavDropdown.Item>
                   </NavDropdown>
                 )}
-                {!IsAdmin() &&
+                {!isAdmin &&
                   !isInventoryManager &&
-                  !IsVet() &&
+                  !isVet &&
                   !isReceptionist && (
                     <Nav.Link as={Link} to={AppRoutePaths.CustomerBills}>
                       Bills
                     </Nav.Link>
                   )}
-                {!IsAdmin() && !isInventoryManager && (
+                {!isAdmin && !isInventoryManager && (
                   <Nav.Link as={Link} to={AppRoutePaths.CustomerVisits}>
                     Visits
                   </Nav.Link>
@@ -229,27 +240,27 @@ export function NavBar(): JSX.Element {
                     Emergency
                   </Nav.Link>
                 )}
-                {IsAdmin() && (
+                {isAdmin && (
                   <Nav.Link as={Link} to={AppRoutePaths.AdminBills}>
                     Bills
                   </Nav.Link>
                 )}
-                {(IsAdmin() || IsVet()) && (
+                {(isAdmin || isVet) && (
                   <Nav.Link as={Link} to={AppRoutePaths.Visits}>
                     Visits
                   </Nav.Link>
                 )}
-                {(isInventoryManager || IsAdmin()) && (
+                {(isInventoryManager || isAdmin) && (
                   <Nav.Link as={Link} to={AppRoutePaths.Inventories}>
                     Inventories
                   </Nav.Link>
                 )}
-                {IsAdmin() && (
+                {isAdmin && (
                   <Nav.Link as={Link} to={AppRoutePaths.Promos}>
                     Promos
                   </Nav.Link>
                 )}
-                {!IsAdmin() && (
+                {!isAdmin && (
                   <Nav.Link as={Link} to={AppRoutePaths.CustomerPromos}>
                     Promos
                   </Nav.Link>
@@ -260,13 +271,13 @@ export function NavBar(): JSX.Element {
                   </Nav.Link>
                 }
 
-                {IsAdmin() && (
+                {isAdmin && (
                   <Nav.Link as={Link} to={AppRoutePaths.Carts}>
                     Carts
                   </Nav.Link>
                 )}
 
-                {cartId && !isReceptionist && (
+                {cartId && isOwner && (
                   <Nav.Link
                     as={Link}
                     to={AppRoutePaths.UserCart.replace(':cartId', cartId)}
@@ -289,7 +300,7 @@ export function NavBar(): JSX.Element {
           <Nav className="ms-auto">
             {user.userId ? (
               <NavDropdown title={`${user.username}`} id="user-dropdown">
-                {IsOwner() && (
+                {isOwner && (
                   <NavDropdown.Item
                     as={Link}
                     to={AppRoutePaths.CustomerProfile}
@@ -297,7 +308,7 @@ export function NavBar(): JSX.Element {
                     Profile
                   </NavDropdown.Item>
                 )}
-                {IsOwner() && (
+                {isOwner && (
                   <NavDropdown.Item
                     as={Link}
                     to={AppRoutePaths.CustomerProfileEdit}
@@ -305,12 +316,12 @@ export function NavBar(): JSX.Element {
                     Edit Profile
                   </NavDropdown.Item>
                 )}
-                {IsAdmin() && (
+                {isAdmin && (
                   <NavDropdown.Item as={Link} to={AppRoutePaths.Home}>
                     Admin Panel
                   </NavDropdown.Item>
                 )}
-                {IsReceptionist() && (
+                {isReceptionist && (
                   <NavDropdown.Item as={Link} to={AppRoutePaths.AddingCustomer}>
                     Receptionist Panel
                   </NavDropdown.Item>


### PR DESCRIPTION
**JIRA:**
[Jira link](https://champlainsaintlambert.atlassian.net/browse/CPC-1711?atlOrigin=eyJpIjoiNmI4NTMxODk0MjAyNDllNTk2MzM1MTVkZjY3N2E2N2QiLCJwIjoiaiJ9)
## Context:
Allowing admin to access certain customer endpoints because as an admin in case something goes wrong they should be able to, for example, retrieve a cart. This issue is important because there's also an api call to cart in the navbar which only allowed owners to call, so when an admin tried to log in they would be met with 403 Forbidden.
## Does this PR change the .vscode folder in petclinic-frontend?:
No
## Changes
- Added Admin as an allowed role for certain endpoints in CartControllerV1
- Added missing tests for moveAllWishlistToCart for 90% coverage for CartControllerV1
- Updated AppNavBar and CartTable for improved cart visibility for admin
## Does this use the v2 API?:
No
## Does this add a new communication between services?:
No
## Before and After UI (Required for UI-impacting PRs)
No UI changes