### PR TITLE
finished feature ready to be merged.

### DIFF
--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClient.java
@@ -17,6 +17,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 
@@ -384,6 +386,14 @@ public class BillServiceClient {
                     // Fallback: let other statuses bubble up
                     return resp.createException().flatMap(Mono::error);
                 });
+    }
+
+
+    public Flux<BillResponseDTO> archiveBill() {
+        return webClientBuilder.build().patch()
+                .uri(billServiceUrl + "/archive")
+                .retrieve()
+                .bodyToFlux(BillResponseDTO.class);
     }
 
 

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillResponseDTO.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/Bills/BillResponseDTO.java
@@ -27,4 +27,5 @@ public class BillResponseDTO {
     private BillStatus billStatus;
     private LocalDate dueDate;
     private Long timeRemaining;
+    private Boolean archive;
 }

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/presentationlayer/BFFApiGatewayController.java
@@ -6,8 +6,6 @@ import com.petclinic.bffapigateway.dtos.Auth.*;
 import com.petclinic.bffapigateway.dtos.Bills.BillRequestDTO;
 import com.petclinic.bffapigateway.dtos.Bills.BillResponseDTO;
 import com.petclinic.bffapigateway.dtos.Bills.PaymentRequestDTO;
-import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerRequestDTO;
-import com.petclinic.bffapigateway.dtos.Inventory.*;
 import com.petclinic.bffapigateway.dtos.CustomerDTOs.OwnerResponseDTO;
 import com.petclinic.bffapigateway.dtos.Pets.*;
 import com.petclinic.bffapigateway.dtos.Vets.*;
@@ -24,16 +22,17 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.*;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
 
