### PR TITLE
bug(INVT-CPC-1607): fix move button in supply list

### DIFF
--- a/petclinic-frontend/src/features/inventories/InventoryProducts.tsx
+++ b/petclinic-frontend/src/features/inventories/InventoryProducts.tsx
@@ -497,7 +497,7 @@ const InventoryProducts: React.FC = () => {
                     <button
                       onClick={e => {
                         e.stopPropagation();
-                        navigate(`${product.productId}/move`);
+                        navigate(`${product.productId}`);
                       }}
                       className="btn btn-info btn-sm"
                     >

--- a/petclinic-frontend/src/features/inventories/MoveInventoryProducts.tsx
+++ b/petclinic-frontend/src/features/inventories/MoveInventoryProducts.tsx
@@ -100,8 +100,10 @@ export default function MoveInventoryProducts(): JSX.Element {
           <select
             className="form-control"
             id="newInventorySelect"
+            value={newInventoryId}
             onChange={handleNewInventoryChange}
           >
+            <option value="">Select inventory</option>
             {filteredInventories.map(inventory => (
               <option key={inventory.inventoryId} value={inventory.inventoryId}>
                 {inventory.inventoryName}
@@ -109,16 +111,31 @@ export default function MoveInventoryProducts(): JSX.Element {
             ))}
           </select>
         </div>
-        <button
-          type="submit"
-          style={{
-            width: '100px',
-            backgroundColor: '#333',
-            color: 'white',
-          }}
-        >
-          Move
-        </button>
+        <div style={{ display: 'flex', gap: '12px', marginTop: '12px' }}>
+          <button
+            type="submit"
+            disabled={!newInventoryId}
+            style={{
+              width: '100px',
+              backgroundColor: '#333',
+              color: 'white',
+            }}
+          >
+            Move
+          </button>
+
+          <button
+            type="button"
+            onClick={() => navigate(`/inventories/${inventoryId}/products`)}
+            style={{
+              width: '100px',
+              backgroundColor: '#ff0000ff',
+              color: 'white',
+            }}
+          >
+            Cancel
+          </button>
+        </div>
       </form>
       <div>
         {loading && <p>Loading...</p>}

--- a/petclinic-frontend/src/features/inventories/api/moveInventoryProduct.ts
+++ b/petclinic-frontend/src/features/inventories/api/moveInventoryProduct.ts
@@ -24,6 +24,7 @@ export const updateProductInventoryId = async (
   try {
     await axiosInstance.put<void>(
       `/inventories/${currentInventoryId}/products/${productId}/updateInventoryId/${newInventoryId}`,
+      undefined,
       { useV2: false } // not implemented, must find
     );
   } catch (error) {

--- a/petclinic-frontend/src/shared/models/path.routes.ts
+++ b/petclinic-frontend/src/shared/models/path.routes.ts
@@ -1,6 +1,6 @@
 export enum AppRoutePaths {
   Default = '/',
-  MoveInventoryProducts = 'inventories/:inventoryId/products/:productId/move',
+  MoveInventoryProducts = 'inventories/:inventoryId/products/:productId',
   EditInventory = 'inventories/:inventoryId/edit',
   EditInventoryProducts = 'inventories/:inventoryId/products/:productId/edit',
   LowStockProducts = '/products/lowstock',


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1607
## Context:
Allow inventory managers to move products between inventory types and cancel the operation from the move dialog. Fixes an axios PUT call so the request config is passed correctly.
## Does this PR change the .vscode folder in petclinic-frontend?:
No
## Changes

- Added `undefined` as the PUT body in `moveInventoryProducts.ts` so that the config arg `{ useV2: false }` is passed correctly in the axios.put
- Added a cancel button to `moveInventoryProducts.tsx` 
- Updated the endpoint URL to be fully RESTful (removed redundant `/move`).

## Does this use the v2 API?:
No
## Does this add a new communication between services?:
No
## Before and After UI (Required for UI-impacting PRs)
Before (no cancel button):
<img width="493" height="344" alt="after-movebutton" src="https://github.com/user-attachments/assets/6fa49128-d8a2-4dcc-8519-aa5abafbd7b8" />
After:
<img width="626" height="445" alt="before-moveproduct" src="https://github.com/user-attachments/assets/4354d016-3d59-474c-90c3-af571a4fc225" />
