### PR TITLE
feat(CUST-CPC-1528): Implement Delete File

### DIFF
--- a/files-service/files/businesslayer/file_service.go
+++ b/files-service/files/businesslayer/file_service.go
@@ -7,4 +7,5 @@ import (
 type FileService interface {
 	GetFile(string) (*models.FileResponseModel, error)
 	AddFile(*models.FileRequestModel) (*models.FileResponseModel, error)
+	DeleteFileByFileId(string) error
 }

--- a/files-service/files/businesslayer/file_service_impl.go
+++ b/files-service/files/businesslayer/file_service_impl.go
@@ -85,3 +85,20 @@ func (i *FilesServiceImpl) AddFile(model *models.FileRequestModel) (*models.File
 
 	return response, nil
 }
+
+func (i *FilesServiceImpl) DeleteFileByFileId(id string) error {
+	fileInfo := i.repository.GetFileInfo(id)
+	if fileInfo == nil {
+		return exception.NewNotFoundException("fileId: " + id + " was not found")
+	}
+
+	if err := i.minioServiceClient.DeleteFile(fileInfo); err != nil {
+		return err
+	}
+
+	if err := i.repository.DeleteFileInfo(id); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/files-service/files/businesslayer/file_service_unit_test.go
+++ b/files-service/files/businesslayer/file_service_unit_test.go
@@ -57,3 +57,30 @@ func TestWhenGetFileById_withNonExistingFileId_thenReturnError(t *testing.T) {
 	assert.Nil(t, file)
 	mockRepo.AssertExpectations(t)
 }
+
+func TestWhenDeleteFileById_withExistingFileId_thenDeleteSuccessfully(t *testing.T) {
+	mockRepo, mockClient := setupFileServiceUnitTest()
+	mockRepo.On("GetFileInfo", EXISTING_FILE_ID).Return(&VALID_FILE_INFO)
+	mockRepo.On("DeleteFileInfo", EXISTING_FILE_ID).Return(nil)
+	mockClient.On("DeleteFile", &VALID_FILE_INFO).Return(nil)
+
+	service := businesslayer.NewFileService(mockRepo, mockClient)
+	err := service.DeleteFileByFileId(EXISTING_FILE_ID)
+
+	assert.Nil(t, err)
+	mockRepo.AssertExpectations(t)
+	mockClient.AssertExpectations(t)
+}
+
+func TestWhenDeleteFileById_withNonExistingFileId_thenReturnError(t *testing.T) {
+	mockRepo, mockClient := setupFileServiceUnitTest()
+	mockRepo.On("GetFileInfo", NON_EXISTING_FILE_ID).Return(nil)
+
+	service := businesslayer.NewFileService(mockRepo, mockClient)
+	err := service.DeleteFileByFileId(NON_EXISTING_FILE_ID)
+
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "fileId: "+NON_EXISTING_FILE_ID+" was not found")
+
+	mockRepo.AssertExpectations(t)
+}

--- a/files-service/files/businesslayer/minio_service_client_mock_test.go
+++ b/files-service/files/businesslayer/minio_service_client_mock_test.go
@@ -23,3 +23,8 @@ func (m *MockMinioServiceClient) AddFile(fileInfo *datalayer.FileInfo, data []by
 	args := m.Called(fileInfo, data)
 	return args.Error(0)
 }
+
+func (m *MockMinioServiceClient) DeleteFile(fileInfo *datalayer.FileInfo) error {
+	args := m.Called(fileInfo)
+	return args.Error(0)
+}

--- a/files-service/files/clientlayer/minio_service_client.go
+++ b/files-service/files/clientlayer/minio_service_client.go
@@ -8,4 +8,5 @@ import (
 type MinioServiceClient interface {
 	GetFile(fileInfo *datalayer.FileInfo) (*models.FileResponseModel, error)
 	AddFile(fileInfo *datalayer.FileInfo, data []byte) error
+	DeleteFile(fileInfo *datalayer.FileInfo) error
 }

--- a/files-service/files/clientlayer/minio_service_client_impl.go
+++ b/files-service/files/clientlayer/minio_service_client_impl.go
@@ -50,3 +50,8 @@ func (msc *MinioServiceClientImpl) AddFile(fileInfo *datalayer.FileInfo, data []
 	_, err := msc.client.PutObject(ctx, fileInfo.GetFileBucket(), fileInfo.GetFileLink(), obj, obj.Size(), minio.PutObjectOptions{ContentType: fileInfo.FileType})
 	return err
 }
+
+func (msc *MinioServiceClientImpl) DeleteFile(fileInfo *datalayer.FileInfo) error {
+	ctx := context.Background()
+	return msc.client.RemoveObject(ctx, fileInfo.GetFileBucket(), fileInfo.GetFileLink(), minio.RemoveObjectOptions{})
+}

--- a/files-service/files/datalayer/file_info_repository_intergration_test.go
+++ b/files-service/files/datalayer/file_info_repository_intergration_test.go
@@ -64,3 +64,21 @@ func TestWhenGetFileInfo_withNonExistingFileId_thenReturnNilFileInfo(t *testing.
 	assert.Nil(t, file)
 	t.Cleanup(reset)
 }
+
+func TestWhenDeleteFileInfo_withExistingFileId_thenDeleteSuccessfully(t *testing.T) {
+	err := fileRepo.AddFileInfo(&VALID_FILE_INFO)
+	assert.Nil(t, err)
+
+	err = fileRepo.DeleteFileInfo(EXISTING_FILE_ID)
+	assert.Nil(t, err)
+
+	file := fileRepo.GetFileInfo(EXISTING_FILE_ID)
+	assert.Nil(t, file)
+	t.Cleanup(reset)
+}
+
+func TestWhenDeleteFileInfo_withNonExistingFileId_thenNoError(t *testing.T) {
+	err := fileRepo.DeleteFileInfo(NON_EXISTING_FILE_ID)
+	assert.Nil(t, err)
+	t.Cleanup(reset)
+}

--- a/files-service/files/presentationlayer/file_controller.go
+++ b/files-service/files/presentationlayer/file_controller.go
@@ -52,11 +52,27 @@ func (i *FilesController) addFile(c *gin.Context) {
 	c.IndentedJSON(http.StatusCreated, file)
 }
 
+func (i *FilesController) deleteFileByFileId(c *gin.Context) {
+	id := c.Param("id")
+	if len([]rune(id)) != 36 {
+		cancel(c, exception.NewInvalidFileIdException(id))
+		return
+	}
+
+	err := i.s.DeleteFileByFileId(id)
+	if err != nil {
+		cancel(c, err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
 func (i *FilesController) Routes(engine *gin.Engine) error {
 	filesGroup := engine.Group("/files").Use(GlobalExceptionHandler)
 
 	filesGroup.GET("/:id", i.getFile)
 	filesGroup.POST("/", ValidateRequestBody, i.addFile)
-
+	filesGroup.DELETE("/:id", i.deleteFileByFileId)
 	return nil
 }

--- a/files-service/files/presentationlayer/file_controller_unit_test.go
+++ b/files-service/files/presentationlayer/file_controller_unit_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"files-service/files/models"
 	"files-service/files/presentationlayer"
+	"files-service/files/util/exception"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -40,6 +41,46 @@ func TestWhenGetFileById_withExistingFileId_thenReturnFileResponseModel(t *testi
 	assert.EqualValues(t, VALID_FILE_RESPONSE_MODEL.FileType, got.FileType)
 	assert.EqualValues(t, VALID_FILE_RESPONSE_MODEL.FileData, got.FileData)
 	mockService.AssertExpectations(t)
+}
+
+func TestWhenGetFileById_withNonExistingFileId_thenReturnFileResponseModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	controller, mockService := setUpControllerUnitTests()
+
+	router := gin.Default()
+	_ = controller.Routes(router)
+
+	mockService.On("GetFile", NON_EXISTING_ID).Return(nil, exception.NewNotFoundException("fileId: "+NON_EXISTING_ID+" was not found"))
+
+	req, _ := http.NewRequest(http.MethodGet, "/files/"+NON_EXISTING_ID, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	var resp string
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "fileId: "+NON_EXISTING_ID+" was not found", resp)
+
+	mockService.AssertExpectations(t)
+}
+
+func TestWhenGetFileById_withInvalidFileId_thenReturnInvalidFileIdException(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controller, _ := setUpControllerUnitTests()
+	router := gin.Default()
+	_ = controller.Routes(router)
+
+	req, _ := http.NewRequest(http.MethodGet, "/files/"+INVALID_FILE_ID, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp string
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "Invalid fileId: "+INVALID_FILE_ID, resp)
 }
 
 func TestWhenDeleteFile_withExistingFileId_thenReturnSuccess(t *testing.T) {

--- a/files-service/files/presentationlayer/file_controller_unit_test.go
+++ b/files-service/files/presentationlayer/file_controller_unit_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"files-service/files/models"
 	"files-service/files/presentationlayer"
-	"files-service/files/util/exception"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -43,42 +42,19 @@ func TestWhenGetFileById_withExistingFileId_thenReturnFileResponseModel(t *testi
 	mockService.AssertExpectations(t)
 }
 
-func TestWhenGetFileById_withNonExistingFileId_thenReturnFileResponseModel(t *testing.T) {
+func TestWhenDeleteFile_withExistingFileId_thenReturnSuccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-
 	controller, mockService := setUpControllerUnitTests()
-
 	router := gin.Default()
 	_ = controller.Routes(router)
 
-	mockService.On("GetFile", NON_EXISTING_ID).Return(nil, exception.NewNotFoundException("fileId: "+NON_EXISTING_ID+" was not found"))
+	mockService.On("DeleteFileByFileId", EXISTING_FILE_ID).Return(nil)
 
-	req, _ := http.NewRequest(http.MethodGet, "/files/"+NON_EXISTING_ID, nil)
+	req, _ := http.NewRequest(http.MethodDelete, "/files/"+EXISTING_FILE_ID, nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	var resp string
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	assert.NoError(t, err)
-	assert.Equal(t, "fileId: "+NON_EXISTING_ID+" was not found", resp)
-
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Body.String())
 	mockService.AssertExpectations(t)
-}
-
-func TestWhenGetFileById_withInvalidFileId_thenReturnInvalidFileIdException(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	controller, _ := setUpControllerUnitTests()
-	router := gin.Default()
-	_ = controller.Routes(router)
-
-	req, _ := http.NewRequest(http.MethodGet, "/files/"+INVALID_FILE_ID, nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	var resp string
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	assert.NoError(t, err)
-	assert.Equal(t, "Invalid fileId: "+INVALID_FILE_ID, resp)
 }

--- a/files-service/files/presentationlayer/file_service_mock_test.go
+++ b/files-service/files/presentationlayer/file_service_mock_test.go
@@ -25,3 +25,8 @@ func (m *MockFileService) AddFile(model *models.FileRequestModel) (*models.FileR
 	}
 	return args.Get(0).(*models.FileResponseModel), args.Error(1)
 }
+
+func (m *MockFileService) DeleteFileByFileId(id string) error {
+	args := m.Called(id)
+	return args.Error(0)
+}


### PR DESCRIPTION
**JIRA:** https://champlainsaintlambert.atlassian.net/browse/CPC-1532
## Context:
We’re adding file deletion to the files-service so that other services can safely remove stored files. You can now remove a file, and an error will be returned if something isn't correct, or is wrong with the system. Also, testing has been added (Positive/Negative), whom all pass, so that everything works. 
## Does this PR change the .vscode folder in petclinic-frontend?:
No.

<span style="color:red">**Reviewers need to check for any changes to the 
.vscode folder and add a comment about it to their review comments.**</span>

## Changes
Added the DELETE /files/:id endpoint with full service, business, and data-layer logic plus unit and integration tests to enable secure file deletion from both the database and MinIO.
## Does this use the v2 API?:
No.
## Does this add a new communication between services?:
No.
## Before and After UI (Required for UI-impacting PRs)
No UI Changes, touching File Service
## Dev notes (Optional)
Look at README for File Service
## Linked pull requests (Optional)
None.