@@ -842,6 +841,15 @@ public class BFFApiGatewayController {
     public Mono<ResponseEntity<UserPasswordLessDTO>> createInventoryManager(@RequestBody @Valid Mono<RegisterInventoryManager> model) {
         return authServiceClient.createInventoryMangerUser(model).map(s -> ResponseEntity.status(HttpStatus.CREATED).body(s))
                 .defaultIfEmpty(ResponseEntity.badRequest().build());
+    }
+
+    @SecuredEndpoint(allowedRoles = {Roles.ADMIN})
+    @PatchMapping("/bills/archive")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<ResponseEntity<Object>> archiveBill() {
+        return billServiceClient.archiveBill()
+                .then(Mono.just(ResponseEntity.noContent().build()))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
     /**

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientIntegrationTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientIntegrationTest.java
@@ -734,4 +734,91 @@ class BillServiceClientIntegrationTest {
                 .verify();
     }
 
+    @Test
+    void archiveBill_Success() throws Exception {
+        List<BillResponseDTO> archivedBills = Arrays.asList(
+                BillResponseDTO.builder()
+                        .billId("1")
+                        .amount(100.0)
+                        .taxedAmount(115.0)
+                        .customerId("1")
+                        .vetId("1")
+                        .visitType("Check up")
+                        .billStatus(BillStatus.PAID)
+                        .archive(false)
+                        .build(),
+                BillResponseDTO.builder()
+                        .billId("2")
+                        .amount(200.0)
+                        .taxedAmount(230.0)
+                        .customerId("2")
+                        .vetId("2")
+                        .visitType("Surgery")
+                        .billStatus(BillStatus.PAID)
+                        .archive(false)
+                        .build()
+        );
+
+        String responseBody = mapper.writeValueAsString(archivedBills);
+
+        prepareResponse(response -> response
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(responseBody)
+        );
+
+        Flux<BillResponseDTO> result = billServiceClient.archiveBill();
+
+        StepVerifier.create(result.collectList())
+                .expectNextMatches(bills -> {
+                    assertEquals(2, bills.size());
+                    assertTrue(bills.stream().anyMatch(bill -> "1".equals(bill.getBillId())));
+                    assertTrue(bills.stream().anyMatch(bill -> "2".equals(bill.getBillId())));
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void archiveBill_FailsForUnpaidOrOverdueBills() throws Exception {
+        List<BillResponseDTO> bills = Arrays.asList(
+                BillResponseDTO.builder()
+                        .billId("1")
+                        .amount(100.0)
+                        .taxedAmount(115.0)
+                        .customerId("1")
+                        .vetId("1")
+                        .visitType("Check up")
+                        .billStatus(BillStatus.UNPAID)
+                        .archive(false)
+                        .build(),
+                BillResponseDTO.builder()
+                        .billId("2")
+                        .amount(200.0)
+                        .taxedAmount(230.0)
+                        .customerId("2")
+                        .vetId("2")
+                        .visitType("Surgery")
+                        .billStatus(BillStatus.OVERDUE)
+                        .archive(false)
+                        .build()
+        );
+
+        String responseBody = mapper.writeValueAsString(bills);
+
+        prepareResponse(response -> response
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(responseBody)
+        );
+
+        Flux<BillResponseDTO> result = billServiceClient.archiveBill();
+
+        StepVerifier.create(result.collectList())
+                .expectNextMatches(returnedBills -> {
+                    assertEquals(2, returnedBills.size());
+                    assertTrue(returnedBills.stream().allMatch(bill -> !bill.getArchive())); // Ensure no bills are archived
+                    return true;
+                })
+                .verifyComplete();
+    }
+
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -3122,6 +3122,30 @@ private VetAverageRatingDTO buildVetAverageRatingDTO(){
                 });
     }
 
+    @Test
+    void archiveBill_ShouldReturnNoContent_WhenSuccessful() {
+        Mockito.when(billServiceClient.archiveBill()).thenReturn(Flux.empty());
+
+        client.patch()
+                .uri("/api/gateway/bills/archive")
+                .exchange()
+                .expectStatus().isNoContent();
+
+        Mockito.verify(billServiceClient).archiveBill();
+    }
+
+    @Test
+    void archiveBill_ShouldReturnNotContent_WhenNoBillsArchived() {
+        Mockito.when(billServiceClient.archiveBill()).thenReturn(Flux.empty());
+
+        client.patch()
+                .uri("/api/gateway/bills/archive")
+                .exchange()
+                .expectStatus().isNoContent();
+
+        Mockito.verify(billServiceClient).archiveBill();
+    }
+
     private EducationResponseDTO buildEducation(){
         return EducationResponseDTO.builder()
                 .educationId("1")

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillService.java
@@ -9,6 +9,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 public interface BillService {
     Mono<BillResponseDTO> getBillByBillId(String billId);
 
@@ -75,6 +78,7 @@ public interface BillService {
 
     Mono<BillResponseDTO> processPayment(String customerId, String billId, PaymentRequestDTO paymentRequestDTO);
 
+    Flux<Bill> archiveBill();
 
 
 }

--- a/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
+++ b/billing-service/src/main/java/com/petclinic/billing/businesslayer/BillServiceImpl.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.function.Predicate;
 
@@ -353,6 +354,20 @@ public class BillServiceImpl implements BillService{
                 .map(EntityDtoUtil::toBillResponseDto);
     }
 
+    @Override
+    public Flux<Bill> archiveBill() {
+        return billRepository.findAllByArchiveFalse()
+                .flatMap(bill -> {
+                    if (bill.getBillStatus() == BillStatus.UNPAID || bill.getBillStatus() == BillStatus.OVERDUE) {
+                        bill.setArchive(false);
+                    }
+                    else if (bill.getDate().isBefore(LocalDate.now().minusYears(1))) {
+                        bill.setArchive(true);
+                        return billRepository.save(bill);
+                    }
+                    return Mono.just(bill);
+                });
+    }
 
 
 

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/Bill.java
@@ -2,6 +2,7 @@ package com.petclinic.billing.datalayer;
 
 import lombok.*;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.LocalDate;
 
@@ -27,4 +28,6 @@ public class Bill {
     private double taxedAmount;
     private BillStatus billStatus;
     private LocalDate dueDate;
+    @Field("archive")
+    private Boolean archive = false;
 }

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillRepository.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillRepository.java
@@ -1,7 +1,6 @@
 package com.petclinic.billing.datalayer;
 
 //import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
@@ -12,6 +11,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Repository
 public interface BillRepository extends ReactiveMongoRepository<Bill, String> {
@@ -42,4 +42,12 @@ public interface BillRepository extends ReactiveMongoRepository<Bill, String> {
 
     Mono<Bill> findByCustomerIdAndBillId(String customerId, String billId);
 
-}
+    Flux<Bill> findAllByArchiveFalse();
+
+    @Query("{ '_id': ?0 }")
+    Mono<Void> archiveBillById(String billId);
+
+    Flux<Bill> findAllByDateBefore(LocalDate date);
+
+    @Query("{ 'billStatus': { $in: [?0, ?1] } }")
+    Flux<Bill> findAllByBillStatusIn(BillStatus status1, BillStatus status2);}

--- a/billing-service/src/main/java/com/petclinic/billing/datalayer/BillResponseDTO.java
+++ b/billing-service/src/main/java/com/petclinic/billing/datalayer/BillResponseDTO.java
@@ -26,5 +26,5 @@ public class BillResponseDTO {
     private BillStatus billStatus;
     private LocalDate dueDate;
     private Long timeRemaining;
-
+    private Boolean archive;
     }

--- a/billing-service/src/main/java/com/petclinic/billing/presentationlayer/BillController.java
+++ b/billing-service/src/main/java/com/petclinic/billing/presentationlayer/BillController.java
@@ -2,10 +2,10 @@ package com.petclinic.billing.presentationlayer;
 
 import com.petclinic.billing.businesslayer.BillService;
 import com.petclinic.billing.datalayer.*;
-import com.petclinic.billing.exceptions.InvalidPaymentException;
-import com.petclinic.billing.exceptions.NotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.repository.query.Param;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.MediaType;
@@ -13,7 +13,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import javax.validation.Valid;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @RestController
@@ -21,7 +23,7 @@ import java.util.Optional;
 public class BillController {
     private final BillService billService;
 
-    BillController(BillService billService){
+    BillController(BillService billService) {
         this.billService = billService;
     }
 
@@ -41,7 +43,7 @@ public class BillController {
 
     // Read Bill //
     @GetMapping(value = "/bills/{billId}")
-    public Mono<BillResponseDTO> getBillByBillId(@PathVariable String billId){
+    public Mono<BillResponseDTO> getBillByBillId(@PathVariable String billId) {
         return billService.getBillByBillId(billId);
     }
 
@@ -61,7 +63,7 @@ public class BillController {
 //
     //to be changed
     @GetMapping("/bills/bills-count")
-    public Mono<ResponseEntity<Long>> getTotalNumberOfBills(){
+    public Mono<ResponseEntity<Long>> getTotalNumberOfBills() {
         return billService.getAllBills().count()
                 .map(response -> ResponseEntity.status(HttpStatus.OK).body(response));
     }
@@ -105,18 +107,16 @@ public class BillController {
     }
 
 
-
-
     @GetMapping("/bills/bills-filtered-count")
     public Mono<Long> getNumberOfBillsWithFilters(@RequestParam(required = false) String billId,
-                                                        @RequestParam(required = false) String customerId,
-                                                        @RequestParam(required = false) String ownerFirstName,
-                                                        @RequestParam(required = false) String ownerLastName,
-                                                        @RequestParam(required = false) String visitType,
-                                                        @RequestParam(required = false) String vetId,
-                                                        @RequestParam(required = false) String vetFirstName,
-                                                        @RequestParam(required = false) String vetLastName
-    ){
+                                                  @RequestParam(required = false) String customerId,
+                                                  @RequestParam(required = false) String ownerFirstName,
+                                                  @RequestParam(required = false) String ownerLastName,
+                                                  @RequestParam(required = false) String visitType,
+                                                  @RequestParam(required = false) String vetId,
+                                                  @RequestParam(required = false) String vetFirstName,
+                                                  @RequestParam(required = false) String vetLastName
+    ) {
 
         return billService.getNumberOfBillsWithFilters(billId, customerId, ownerFirstName, ownerLastName, visitType, vetId,
                 vetFirstName, vetLastName);
@@ -152,23 +152,21 @@ public class BillController {
         return billService.getAllBillsByStatus(BillStatus.OVERDUE);
     }
 
-    @PutMapping(value ="/bills/{billId}")
-    public Mono<ResponseEntity<BillResponseDTO>> updateBill(@PathVariable String billId, @RequestBody Mono<BillRequestDTO> billRequestDTO){
+    @PutMapping(value = "/bills/{billId}")
+    public Mono<ResponseEntity<BillResponseDTO>> updateBill(@PathVariable String billId, @RequestBody Mono<BillRequestDTO> billRequestDTO) {
         return billService.updateBill(billId, billRequestDTO)
                 .map(ResponseEntity::ok)
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
     @GetMapping(value = "/bills/customer/{customerId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<BillResponseDTO> getBillsByCustomerId(@PathVariable("customerId") String customerId)
-    {
+    public Flux<BillResponseDTO> getBillsByCustomerId(@PathVariable("customerId") String customerId) {
         return billService.getBillsByCustomerId(customerId);
     }
 
 
     @GetMapping(value = "/bills/vet/{vetId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<BillResponseDTO> getBillsByVetId(@PathVariable("vetId") String vetId)
-    {
+    public Flux<BillResponseDTO> getBillsByVetId(@PathVariable("vetId") String vetId) {
         return billService.getBillsByVetId(vetId);
     }
 
@@ -176,25 +174,25 @@ public class BillController {
 
     @DeleteMapping(value = "/bills")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public Mono<Void> deleteAllBills(){
+    public Mono<Void> deleteAllBills() {
         return billService.deleteAllBills();
     }
 
     @DeleteMapping(value = "/bills/{billId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public Mono<Void> deleteBill(@PathVariable("billId") String billId){
+    public Mono<Void> deleteBill(@PathVariable("billId") String billId) {
         return billService.deleteBill(billId);
     }
 
-    @DeleteMapping (value = "/bills/vet/{vetId}")
-    @ResponseStatus (HttpStatus.NO_CONTENT)
-    public Flux<Void> deleteBillsByVetId (@PathVariable("vetId") String vetId){
+    @DeleteMapping(value = "/bills/vet/{vetId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Flux<Void> deleteBillsByVetId(@PathVariable("vetId") String vetId) {
         return billService.deleteBillsByVetId(vetId);
     }
 
-    @DeleteMapping (value = "/bills/customer/{customerId}")
-    @ResponseStatus (HttpStatus.NO_CONTENT)
-    public Flux<Void> deleteBillsByCustomerId (@PathVariable("customerId") String customerId){
+    @DeleteMapping(value = "/bills/customer/{customerId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Flux<Void> deleteBillsByCustomerId(@PathVariable("customerId") String customerId) {
         return billService.deleteBillsByCustomerId(customerId);
     }
 
@@ -209,4 +207,11 @@ public class BillController {
         return billService.getBillsByMonth(year, month);
     }
 
+    @PatchMapping("/bills/archive")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<ResponseEntity<Object>> archiveBill() {
+        return billService.archiveBill()
+                .then(Mono.just(ResponseEntity.noContent().build()))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
 }

--- a/billing-service/src/main/java/com/petclinic/billing/util/DataSetupService.java
+++ b/billing-service/src/main/java/com/petclinic/billing/util/DataSetupService.java
@@ -55,6 +55,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.OVERDUE)
                 .dueDate(LocalDate.of(2024, 3, 31))
+                .archive(false)
                 .build();
 
         Bill b2 = Bill.builder()
@@ -71,6 +72,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 4, 30))
+                .archive(false)
                 .build();
 
         Bill b3 = Bill.builder()
@@ -87,6 +89,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 5, 31))
+                .archive(false)
                 .build();
 
         Bill b4 = Bill.builder()
@@ -103,6 +106,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 6, 30))
+                .archive(false)
                 .build();
 
         Bill b5 = Bill.builder()
@@ -119,6 +123,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.UNPAID)
                 .dueDate(LocalDate.of(2024, 11, 30))
+                .archive(false)
                 .build();
 
         Bill b6 = Bill.builder()
@@ -135,6 +140,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.UNPAID)
                 .dueDate(LocalDate.of(2024, 8, 30))
+                .archive(false)
                 .build();
 
         Bill b7 = Bill.builder()
@@ -151,6 +157,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 9, 30))
+                .archive(false)
                 .build();
 
         Bill b8 = Bill.builder()
@@ -167,6 +174,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 4, 30))
+                .archive(false)
                 .build();
 
         Bill b9 = Bill.builder()
@@ -183,6 +191,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 5, 31))
+                .archive(false)
                 .build();
 
         Bill b10 = Bill.builder()
@@ -199,6 +208,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 6, 30))
+                .archive(false)
                 .build();
 
         Bill b11 = Bill.builder()
@@ -215,6 +225,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 8, 30))
+                .archive(false)
                 .build();
 
         Bill b12 = Bill.builder()
@@ -231,6 +242,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 8, 30))
+                .archive(false)
                 .build();
 
         Bill b13 = Bill.builder()
@@ -247,6 +259,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.UNPAID)
                 .dueDate(LocalDate.of(2024, 11, 30))
+                .archive(false)
                 .build();
 
         Bill b14 = Bill.builder()
@@ -263,6 +276,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.PAID)
                 .dueDate(LocalDate.of(2024, 4, 30))
+                .archive(false)
                 .build();
 
         Bill b15 = Bill.builder()
@@ -279,6 +293,7 @@ public class DataSetupService implements CommandLineRunner {
                 .taxedAmount(0.0)
                 .billStatus(BillStatus.UNPAID)
                 .dueDate(LocalDate.of(2024, 11, 30))
+                .archive(false)
                 .build();
 
         Flux.just(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15)

--- a/billing-service/src/main/java/com/petclinic/billing/util/EntityDtoUtil.java
+++ b/billing-service/src/main/java/com/petclinic/billing/util/EntityDtoUtil.java
@@ -34,6 +34,7 @@ public class EntityDtoUtil {
         billResponseDTO.setBillStatus(bill.getBillStatus());
         billResponseDTO.setDueDate(bill.getDueDate());
         billResponseDTO.setTimeRemaining(timeRemaining(bill));
+        billResponseDTO.setArchive(bill.getArchive());
 
         log.info("Mapped BillResponseDTO: {}", billResponseDTO);
 
@@ -44,6 +45,9 @@ public class EntityDtoUtil {
     public static Bill toBillEntity(BillRequestDTO billRequestDTO){
         Bill bill = new Bill();
         BeanUtils.copyProperties(billRequestDTO,bill);
+        if (bill.getArchive() == null) {
+            bill.setArchive(false);
+        }
         return bill;
     }
 

--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillControllerIntegrationTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillControllerIntegrationTest.java
@@ -674,6 +674,7 @@ class BillControllerIntegrationTest {
                 .amount(100.0)
                 .billStatus(BillStatus.OVERDUE)
                 .dueDate(dueDate)
+                .archive(false)
                 .build();
     }
 
@@ -692,6 +693,7 @@ class BillControllerIntegrationTest {
                 .amount(100.0)
                 .billStatus(BillStatus.UNPAID)
                 .dueDate(dueDate)
+                .archive(false)
                 .build();
     }
 
@@ -716,6 +718,7 @@ class BillControllerIntegrationTest {
                 .ownerLastName("Doe")
                 .vetFirstName("Jane")
                 .vetLastName("Smith")
+                .archive(false)
                 .build();
     }
 

--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillControllerUnitTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/BillControllerUnitTest.java
@@ -313,6 +313,18 @@ class BillControllerUnitTest {
         Mockito.verify(billService, times(1)).deleteBillsByCustomerId(CUSTOMER_ID_OK);
     }
 
+    @Test
+    void testArchiveBill() {
+        when(billService.archiveBill()).thenReturn(Flux.empty());
+
+        client.patch()
+                .uri("/bills/archive")
+                .exchange()
+                .expectStatus().isNoContent();
+
+        verify(billService, times(1)).archiveBill();
+    }
+
 
     private BillResponseDTO buildBillResponseDTO() {
         Calendar calendar = Calendar.getInstance();

--- a/billing-service/src/test/java/com/petclinic/billing/presentationlayer/CustomerBillsControllerIntegrationTest.java
+++ b/billing-service/src/test/java/com/petclinic/billing/presentationlayer/CustomerBillsControllerIntegrationTest.java
@@ -159,6 +159,7 @@ public class CustomerBillsControllerIntegrationTest {
                                 .date(LocalDate.now().minusDays(10))
                                 .amount(150.0)
                                 .dueDate(LocalDate.now().plusDays(20))
+                                .archive(false)
                                 .build();
         }
 
@@ -176,6 +177,7 @@ public class CustomerBillsControllerIntegrationTest {
                                 .date(date)
                                 .amount(150.0)
                                 .billStatus(BillStatus.UNPAID)
+                                .archive(false)
                                 .build();
         }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,4 +399,3 @@ services:
     depends_on:
       - mongo-carts
       - cart-service
-

--- a/petclinic-frontend/src/features/bills/api/archiveBills.tsx
+++ b/petclinic-frontend/src/features/bills/api/archiveBills.tsx
@@ -1,0 +1,18 @@
+import axiosInstance from '@/shared/api/axiosInstance';
+import { Bill } from '../models/Bill';
+
+export async function archiveBills(): Promise<Bill[]> {
+  try {
+    const response = await axiosInstance.patch<Bill[]>(
+      '/bills/archive',
+      {},
+      {
+        useV2: false, // Use v1 API explicitly (preferred for backwards compatibility)
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error archiving bills:', error);
+    throw error;
+  }
+}

--- a/petclinic-frontend/src/features/bills/api/getAllBillsPaginated.tsx
+++ b/petclinic-frontend/src/features/bills/api/getAllBillsPaginated.tsx
@@ -5,25 +5,8 @@ export async function getAllBillsPaginated(
   currentPage: number,
   listSize: number
 ): Promise<Bill[]> {
-  //const url = `bills?page=${currentPage}&size=${listSize}`;
-
-  //const response = await axiosInstance.get<Bill[]>(
-  //    axiosInstance.defaults.baseURL + url
-  //  );
-
   const response = await axiosInstance.get<Bill[]>(
     `/bills?page=${currentPage}&size=${listSize}`
-    //{ responseType: 'stream' }
   );
   return response.data;
-  //.split('data:')
-  //  .map((payLoad: string) => {
-  //   try {
-  //    if (payLoad == '') return null;
-  //    return JSON.parse(payLoad);
-  //   } catch (err) {
-  //     console.error("Can't parse JSON: " + err);
-  //   }
-  //  })
-  //.filter((data?: JSON) => data !== null);
 }

--- a/petclinic-frontend/src/features/bills/api/payBill.tsx
+++ b/petclinic-frontend/src/features/bills/api/payBill.tsx
@@ -13,25 +13,7 @@ export async function payBill(
       headers: { 'Content-Type': 'application/json' },
       withCredentials: true,
       useV2: true,
-      //body: JSON.stringify(paymentDetails),
     }
   );
   return response.data.filter((item: Bill) => item.billStatus === 'PAID');
-
-  /*const response = await fetch(
-    `http://localhost:8080/api/v2/gateway/bills/customer/${customerId}/bills/${billId}/pay`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-      body: JSON.stringify(paymentDetails),
-    }
-  );
-
-  if (!response.ok) {
-    throw new Error('Payment failed');
-  }
-    */
 }

--- a/petclinic-frontend/src/features/bills/models/Bill.ts
+++ b/petclinic-frontend/src/features/bills/models/Bill.ts
@@ -13,4 +13,5 @@ export interface Bill {
   billStatus: string;
   dueDate: string;
   timeRemaining: number;
+  archive: boolean;
 }


### PR DESCRIPTION
The admin now no longer has the option to delete bills. All "delete" functionallity is now archive, which is handled automatically by the front-end. The admin has the option to toggle archived bills or to untoggle them in the front-end

**JIRA:** link to jira ticket
## Context:
The ticket is about the controversial and illegal option for the admin to delete bills.

## Does this PR change the .vscode folder in petclinic-frontend?:
no

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
The admin now no longer has the option of deleting bills. All deletion functionallity is now handled with an automatic option to archive bills, and admin can see archived bills by checking the checkmark
## Does this use the v2 API?:
no
## Does this add a new communication between services?:
no
## Before and After UI (Required for UI-impacting PRs)
<img width="1893" height="968" alt="image" src="https://github.com/user-attachments/assets/a3ae08cf-0974-4aa8-ad30-83980f240700" />
<img width="1915" height="951" alt="image" src="https://github.com/user-attachments/assets/aefe8379-0a24-4e11-adea-c17c1addc087" />
note *I did my pr after Jake's so you get to see his feature in the before and not the after*
## Dev notes (Optional)
## Linked pull requests (Optional)
